### PR TITLE
fix: remove legacy artist external links render path

### DIFF
--- a/src/layouts/partials/artist-content.html
+++ b/src/layouts/partials/artist-content.html
@@ -1,34 +1,31 @@
-{{ $renderedSectionHeadingMarker := `<h2 class="relative group">` }}
 {{ $biographyCollapseParagraphThreshold := 2 }}
 {{ $biographyCollapseTextThreshold := 500 }}
 {{ $biographyBodyClasses := `prose max-w-none leading-relaxed dark:prose-invert` }}
-{{ $contentSections := split .Content $renderedSectionHeadingMarker }}
+{{ $contentSections := split .Content `<h2` }}
 {{ $biographyContent := "" }}
 {{ $supplementaryContent := "" }}
 
 {{ if ge (len $contentSections) 2 }}
-  {{ $firstSection := index $contentSections 1 | strings.TrimSpace }}
-  {{ if hasPrefix $firstSection "About" }}
-    {{ $firstSectionParts := split $firstSection `</h2>` }}
-    {{ if ge (len $firstSectionParts) 2 }}
-      {{ $biographyContent = printf `%s%s` (index $contentSections 0) (delimit (after 1 $firstSectionParts) `</h2>`) | strings.TrimSpace }}
-    {{ else }}
-      {{ $biographyContent = index $contentSections 0 | strings.TrimSpace }}
-    {{ end }}
+  {{ $introContent := index $contentSections 0 | strings.TrimSpace }}
+  {{ $firstSection := printf `<h2%s` (index $contentSections 1) }}
+  {{ $firstHeading := index (split $firstSection `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
+  {{ if eq $firstHeading "About" }}
+    {{ $firstSectionBody := delimit (after 1 (split $firstSection `</h2>`)) `</h2>` | strings.TrimSpace }}
+    {{ $biographyContent = printf `%s%s` $introContent $firstSectionBody | strings.TrimSpace }}
     {{ range after 2 $contentSections }}
-      {{ $section := . | strings.TrimSpace }}
-      {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace }}
+      {{ $section := printf `<h2%s` . }}
+      {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
       {{ if ne $sectionHeading "External Links" }}
-        {{ $supplementaryContent = printf `%s%s%s` $supplementaryContent $renderedSectionHeadingMarker . }}
+        {{ $supplementaryContent = printf `%s%s` $supplementaryContent $section }}
       {{ end }}
     {{ end }}
   {{ else }}
-    {{ $biographyContent = index $contentSections 0 | strings.TrimSpace }}
+    {{ $biographyContent = $introContent }}
     {{ range after 1 $contentSections }}
-      {{ $section := . | strings.TrimSpace }}
-      {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace }}
+      {{ $section := printf `<h2%s` . }}
+      {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
       {{ if ne $sectionHeading "External Links" }}
-        {{ $supplementaryContent = printf `%s%s%s` $supplementaryContent $renderedSectionHeadingMarker . }}
+        {{ $supplementaryContent = printf `%s%s` $supplementaryContent $section }}
       {{ end }}
     {{ end }}
   {{ end }}

--- a/src/layouts/partials/artist-header.html
+++ b/src/layouts/partials/artist-header.html
@@ -30,23 +30,18 @@
 {{ end }}
 
 {{/* Artist summary — prefer editorial summary when present, fall back to factual summary */}}
-{{ $renderedSectionHeadingMarker := `<h2 class="relative group">` }}
 {{ $artistSummary := .Params.editorialSummary | default (.Params.summary | default .Description) }}
 {{ if not $artistSummary }}
-  {{ $artistSummary = (.Summary | plainify | htmlUnescape | strings.TrimSpace) }}
-{{ end }}
-{{ if not $artistSummary }}
-  {{ $contentSections := split .Content $renderedSectionHeadingMarker }}
+  {{ $contentSections := split .Content `<h2` }}
   {{ $summarySource := .Content }}
   {{ if ge (len $contentSections) 2 }}
-    {{ $firstSection := index $contentSections 1 | strings.TrimSpace }}
-    {{ if hasPrefix $firstSection "About" }}
-      {{ $firstSectionParts := split $firstSection `</h2>` }}
-      {{ if ge (len $firstSectionParts) 2 }}
-        {{ $summarySource = delimit (after 1 $firstSectionParts) `</h2>` | strings.TrimSpace }}
-      {{ end }}
+    {{ $introContent := index $contentSections 0 | strings.TrimSpace }}
+    {{ $firstSection := printf `<h2%s` (index $contentSections 1) }}
+    {{ $firstHeading := index (split $firstSection `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
+    {{ if eq $firstHeading "About" }}
+      {{ $summarySource = delimit (after 1 (split $firstSection `</h2>`)) `</h2>` | strings.TrimSpace }}
     {{ else }}
-      {{ $summarySource = index $contentSections 0 | strings.TrimSpace }}
+      {{ $summarySource = $introContent }}
     {{ end }}
   {{ end }}
   {{ with findRE `(?s)<p>.*?</p>` $summarySource 1 }}
@@ -54,7 +49,7 @@
   {{ end }}
 {{ end }}
 {{ if not $artistSummary }}
-  {{ $artistSummary = (.Plain | htmlUnescape | replaceRE `\s+` " " | strings.TrimSpace | replaceRE `^About\s*#?\s*` "") }}
+  {{ $artistSummary = "" }}
 {{ end }}
 {{/* Keep summaries to ~2 lines in the desktop card by capping at 220 characters. */}}
 {{ $artistSummaryMaxLength := 220 }}


### PR DESCRIPTION
## Summary
- remove the legacy External Links section from rendered artist body content using generic h2 parsing instead of Blowfish-specific heading markup
- keep the modern External Links component after Related Artists as the only visible External Links section
- prevent empty artist bios from falling back to raw External Links text in the artist header summary

## Why the previous fix missed it
The earlier filter still depended on exact rendered heading markup. In production, Blowfish adds anchor markup inside headings, so plainified headings become values like `External Links #`, and the legacy section was not filtered out.

## Verification
- built with the deployment-pinned Hugo version: `hugo v0.146.5+extended` using `--environment production` against the checked-out Blowfish submodule
- checked generated Bauhaus and Franz Ferdinand artist pages: About appears before Related Artists, and External Links appears after Related Artists
- swept generated artist pages under `public-codex-verify/artists`: duplicate External Links pages = 0
- ran `git diff --check`