### PR TITLE
fix(website): avoid repeated artist biography excerpt

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -178,3 +178,25 @@
 .artist-biography-read-more:hover {
   text-decoration: underline;
 }
+
+/* Reveal the complete introductory paragraph alongside the remaining biography
+   when the native disclosure is open. The remainder itself excludes this
+   paragraph, preventing duplicated content. */
+
+.artist-biography-excerpt:has(+ details[open]) p {
+  display: block;
+  overflow: visible;
+  -webkit-line-clamp: unset;
+}
+
+.artist-biography-show-less {
+  display: none;
+}
+
+details[open] > .artist-biography-read-more .artist-biography-read-full {
+  display: none;
+}
+
+details[open] > .artist-biography-read-more .artist-biography-show-less {
+  display: inline;
+}

--- a/src/layouts/partials/artist-content.html
+++ b/src/layouts/partials/artist-content.html
@@ -34,8 +34,10 @@
 {{ $biographyTextLength := len ($biographyContent | plainify | strings.TrimSpace) }}
 {{ $collapseBiography := or (gt (len $biographyParagraphs) $biographyCollapseParagraphThreshold) (gt $biographyTextLength $biographyCollapseTextThreshold) }}
 {{ $biographyExcerpt := $biographyContent }}
+{{ $biographyRemainder := "" }}
 {{ if gt (len $biographyParagraphs) 0 }}
   {{ $biographyExcerpt = index $biographyParagraphs 0 }}
+  {{ $biographyRemainder = replaceRE `(?s)^.*?</p>\s*` "" $biographyContent | strings.TrimSpace }}
 {{ end }}
 
 {{ if or $biographyContent $genres }}
@@ -56,11 +58,14 @@
         </div>
         <details class="mt-3">
           <summary class="artist-biography-read-more cursor-pointer text-sm font-semibold text-neutral-600 marker:hidden dark:text-neutral-300">
-            Read full biography <span aria-hidden="true">→</span>
+            <span class="artist-biography-read-full">Read full biography <span aria-hidden="true">→</span></span>
+            <span class="artist-biography-show-less">Show less</span>
           </summary>
-          <div class="mt-4 {{ $biographyBodyClasses }}">
-            {{ $biographyContent | safeHTML }}
-          </div>
+          {{ with $biographyRemainder }}
+            <div class="mt-4 {{ $biographyBodyClasses }}">
+              {{ . | safeHTML }}
+            </div>
+          {{ end }}
         </details>
       {{ else }}
         <div class="{{ $biographyBodyClasses }}">


### PR DESCRIPTION
## Summary

- split the visible biography introduction from the expanded remainder
- prevent the introductory paragraph from being rendered twice
- reveal line-clamped single-paragraph biographies fully when expanded
- change the disclosure label to Show less while open

## Validation

- git diff --check
- Hugo build not run locally because Hugo and the Blowfish submodule are not materialised in this environment