### PR TITLE
feat(src): add Hugo regression preflight safety net

### DIFF
--- a/.github/workflows/hugo-regression-preflight.yml
+++ b/.github/workflows/hugo-regression-preflight.yml
@@ -1,0 +1,77 @@
+name: Hugo Regression Preflight
+
+on:
+  pull_request:
+    paths:
+      - src/content/**
+      - src/layouts/**
+      - src/config/**
+      - src/static/**
+      - src/themes/**
+      - scripts/**
+      - .hugo-warnings-baseline
+      - .github/workflows/hugo-regression-preflight.yml
+  push:
+    branches:
+      - main
+    paths:
+      - src/content/**
+      - src/layouts/**
+      - src/config/**
+      - src/static/**
+      - src/themes/**
+      - scripts/**
+      - .hugo-warnings-baseline
+      - .github/workflows/hugo-regression-preflight.yml
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.146.5
+    steps:
+      - name: Checkout source using v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Build Hugo site and capture warnings
+        run: |
+          mkdir -p build
+          hugo \
+            --source src \
+            --printPathWarnings \
+            --printUnusedTemplates \
+            --environment production \
+            --baseURL https://example.invalid/ \
+            > build/hugo-build.log \
+            2> build/hugo-warnings.log
+
+      - name: Report warning delta (non-blocking)
+        run: |
+          chmod +x scripts/check-build-warnings.sh
+          CHECK_MODE=report scripts/check-build-warnings.sh .hugo-warnings-baseline build/hugo-warnings.log build/warning-delta.txt
+
+      - name: Validate front matter asset references (non-blocking)
+        continue-on-error: true
+        run: |
+          chmod +x scripts/validate-hugo-assets.sh
+          scripts/validate-hugo-assets.sh src/content src/static build/missing-assets.txt
+
+      - name: Upload regression reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hugo-regression-preflight-reports
+          path: |
+            build/hugo-build.log
+            build/hugo-warnings.log
+            build/warning-delta.txt
+            build/missing-assets.txt
+          if-no-files-found: warn

--- a/.hugo-warnings-baseline
+++ b/.hugo-warnings-baseline
@@ -1,0 +1,2 @@
+# Hugo warning baseline
+# Keep this sorted and add entries only for intentional, accepted warnings.

--- a/docs/regression-safety-net.md
+++ b/docs/regression-safety-net.md
@@ -1,0 +1,49 @@
+# Hugo Regression Safety Net
+
+This document defines the first implementation slice of regression protection for the Hugo website under `src/`.
+
+## Current coverage
+
+The `Hugo Regression Preflight` workflow adds report-driven checks for pull requests and pushes that touch Hugo content, layouts, configuration, theme assets, or regression scripts.
+
+Checks included in this phase:
+
+- Hugo production build with warnings captured to an artefact
+- warning delta report against `.hugo-warnings-baseline`
+- front matter asset reference validation (non-blocking while baseline is established)
+
+## Workflow
+
+- Workflow file: `.github/workflows/hugo-regression-preflight.yml`
+- Artefact name: `hugo-regression-preflight-reports`
+- Report files:
+  - `build/hugo-build.log`
+  - `build/hugo-warnings.log`
+  - `build/warning-delta.txt`
+  - `build/missing-assets.txt`
+
+## Local execution
+
+Scripts are Bash scripts and run natively on Linux/macOS, WSL, or Git Bash.
+
+Run from repository root:
+
+```bash
+CHECK_MODE=report scripts/check-build-warnings.sh .hugo-warnings-baseline build/hugo-warnings.log build/warning-delta.txt
+scripts/validate-hugo-assets.sh src/content src/static build/missing-assets.txt
+```
+
+If you run on Windows PowerShell without WSL/Git Bash, use the CI artefacts as the source of truth until a PowerShell wrapper is introduced.
+
+## Baseline governance
+
+- Keep `.hugo-warnings-baseline` sorted and minimal.
+- Add entries only for intentional, accepted warnings.
+- Baseline changes must be made in pull requests that explicitly describe why the warning is acceptable.
+
+## Next implementation slices
+
+- Promote asset validation to merge-blocking once the current baseline is clean.
+- Add internal link validation on generated output.
+- Add deterministic HTML snapshot regression checks.
+- Add targeted Playwright screenshot regression checks for key templates and viewports.

--- a/scripts/check-build-warnings.sh
+++ b/scripts/check-build-warnings.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <baseline-file> <warnings-file> [report-file]" >&2
+  exit 2
+fi
+
+baseline_file="$1"
+warnings_file="$2"
+report_file="${3:-build/warning-delta.txt}"
+mode="${CHECK_MODE:-report}"
+
+mkdir -p "$(dirname "$report_file")"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+normalise() {
+  local src="$1"
+  if [ ! -f "$src" ]; then
+    touch "$2"
+    return
+  fi
+
+  grep -v '^[[:space:]]*$' "$src" \
+    | grep -v '^[[:space:]]*#' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+    | sort -u > "$2" || true
+}
+
+normalise "$baseline_file" "$tmp_dir/baseline.txt"
+normalise "$warnings_file" "$tmp_dir/current.txt"
+
+comm -13 "$tmp_dir/baseline.txt" "$tmp_dir/current.txt" > "$tmp_dir/new.txt"
+comm -23 "$tmp_dir/baseline.txt" "$tmp_dir/current.txt" > "$tmp_dir/resolved.txt"
+
+new_count="$(wc -l < "$tmp_dir/new.txt" | tr -d ' ')"
+resolved_count="$(wc -l < "$tmp_dir/resolved.txt" | tr -d ' ')"
+
+{
+  echo "Mode: $mode"
+  echo "Baseline file: $baseline_file"
+  echo "Warnings file: $warnings_file"
+  echo "New warnings: $new_count"
+  echo "Resolved warnings: $resolved_count"
+  echo
+
+  if [ "$new_count" -gt 0 ]; then
+    echo "New warnings:"
+    cat "$tmp_dir/new.txt"
+    echo
+  fi
+
+  if [ "$resolved_count" -gt 0 ]; then
+    echo "Resolved warnings:"
+    cat "$tmp_dir/resolved.txt"
+    echo
+  fi
+} > "$report_file"
+
+cat "$report_file"
+
+if [ "$mode" = "enforce" ] && [ "$new_count" -gt 0 ]; then
+  echo "Found new Hugo warnings compared to baseline." >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/validate-hugo-assets.sh
+++ b/scripts/validate-hugo-assets.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+content_root="${1:-$repo_root/src/content}"
+static_root="${2:-$repo_root/src/static}"
+report_file="${3:-build/missing-assets.txt}"
+
+mkdir -p "$(dirname "$report_file")"
+
+if [ ! -d "$content_root" ]; then
+  echo "Content directory not found: $content_root" >&2
+  exit 2
+fi
+
+if [ ! -d "$static_root" ]; then
+  echo "Static directory not found: $static_root" >&2
+  exit 2
+fi
+
+tmp_refs="$(mktemp)"
+trap 'rm -f "$tmp_refs"' EXIT
+
+extract_front_matter_refs() {
+  local file="$1"
+  awk '
+    NR == 1 && $0 !~ /^---[[:space:]]*$/ { exit }
+    /^---[[:space:]]*$/ {
+      if (in_fm == 0) {
+        in_fm = 1
+        next
+      }
+      if (in_fm == 1) {
+        exit
+      }
+    }
+    in_fm == 1 {
+      if ($0 ~ /^[[:space:]]*images:[[:space:]]*$/) {
+        in_images = 1
+        next
+      }
+
+      if (in_images == 1) {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]+/) {
+          value = $0
+          sub(/^[[:space:]]*-[[:space:]]+/, "", value)
+          gsub(/^["\047]|["\047]$/, "", value)
+          print value
+          next
+        }
+
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        in_images = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*(featured_image|image|hero_image|thumbnail|cover_image):[[:space:]]+/) {
+        value = $0
+        sub(/^[[:space:]]*(featured_image|image|hero_image|thumbnail|cover_image):[[:space:]]+/, "", value)
+        gsub(/^["\047]|["\047]$/, "", value)
+        print value
+      }
+    }
+  ' "$file"
+}
+
+while IFS= read -r -d '' file; do
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    printf '%s\t%s\n' "$file" "$ref" >> "$tmp_refs"
+  done < <(extract_front_matter_refs "$file")
+done < <(find "$content_root" -type f -name '*.md' -print0)
+
+missing_count=0
+
+{
+  echo "Missing asset references"
+  echo "content_root=$content_root"
+  echo "static_root=$static_root"
+  echo
+} > "$report_file"
+
+while IFS=$'\t' read -r source_file raw_ref; do
+  ref="${raw_ref%%#*}"
+  ref="${ref%%\?*}"
+
+  if [ -z "$ref" ]; then
+    continue
+  fi
+
+  case "$ref" in
+    http://*|https://*|data:*|mailto:*|tel:*|{{*|*}}*)
+      continue
+      ;;
+  esac
+
+  candidate_1=""
+  candidate_2=""
+
+  if [[ "$ref" == /* ]]; then
+    candidate_1="$static_root$ref"
+  else
+    candidate_1="$(dirname "$source_file")/$ref"
+    candidate_2="$static_root/$ref"
+  fi
+
+  if [ -f "$candidate_1" ]; then
+    continue
+  fi
+
+  if [ -n "$candidate_2" ] && [ -f "$candidate_2" ]; then
+    continue
+  fi
+
+  missing_count=$((missing_count + 1))
+  {
+    echo "source: $source_file"
+    echo "reference: $raw_ref"
+    if [ -n "$candidate_2" ]; then
+      echo "checked: $candidate_1"
+      echo "checked: $candidate_2"
+    else
+      echo "checked: $candidate_1"
+    fi
+    echo
+  } >> "$report_file"
+done < <(sort -u "$tmp_refs")
+
+if [ "$missing_count" -eq 0 ]; then
+  echo "No missing asset references found." >> "$report_file"
+fi
+
+cat "$report_file"
+
+if [ "$missing_count" -gt 0 ]; then
+  echo "Found $missing_count missing asset reference(s)." >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary\n- add a Hugo regression preflight workflow for src changes\n- capture Hugo build warnings and report deltas against a tracked baseline\n- add front matter asset reference validation (non-blocking in this rollout phase)\n- document the new safety net workflow and baseline governance\n\n## Added\n- .github/workflows/hugo-regression-preflight.yml\n- .hugo-warnings-baseline\n- scripts/check-build-warnings.sh\n- scripts/validate-hugo-assets.sh\n- docs/regression-safety-net.md\n\n## Notes\n- this is Phase 1 and intentionally report-first to establish baseline confidence before enforcing merge-blocking gates