### PR TITLE
fix(website): improve artist biography collapse

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -159,6 +159,16 @@
 /* Artist biography excerpt — keep the first paragraph concise before the full
    biography disclosure while preserving natural prose styling. */
 
+#artist-biography-heading {
+  scroll-margin-top: 6rem;
+}
+
+@media (min-width: 1024px) {
+  #artist-biography-heading {
+    scroll-margin-top: 8rem;
+  }
+}
+
 .artist-biography-excerpt p {
   display: -webkit-box;
   margin-bottom: 0;
@@ -177,6 +187,23 @@
 
 .artist-biography-read-more:hover {
   text-decoration: underline;
+}
+
+/* Keep the native disclosure semantics while placing the close control after
+   the expanded biography, where the reader finishes. */
+
+#artist-about details[open] {
+  display: flex;
+  flex-direction: column;
+}
+
+#artist-about details[open] > .artist-biography-read-more {
+  order: 2;
+  margin-top: 0.75rem;
+}
+
+#artist-about details[open] > div {
+  order: 1;
 }
 
 /* Reveal the complete introductory paragraph alongside the remaining biography

--- a/src/layouts/artists/single.html
+++ b/src/layouts/artists/single.html
@@ -54,5 +54,30 @@
       {{ end }}
     </footer>
 
+    <script>
+      (() => {
+        const aboutHeading = document.getElementById("artist-biography-heading");
+        const biographyDisclosure = document.querySelector("#artist-about details");
+
+        if (!aboutHeading || !biographyDisclosure) return;
+
+        let wasExpanded = biographyDisclosure.open;
+
+        biographyDisclosure.addEventListener("toggle", () => {
+          if (biographyDisclosure.open) {
+            wasExpanded = true;
+            return;
+          }
+
+          if (!wasExpanded) return;
+          wasExpanded = false;
+
+          requestAnimationFrame(() => {
+            aboutHeading.scrollIntoView({ behavior: "smooth", block: "start" });
+          });
+        });
+      })();
+    </script>
+
   </article>
 {{ end }}

--- a/src/layouts/partials/artist-content.html
+++ b/src/layouts/partials/artist-content.html
@@ -1,5 +1,3 @@
-{{ $genres := .Params.genres }}
-
 {{ $renderedSectionHeadingMarker := `<h2 class="relative group">` }}
 {{ $biographyCollapseParagraphThreshold := 2 }}
 {{ $biographyCollapseTextThreshold := 500 }}
@@ -40,8 +38,9 @@
   {{ $biographyRemainder = replaceRE `(?s)^.*?</p>\s*` "" $biographyContent | strings.TrimSpace }}
 {{ end }}
 
-{{ if or $biographyContent $genres }}
+{{ if $biographyContent }}
   <section
+    id="artist-about"
     class="mb-10 w-full max-w-none not-prose"
     role="region"
     aria-labelledby="artist-biography-heading">
@@ -74,19 +73,6 @@
       {{ end }}
     {{ end }}
 
-    {{ with $genres }}
-      <p class="mt-4 text-sm text-neutral-500 dark:text-neutral-400">
-        <span class="font-semibold text-neutral-700 dark:text-neutral-300">Genres:</span>
-        {{- range $index, $genre := . -}}
-          {{- if eq $index 0 }} {{ else }} · {{ end -}}
-          {{- with site.GetPage (printf "/genres/%s" ($genre | urlize)) -}}
-            <a href="{{ .RelPermalink }}" class="hover:underline">{{ $genre }}</a>
-          {{- else -}}
-            {{ $genre }}
-          {{- end -}}
-        {{- end -}}
-      </p>
-    {{ end }}
   </section>
 {{ end }}
 

--- a/src/layouts/partials/artist-header.html
+++ b/src/layouts/partials/artist-header.html
@@ -1,7 +1,6 @@
 {{/* Artist Header — replaces the standard hero banner on artist pages.
      Displays the artist image alongside key information: name, a short summary,
-     Sundown Sessions statistics, and a primary call to action. Genres are
-     rendered within the biography section by artist-content.html. */}}
+     Sundown Sessions statistics, and a primary call to action. */}}
 
 {{/* Image resolution: mirrors the logic used in hero/basic.html and card.html */}}
 {{ $featured := "" }}


### PR DESCRIPTION
## Summary

- smooth-scroll back to the About heading when an expanded biography is collapsed
- place the Show less control after the expanded biography while preserving native disclosure semantics
- hide genre metadata from artist pages without removing taxonomy data or related-artist scoring

## Validation

- `git diff --check`
- confirmed genre taxonomy configuration and genre-based related-artist logic remain in place
- Hugo build not run locally because Hugo is not installed in the environment