### PR TITLE
fix: remove duplicate artist external links

### DIFF
--- a/src/layouts/partials/artist-content.html
+++ b/src/layouts/partials/artist-content.html
@@ -17,7 +17,8 @@
     {{ end }}
     {{ range after 2 $contentSections }}
       {{ $section := . | strings.TrimSpace }}
-      {{ if not (hasPrefix $section "External Links</h2>") }}
+      {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace }}
+      {{ if ne $sectionHeading "External Links" }}
         {{ $supplementaryContent = printf `%s%s%s` $supplementaryContent $renderedSectionHeadingMarker . }}
       {{ end }}
     {{ end }}
@@ -25,7 +26,8 @@
     {{ $biographyContent = index $contentSections 0 | strings.TrimSpace }}
     {{ range after 1 $contentSections }}
       {{ $section := . | strings.TrimSpace }}
-      {{ if not (hasPrefix $section "External Links</h2>") }}
+      {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace }}
+      {{ if ne $sectionHeading "External Links" }}
         {{ $supplementaryContent = printf `%s%s%s` $supplementaryContent $renderedSectionHeadingMarker . }}
       {{ end }}
     {{ end }}


### PR DESCRIPTION
## Summary
- remove the legacy External Links render from artist body content
- keep the modern External Links component after Related Artists as the single canonical section
- make the section filtering resilient to Blowfish heading markup

## Verification
- ran git diff --check
- confirmed artist template order remains artist content, Related Artists, External Links
- Hugo build not run: hugo is not installed in this environment