### PR TITLE
fix: clarify artist page link hierarchy

### DIFF
--- a/src/layouts/artists/single.html
+++ b/src/layouts/artists/single.html
@@ -29,7 +29,6 @@
         {{ partial "series/series.html" . }}
         {{ partial "artist-content.html" . }}
         {{ partial "series/series-closed.html" . }}
-        {{ partial "sharing-links.html" . }}
         {{ partial "related.html" . }}
       </div>
     </section>
@@ -37,7 +36,7 @@
     {{/* Related Artists — automatically generated from shared shows and genres */}}
     {{ partial "artist-related-artists.html" . }}
 
-    {{/* External destinations follow internal discovery content. */}}
+    {{/* Artist destinations follow internal discovery content. */}}
     {{ partial "artist-external-links.html" . }}
 
     {{/* Footer */}}

--- a/src/layouts/partials/artist-content.html
+++ b/src/layouts/partials/artist-content.html
@@ -15,7 +15,7 @@
     {{ range after 2 $contentSections }}
       {{ $section := printf `<h2%s` . }}
       {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
-      {{ if ne $sectionHeading "External Links" }}
+      {{ if and (ne $sectionHeading "External Links") (ne $sectionHeading "Artist Links") }}
         {{ $supplementaryContent = printf `%s%s` $supplementaryContent $section }}
       {{ end }}
     {{ end }}
@@ -24,7 +24,7 @@
     {{ range after 1 $contentSections }}
       {{ $section := printf `<h2%s` . }}
       {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
-      {{ if ne $sectionHeading "External Links" }}
+      {{ if and (ne $sectionHeading "External Links") (ne $sectionHeading "Artist Links") }}
         {{ $supplementaryContent = printf `%s%s` $supplementaryContent $section }}
       {{ end }}
     {{ end }}

--- a/src/layouts/partials/artist-external-links.html
+++ b/src/layouts/partials/artist-external-links.html
@@ -5,7 +5,7 @@
 {{ $externalSection := "" }}
 {{ range split .RawContent "\n## " }}
   {{ $section := . | strings.TrimSpace }}
-  {{ if or (hasPrefix $section "External Links") (hasPrefix $section "## External Links") }}
+  {{ if or (hasPrefix $section "External Links") (hasPrefix $section "## External Links") (hasPrefix $section "Artist Links") (hasPrefix $section "## Artist Links") }}
     {{ $externalSection = $section }}
   {{ end }}
 {{ end }}
@@ -21,7 +21,7 @@
     <h2
       id="artist-external-links-heading"
       class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">
-      External Links
+      Artist Links
     </h2>
 
     <ul class="m-0 flex list-none flex-col items-start gap-1 p-0">


### PR DESCRIPTION
## Summary
- remove artist-page share icons from the artist single template
- rename the rendered destination heading to Artist Links
- keep artist link parsing compatible with both External Links and Artist Links headings while hiding raw URLs

## Validation
- `hugo --source src --printPathWarnings --panicOnWarning --environment production --baseURL https://example.invalid/` using Hugo 0.146.5