### PR TITLE
docs: improve README with architecture, setup, screenshots, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,40 @@
-# :octocat: GitHub Action workflows
+# Sundown Sessions
 
-| Workflow                                                                                                                                                                                                                           | Description                                        |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-| [![markdown linter](https://github.com/colin-gourlay/sundown-sessions/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/colin-gourlay/sundown-sessions/blob/main/.github/workflows/lint-markdown.yml)             | The current status of the markdown linter          |
-| [![deployment - github pages](https://github.com/colin-gourlay/sundown-sessions/actions/workflows/deploy-github-pages.yml/badge.svg)](https://github.com/colin-gourlay/sundown-sessions/blob/main/.github/workflows/deploy-github-pages.yml) | The current status of the deployment to production |
+Sundown Sessions curates and publishes eclectic music sessions for listeners who want to discover beyond algorithmic playlists.
 
----
+![Sundown Sessions logo](src/static/images/sundown-sessions-logo.jpg)
 
+## Problem Statement
 
+Curating a diverse catalogue of shows, artists, and episodes is difficult to do consistently when editorial content and music operations are handled in separate, informal workflows. This project exists to solve that by combining:
 
-# Project Title
+- a Hugo website that presents content clearly and consistently
+- an automation platform that prepares and enriches music data before publication
 
-![Sundown Sessions Logo](src/static/images/sundown-sessions-logo.jpg)
+Together, these workstreams improve discoverability, editorial quality, and operational repeatability.
 
-## Overview
+![Sundown Sessions homepage banner showing editorial presentation style](src/static/images/sundown-sessions-banner.jpg)
 
-This project aims at creating an eclectic radio station application, Sundown Sessions, that provides a diverse range of music from different genres and eras. By intertwining various styles, we ensure a delightful aural experience for our users.
+## Project Overview
 
-## Highlights
+This repository contains two primary workstreams:
 
-At Sundown Sessions, we believe in the power of music and its ability to bridge gaps across various musical tastes and preferences. This application will enable listeners to discover and enjoy an array of music they might not experience otherwise.
+- [src/](src/): Hugo-based website content, templates, and static assets
+- [automation/dotnet/](automation/dotnet/): ContentOps automation platform built with .NET and clean architecture boundaries
 
-## Purpose
+## Architecture Overview
 
-The primary objective of our project is to generate a platform for those exploratory listeners who wish to diversify their musical taste. Our project also promotes artists from different music genres, thereby fostering inclusivity and diversity.
-
-## License
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-
-This project is licensed under the terms of the [MIT license](LICENSE). The MIT license requires that all copies or distributions of this software retain the original copyright notice and license text, ensuring attribution to the original author.
-
-## Contribute
-
-## How to Contribute
-
-We appreciate your interest in contributing to Sundown Sessions. Here are some steps that you can follow:
-
-1. Fork the project repository.
-
-2. Clone your fork locally to your machine.
-
-3. Make your changes in the local repository.
-
-4. Push the changes to your fork.
-
-5. Create a pull request on the Sundown Sessions GitHub repository.
-
-## Code of Conduct
-
-In the interest of fostering an inclusive and respectful environment, we adhere to a [code of conduct](CODE_OF_CONDUCT.md) that all contributors and participants must follow.
-
-## Pull Request Process
-
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
-
-2. Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations and container parameters.
-
-3. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. 
-
-4. Your contributions will be under the [MIT License](LICENSE) in which the project is licensed.
-
----
-
-## ContentOps Automation Platform
-
-### Why This Exists
-
-The Hugo site under `src/` is the production website surface. The music ingestion and curation process happens before content reaches Hugo and requires repeatable automation.
-
-To support that requirement, this repository now includes a dedicated automation workspace under `automation/dotnet` for pre and post processing workflows. The first workflow target is album intake and preparation, with Spotify and Lidarr integration designed as reusable libraries for future pipelines.
-
-### Placement and Boundaries
-
-- `src/` remains Hugo only.
-- `automation/dotnet` contains operational automation code.
-- Spotify and Lidarr integrations are independent and reusable, not coupled to the CLI.
+At repository level, website publishing and automation are intentionally separated while still cooperating through content preparation flow.
 
 ```mermaid
 flowchart LR
-  A[src Hugo website] -->|content output| B[public site]
-  C[automation/dotnet] -->|pre and post processing| A
-  C --> D[Spotify integration library]
-  C --> E[Lidarr integration library]
+  A[automation/dotnet ContentOps] -->|prepare and enrich content| B[src Hugo website]
+  B --> C[public site output]
+  A --> D[Spotify integration library]
+  A --> E[Lidarr integration library]
 ```
 
-### Architectural Choices and Rationale
-
-#### .NET 10
-
-- The solution targets `net10.0` to align with forward-looking runtime strategy.
-- `global.json` pins the SDK baseline for deterministic local and CI behavior.
-
-#### Clean Architecture and SOLID
-
-- `Domain` contains business state and rules.
-- `Application` contains use-case orchestration and validation.
-- `Infrastructure` implements technical concerns.
-- `Cli` is the composition root and runtime entrypoint.
-- Integrations are isolated libraries so other automation tasks can reuse them.
+Within ContentOps, domain rules, orchestration, infrastructure, and CLI wiring are separated to preserve deterministic behaviour and testability.
 
 ```mermaid
 flowchart TB
@@ -111,116 +47,114 @@ flowchart TB
   INFRA --> LID[SundownMedia.Integration.Lidarr]
 ```
 
-#### Result Pattern
+For deeper automation architecture and operational detail, see [automation/dotnet/README.md](automation/dotnet/README.md).
 
-- The application command handlers return `ErrorOr<T>`.
-- Expected failures are represented explicitly as errors.
-- This avoids exception-driven control flow in normal failure scenarios.
+## Setup Instructions
 
-#### Mediator Implementation
+### Hugo Website Local Setup
 
-- The solution uses `Mediator` plus source generators as the MediatR alternative.
-- Command and handler structure follows vertical slice style.
+Prerequisites:
 
-#### Correlation IDs
+- Hugo Extended (current stable release)
 
-- Correlation IDs are generated as GUIDs when not supplied.
-- The CLI sets a correlation ID per invocation and passes it through command flow.
-- This enables reliable traceability in logs and persisted workflow records.
+Run locally from the repository root:
 
-#### One Type Per File
-
-- The solution follows one class/interface/record/enum per file.
-- StyleCop analyzer rule `SA1402` is set to error in `.editorconfig`.
-
-### Solution Structure
-
-```text
-automation/dotnet/
- SundownMedia.ContentOps.sln
- Directory.Build.props
- Directory.Packages.props
- Dockerfile
- .devcontainer/devcontainer.json
- src/
-  SundownMedia.ContentOps.Cli
-  SundownMedia.ContentOps.Application
-  SundownMedia.ContentOps.Domain
-  SundownMedia.ContentOps.Infrastructure
-  SundownMedia.ContentOps.Contracts
- integrations/
-  SundownMedia.Integration.Spotify
-  SundownMedia.Integration.Lidarr
- tests/
-  SundownMedia.ContentOps.Domain.Tests
-  SundownMedia.ContentOps.Application.Tests
-  SundownMedia.ContentOps.Infrastructure.Tests
-  SundownMedia.ContentOps.Integration.Tests
+```powershell
+Set-Location src
+hugo server
 ```
 
-### Testing Strategy
+Build production output:
 
-- `NSubstitute` is used for application and domain unit tests.
-- `Testcontainers` is configured in integration-oriented test projects.
-- `Respawn` is included for database reset workflows in infrastructure/integration testing.
-
-### Dev Container Rationale
-
-- `automation/dotnet/.devcontainer/devcontainer.json` provides a repeatable Ubuntu-based development environment.
-- This is useful when switching machines while keeping tools and SDK expectations consistent.
-- External music libraries can still be mounted into the container as host volumes.
-
-### Container Runtime
-
-`automation/dotnet/Dockerfile` builds and packages a self-contained Linux binary into an Ubuntu runtime image with required runtime tools (`ffmpeg`, `sqlite3`, certificates).
-
-This ensures the app can run on an Ubuntu host without installing the .NET SDK or opening an IDE.
-
-### Release and Delivery Pipeline
-
-The workflow `.github/workflows/contentops-release.yml` supports:
-
-- manual run (`workflow_dispatch`) with version input (default `0.1.0`)
-- automatic run on tags `contentops/v*`
-- build, test, and package steps
-- GitHub Release creation
-- release assets:
-  - self-contained Linux binary tarball
-  - Dockerfile
-  - usage instructions file
-- GHCR image publication
-
-```mermaid
-flowchart LR
-  A[workflow_dispatch or contentops tag] --> B[Build and Test]
-  B --> C[Publish self-contained binary]
-  B --> D[Build and push Docker image]
-  C --> E[Generate usage instructions]
-  D --> F[Create GitHub Release]
-  E --> F
-  C --> F
+```powershell
+Set-Location src
+hugo --environment production
 ```
 
-### SemVer Strategy
+The local site is available at [http://localhost:1313](http://localhost:1313) by default.
 
-- SemVer is the release contract.
-- Initial baseline is `0.1.0`.
-- Tags are namespaced as `contentops/v<version>` to avoid collisions with website-related release concerns.
+### ContentOps .NET Local Setup
 
-### Runtime Usage Quick Start
+Prerequisites:
 
-1. Binary path:
+- .NET SDK 10.0.100 (pinned in [automation/dotnet/global.json](automation/dotnet/global.json))
 
-- download release tarball
-- extract and execute on Ubuntu
+Restore, build, and test:
 
-2. Container path:
+```powershell
+Set-Location automation/dotnet
+dotnet restore SundownMedia.ContentOps.sln
+dotnet build SundownMedia.ContentOps.sln --configuration Release --no-restore
+dotnet test SundownMedia.ContentOps.sln --configuration Release --no-build
+```
 
-- pull GHCR image for the target release
-- run with mounted source and destination paths
+Publish the CLI binary (Linux self-contained):
 
-3. Build-from-source path:
+```powershell
+Set-Location automation/dotnet
+dotnet publish src/SundownMedia.ContentOps.Cli/SundownMedia.ContentOps.Cli.csproj `
+  --configuration Release `
+  --runtime linux-x64 `
+  --self-contained true `
+  -p:PublishSingleFile=true `
+  -p:DebugType=none `
+  -p:DebugSymbols=false `
+  --output ./publish
+```
 
-- build image using `automation/dotnet/Dockerfile`
+These commands mirror the release workflow in [.github/workflows/contentops-release.yml](.github/workflows/contentops-release.yml).
 
-The release workflow generates and uploads step-by-step usage instructions as a release asset to keep operational guidance coupled to each published version.
+## Workstream Details
+
+- Website content and layouts: [src/content/](src/content/) and [src/layouts/](src/layouts/)
+- ContentOps solution root: [automation/dotnet/SundownMedia.ContentOps.sln](automation/dotnet/SundownMedia.ContentOps.sln)
+- Integration libraries: [automation/dotnet/integrations/](automation/dotnet/integrations/)
+- Automation tests: [automation/dotnet/tests/](automation/dotnet/tests/)
+
+## Roadmap
+
+This roadmap is indicative direction rather than a delivery commitment. Completed changes are recorded in [CHANGELOG.md](CHANGELOG.md).
+
+### Now
+
+- Improve contributor onboarding across both workstreams
+- Keep website content structure consistent for artists and shows
+- Stabilise ContentOps release and runtime guidance
+
+### Next
+
+- Expand ContentOps beyond initial album intake workflows
+- Strengthen operational tracing and observability in automation flows
+- Improve editorial tooling and content curation ergonomics
+
+### Later
+
+- Increase reuse of Spotify and Lidarr integration libraries across additional workflows
+- Extend website discovery and presentation capabilities for long-tail catalogue content
+- Formalise richer contributor documentation as the platform footprint grows
+
+## Contribution Standards
+
+- Keep changes scoped to the requested area and avoid unrelated refactors
+- Use British English in documentation and user-facing text
+- Keep architecture boundaries clear between website and automation concerns
+
+Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before contributing.
+
+## Releases and Versioning
+
+- Release history and notable changes: [CHANGELOG.md](CHANGELOG.md)
+- ContentOps release tags use the `contentops/v<version>` namespace
+
+## GitHub Actions
+
+| Workflow | Description |
+| --- | --- |
+| [![markdown linter](https://github.com/colin-gourlay/sundown-sessions/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/colin-gourlay/sundown-sessions/actions/workflows/lint-markdown.yml) | Markdown lint status |
+| [![deployment - github pages](https://github.com/colin-gourlay/sundown-sessions/actions/workflows/deploy-github-pages.yml/badge.svg)](https://github.com/colin-gourlay/sundown-sessions/actions/workflows/deploy-github-pages.yml) | Production deployment status |
+
+## Licence
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+This project is licensed under the terms of the [MIT licence](LICENSE).

--- a/automation/dotnet/README.md
+++ b/automation/dotnet/README.md
@@ -1,0 +1,109 @@
+# SundownMedia ContentOps
+
+SundownMedia ContentOps provides operational automation for music intake and preparation before curated content is published to the Hugo website.
+
+## Purpose
+
+The automation workspace under [automation/dotnet/](.) exists to make ingestion and pre-publication workflows repeatable, testable, and traceable.
+
+Current focus:
+
+- album intake and preparation workflows
+- reusable Spotify and Lidarr integrations
+- deterministic release packaging for binary and container runtime
+
+## Architecture
+
+The solution follows clean architecture boundaries:
+
+- Domain: business state and rules
+- Application: orchestration, validation, and command handling
+- Infrastructure: persistence, external integrations, and technical concerns
+- Cli: composition root and command-line entrypoint
+
+Integrations are intentionally separate libraries so other workflows can reuse them:
+
+- [integrations/SundownMedia.Integration.Spotify/](integrations/SundownMedia.Integration.Spotify/)
+- [integrations/SundownMedia.Integration.Lidarr/](integrations/SundownMedia.Integration.Lidarr/)
+
+```mermaid
+flowchart TB
+  CLI[SundownMedia.ContentOps.Cli] --> APP[SundownMedia.ContentOps.Application]
+  APP --> DOMAIN[SundownMedia.ContentOps.Domain]
+  CLI --> INFRA[SundownMedia.ContentOps.Infrastructure]
+  INFRA --> APP
+  INFRA --> DOMAIN
+  INFRA --> SPOT[SundownMedia.Integration.Spotify]
+  INFRA --> LID[SundownMedia.Integration.Lidarr]
+```
+
+## Prerequisites
+
+- .NET SDK 10.0.100 (see [global.json](global.json))
+- Docker (optional, for containerised runtime)
+
+## Local Setup
+
+Restore, build, and test:
+
+```powershell
+Set-Location automation/dotnet
+dotnet restore SundownMedia.ContentOps.sln
+dotnet build SundownMedia.ContentOps.sln --configuration Release --no-restore
+dotnet test SundownMedia.ContentOps.sln --configuration Release --no-build
+```
+
+## Publish Local Binary
+
+```powershell
+Set-Location automation/dotnet
+dotnet publish src/SundownMedia.ContentOps.Cli/SundownMedia.ContentOps.Cli.csproj `
+  --configuration Release `
+  --runtime linux-x64 `
+  --self-contained true `
+  -p:PublishSingleFile=true `
+  -p:DebugType=none `
+  -p:DebugSymbols=false `
+  --output ./publish
+```
+
+## Docker Runtime
+
+Build a local image:
+
+```powershell
+Set-Location automation/dotnet
+docker build -f Dockerfile -t contentops:local .
+```
+
+Run help:
+
+```powershell
+docker run --rm -it contentops:local --help
+```
+
+## Testing Strategy
+
+- Unit and application tests use NSubstitute
+- Integration-style tests use Testcontainers and Respawn where relevant
+- CI validates restore, build, and test before packaging
+
+## Release Model
+
+The release workflow [.github/workflows/contentops-release.yml](../../.github/workflows/contentops-release.yml) handles:
+
+- manual releases via workflow dispatch
+- tag-based releases using contentops/v* naming
+- release asset generation (binary archive, Dockerfile, usage instructions)
+- GHCR publication
+
+## Contributing
+
+When contributing to ContentOps:
+
+- keep domain rules in Domain and orchestration in Application
+- avoid exception-driven control flow for expected failures
+- respect integration boundaries for Spotify and Lidarr libraries
+- follow one-type-per-file conventions
+
+For repository-wide standards, see [../../README.md](../../README.md) and [../../.github/copilot-instructions.md](../../.github/copilot-instructions.md).


### PR DESCRIPTION
## Summary

This PR refreshes repository documentation to make onboarding clearer and more actionable.

### Root README
- Replaced placeholder/generic content with project-specific narrative
- Added a clear problem statement
- Added a high-level architecture overview with diagrams
- Added in-context screenshot support
- Added full setup instructions for Hugo and ContentOps
- Added a Now/Next/Later roadmap (indicative direction)
- Consolidated contribution, release, and CI status guidance

### Automation README
- Added `automation/dotnet/README.md`
- Documented ContentOps purpose, architecture boundaries, prerequisites, setup, publish, Docker runtime, testing, and release model

## Why

The previous root README mixed concerns and did not provide a clear problem statement or practical setup flow. This update improves discoverability and contributor onboarding while keeping architecture boundaries explicit.

## Validation

- Markdown diagnostics checked for both updated files with no reported issues.
