### PR TITLE
feat(ci): add automation workflows for validation, coverage, and security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: nuget
+    directory: /automation/dotnet
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - dotnet

--- a/.github/workflows/codeql-contentops.yml
+++ b/.github/workflows/codeql-contentops.yml
@@ -1,0 +1,52 @@
+name: CodeQL ContentOps
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - automation/dotnet/**
+      - .github/workflows/codeql-contentops.yml
+  pull_request:
+    paths:
+      - automation/dotnet/**
+      - .github/workflows/codeql-contentops.yml
+  schedule:
+    - cron: '23 3 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+env:
+  DOTNET_DIR: automation/dotnet
+
+jobs:
+  analyse:
+    name: Analyse (csharp)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source using v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Initialise CodeQL using v3
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - name: Setup .NET using v4.3.1
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        with:
+          global-json-file: ${{ env.DOTNET_DIR }}/global.json
+
+      - name: Restore
+        run: dotnet restore SundownMedia.ContentOps.sln
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Build
+        run: dotnet build SundownMedia.ContentOps.sln --configuration Release --no-restore
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Perform CodeQL analysis using v3
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/contentops-ci.yml
+++ b/.github/workflows/contentops-ci.yml
@@ -1,0 +1,71 @@
+name: ContentOps CI
+
+on:
+  pull_request:
+    paths:
+      - automation/dotnet/**
+      - .github/workflows/contentops-ci.yml
+  push:
+    branches:
+      - main
+    paths:
+      - automation/dotnet/**
+      - .github/workflows/contentops-ci.yml
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_DIR: automation/dotnet
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source using v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup .NET using v4.3.1
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        with:
+          global-json-file: ${{ env.DOTNET_DIR }}/global.json
+
+      - name: Restore
+        run: dotnet restore SundownMedia.ContentOps.sln
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Build
+        run: dotnet build SundownMedia.ContentOps.sln --configuration Release --no-restore
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Test
+        run: dotnet test SundownMedia.ContentOps.sln --configuration Release --no-build --logger "trx;LogFileName=test-results.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=TestResults/coverage/
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Install ReportGenerator
+        if: always()
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.*
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          reportgenerator \
+            "-reports:${{ env.DOTNET_DIR }}/**/TestResults/**/coverage.cobertura.xml" \
+            "-targetdir:${{ env.DOTNET_DIR }}/TestResults/CoverageReport" \
+            "-reporttypes:MarkdownSummaryGithub;Cobertura"
+          if [ -f "${{ env.DOTNET_DIR }}/TestResults/CoverageReport/SummaryGithub.md" ]; then
+            cat "${{ env.DOTNET_DIR }}/TestResults/CoverageReport/SummaryGithub.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload test results using v4.6.2
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: contentops-test-results
+          path: |
+            automation/dotnet/**/TestResults/*.trx
+            automation/dotnet/**/TestResults/*/coverage.cobertura.xml
+            automation/dotnet/TestResults/CoverageReport/**
+          if-no-files-found: warn

--- a/.github/workflows/contentops-release.yml
+++ b/.github/workflows/contentops-release.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: write
   packages: write
+  security-events: write
 
 env:
   DOTNET_DIR: automation/dotnet
@@ -153,6 +154,20 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ needs.build-test-package.outputs.release_version }}
             ${{ env.IMAGE_NAME }}:latest
+
+      - name: Pull release image for vulnerability scan
+        run: docker pull ${{ env.IMAGE_NAME }}:${{ needs.build-test-package.outputs.release_version }}
+
+      - name: Scan release image for vulnerabilities
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy:0.51.1 image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            --no-progress \
+            ${{ env.IMAGE_NAME }}:${{ needs.build-test-package.outputs.release_version }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - src/**
+      - .github/workflows/deploy-github-pages.yml
   pull_request:
+    paths:
+      - src/**
+      - .github/workflows/deploy-github-pages.yml
 
 permissions:
   contents: read
@@ -12,8 +18,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -24,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.146.5
+      HUGO_CACHEDIR: /tmp/hugo_cache
     steps:
       - name: Install Hugo CLI
         run: |
@@ -33,6 +40,15 @@ jobs:
         run: sudo snap install dart-sass
       - name: Checkout source using v4.1.1
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Cache Hugo build artefacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/resources/_gen
+            /tmp/hugo_cache
+          key: hugo-${{ runner.os }}-${{ hashFiles('src/config/**', 'src/layouts/**', 'src/content/**', 'src/themes/**', 'src/assets/**') }}
+          restore-keys: |
+            hugo-${{ runner.os }}-
       - name: Setup pages using v4.0.0
         id: pages
         uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d
@@ -53,6 +69,7 @@ jobs:
           path: ./src/public
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,110 @@
+name: PR Governance
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR metadata with GitHub Script using v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = (pr.title || '').trim();
+            const body = (pr.body || '').trim();
+
+            const titlePattern = /^(feat|fix|docs|chore|refactor|test|build|ci)(\([^)]+\))?: .+/;
+            const titleValid = titlePattern.test(title);
+            const bodyValid = body.length >= 20;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const changedPaths = files.map((f) => f.filename);
+            const touchesContentOps = changedPaths.some((path) => path.startsWith('automation/dotnet/'));
+            const changelogUpdated = changedPaths.includes('CHANGELOG.md');
+
+            const failures = [];
+            const notices = [];
+
+            if (!titleValid) {
+              failures.push('PR title must follow Conventional Commits, for example: feat(contentops): add CI checks');
+            }
+
+            if (!bodyValid) {
+              failures.push('PR description is too short. Please include clear context and intent.');
+            }
+
+            if (touchesContentOps && !changelogUpdated) {
+              notices.push('ContentOps files changed without a CHANGELOG update. Add an entry if this change affects behaviour or release notes.');
+            }
+
+            const header = '## PR Governance Check';
+            const lines = [header, ''];
+
+            if (failures.length > 0) {
+              lines.push('### Required fixes');
+              for (const item of failures) {
+                lines.push(`- ${item}`);
+              }
+              lines.push('');
+            } else {
+              lines.push('- Required metadata checks passed.');
+              lines.push('');
+            }
+
+            if (notices.length > 0) {
+              lines.push('### Advisory notices');
+              for (const item of notices) {
+                lines.push(`- ${item}`);
+              }
+              lines.push('');
+            }
+
+            const bodyText = lines.join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            const marker = `${header}\n`;
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && typeof comment.body === 'string' && comment.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: bodyText,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: bodyText,
+              });
+            }
+
+            if (failures.length > 0) {
+              core.setFailed('PR governance checks failed. See PR comment for details.');
+            }

--- a/.github/workflows/validate-hugo-content.yml
+++ b/.github/workflows/validate-hugo-content.yml
@@ -1,0 +1,43 @@
+name: Validate Hugo Content
+
+on:
+  pull_request:
+    paths:
+      - src/content/**
+      - src/layouts/**
+      - src/config/**
+      - .github/workflows/validate-hugo-content.yml
+  push:
+    branches:
+      - main
+    paths:
+      - src/content/**
+      - src/layouts/**
+      - src/config/**
+      - .github/workflows/validate-hugo-content.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.146.5
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Checkout source using v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate content by building Hugo site
+        run: |
+          hugo \
+            --source src \
+            --printPathWarnings \
+            --panicOnWarning \
+            --environment production \
+            --baseURL https://example.invalid/


### PR DESCRIPTION
## Summary

This PR introduces a first automation tranche across GitHub Actions and GitHub Script for both the Hugo website and ContentOps platform.

## Changes

- Added ContentOps CI workflow for PR and main branch validation:
  - restore, build, test
  - coverage collection and summary publication
  - test and coverage artefact upload
- Added Hugo content validation workflow with warning escalation
- Added PR governance workflow using GitHub Script:
  - PR title convention checks
  - minimum PR description quality checks
  - advisory changelog notice for ContentOps changes
- Added Dependabot configuration for:
  - GitHub Actions dependencies
  - NuGet dependencies in `automation/dotnet`
- Updated GitHub Pages deploy workflow:
  - path filters
  - cancellable concurrency per ref
  - Hugo cache to improve runtime
  - deploy restricted to pushes on `main`
- Updated ContentOps release workflow:
  - container vulnerability scanning with Trivy after image push
- Added CodeQL workflow for ContentOps C# analysis on PR, push, and weekly schedule

## Why

These updates provide earlier failure signals, stronger quality and security coverage, and reduced CI time for repeated site builds.

## Validation

- Workflow YAML diagnostics passed in workspace for all new and modified workflow files.
- Branch pushed to remote and ready for CI execution in GitHub.
