### PR TITLE
Redesign artist external links card

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -227,3 +227,29 @@ details[open] > .artist-biography-read-more .artist-biography-read-full {
 details[open] > .artist-biography-read-more .artist-biography-show-less {
   display: inline;
 }
+
+/* Artist external links card: reliable keyboard focus independent of the
+   compiled Blowfish utility set. */
+
+.artist-external-link-row:hover {
+  background-color: rgba(var(--color-neutral-100), 1);
+  color: rgba(var(--color-primary-600), 1);
+}
+
+.artist-external-link-row:hover .artist-external-link-icon {
+  color: rgba(var(--color-primary-600), 1);
+}
+
+.artist-external-link-row:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-600), 1);
+  outline-offset: -2px;
+}
+
+.dark .artist-external-link-row:hover {
+  background-color: rgba(var(--color-neutral-800), 1);
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.dark .artist-external-link-row:hover .artist-external-link-icon {
+  color: rgba(var(--color-primary-400), 1);
+}

--- a/src/layouts/partials/artist-content.html
+++ b/src/layouts/partials/artist-content.html
@@ -15,7 +15,7 @@
     {{ range after 2 $contentSections }}
       {{ $section := printf `<h2%s` . }}
       {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
-      {{ if and (ne $sectionHeading "External Links") (ne $sectionHeading "Artist Links") }}
+      {{ if and (ne $sectionHeading "External Links") (ne $sectionHeading "Artist Links") (ne $sectionHeading "Explore Further") }}
         {{ $supplementaryContent = printf `%s%s` $supplementaryContent $section }}
       {{ end }}
     {{ end }}
@@ -24,7 +24,7 @@
     {{ range after 1 $contentSections }}
       {{ $section := printf `<h2%s` . }}
       {{ $sectionHeading := index (split $section `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
-      {{ if and (ne $sectionHeading "External Links") (ne $sectionHeading "Artist Links") }}
+      {{ if and (ne $sectionHeading "External Links") (ne $sectionHeading "Artist Links") (ne $sectionHeading "Explore Further") }}
         {{ $supplementaryContent = printf `%s%s` $supplementaryContent $section }}
       {{ end }}
     {{ end }}

--- a/src/layouts/partials/artist-external-links.html
+++ b/src/layouts/partials/artist-external-links.html
@@ -1,11 +1,11 @@
-{{/* Render the existing artist link shortcodes as accessible, touch-friendly
-     destination links without exposing raw URLs. Keeping the extraction here
-     avoids a migration of the artist content collection. */}}
+{{/* Render the existing artist link shortcodes as an accessible card of
+     destinations without exposing raw URLs. Keeping the extraction here avoids
+     a migration of the artist content collection. */}}
 
 {{ $externalSection := "" }}
 {{ range split .RawContent "\n## " }}
   {{ $section := . | strings.TrimSpace }}
-  {{ if or (hasPrefix $section "External Links") (hasPrefix $section "## External Links") (hasPrefix $section "Artist Links") (hasPrefix $section "## Artist Links") }}
+  {{ if or (hasPrefix $section "External Links") (hasPrefix $section "## External Links") (hasPrefix $section "Artist Links") (hasPrefix $section "## Artist Links") (hasPrefix $section "Explore Further") (hasPrefix $section "## Explore Further") }}
     {{ $externalSection = $section }}
   {{ end }}
 {{ end }}
@@ -13,7 +13,50 @@
 {{ $linkPattern := `(?m)^\s*-\s+\{\{<\s*new-tab-link\s+"([^":]+):\s+\[[^\]]+\]\((https?://[^)]+)\)"\s*>\}\}\s*$` }}
 {{ $externalLinks := findRESubmatch $linkPattern $externalSection }}
 
-{{ if $externalLinks }}
+{{ $linksByPlatform := dict }}
+{{ range $externalLinks }}
+  {{ $platform := index . 1 | strings.TrimSpace }}
+  {{ $url := index . 2 | strings.TrimSpace }}
+  {{ $platformKey := lower $platform }}
+  {{ $platformKey = replace $platformKey " " "-" }}
+  {{ $platformKey = replace $platformKey "_" "-" }}
+  {{ $platformKey = replace $platformKey "." "" }}
+  {{ $platformKey = replace $platformKey "official-website" "website" }}
+  {{ $platformKey = replace $platformKey "official-site" "website" }}
+  {{ $platformKey = replace $platformKey "apple-music" "apple" }}
+  {{ if or (eq $platformKey "x") (eq $platformKey "x-twitter") }}
+    {{ $platformKey = "twitter" }}
+  {{ end }}
+
+  {{ if and $url (not (index $linksByPlatform $platformKey)) }}
+    {{ $linksByPlatform = merge $linksByPlatform (dict $platformKey $url) }}
+  {{ end }}
+{{ end }}
+
+{{ $destinations := slice
+  (dict "key" "website" "label" "Official Website" "icon" "globe")
+  (dict "key" "bandcamp" "label" "Bandcamp" "icon" "music")
+  (dict "key" "spotify" "label" "Spotify" "icon" "spotify")
+  (dict "key" "apple" "label" "Apple Music" "icon" "apple")
+  (dict "key" "discogs" "label" "Discogs" "icon" "music")
+  (dict "key" "musicbrainz" "label" "MusicBrainz" "icon" "music")
+  (dict "key" "facebook" "label" "Facebook" "icon" "facebook")
+  (dict "key" "instagram" "label" "Instagram" "icon" "instagram")
+  (dict "key" "youtube" "label" "YouTube" "icon" "youtube")
+  (dict "key" "twitter" "label" "X (Twitter)" "icon" "x-twitter")
+  (dict "key" "vimeo" "label" "Vimeo" "icon" "link")
+  (dict "key" "tiktok" "label" "TikTok" "icon" "tiktok")
+}}
+
+{{ $orderedLinks := slice }}
+{{ range $destinations }}
+  {{ $destination := . }}
+  {{ with index $linksByPlatform .key }}
+    {{ $orderedLinks = $orderedLinks | append (merge $destination (dict "url" .)) }}
+  {{ end }}
+{{ end }}
+
+{{ if $orderedLinks }}
   <section
     class="mb-10 w-full max-w-none not-prose"
     role="region"
@@ -21,42 +64,25 @@
     <h2
       id="artist-external-links-heading"
       class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">
-      Artist Links
+      Explore Further
     </h2>
 
-    <ul class="m-0 flex list-none flex-col items-start gap-1 p-0">
-      {{ range $externalLinks }}
-        {{ $platform := index . 1 | strings.TrimSpace }}
-        {{ $url := index . 2 | strings.TrimSpace }}
-        {{ $platformKey := lower $platform }}
-        {{ $label := $platform }}
-        {{ $icon := "link" }}
-
-        {{ if eq $platformKey "facebook" }}
-          {{ $icon = "facebook" }}
-        {{ else if eq $platformKey "instagram" }}
-          {{ $icon = "instagram" }}
-        {{ else if eq $platformKey "twitter" }}
-          {{ $icon = "twitter" }}
-        {{ else if or (eq $platformKey "bandcamp") (eq $platformKey "discogs") }}
-          {{ $icon = "music" }}
-        {{ else if eq $platformKey "website" }}
-          {{ $icon = "globe" }}
-          {{ $label = "Official Website" }}
-        {{ end }}
-
-        <li class="m-0 p-0">
+    <ul class="m-0 overflow-hidden rounded-xl border border-neutral-300 bg-white p-0 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      {{ range $index, $link := $orderedLinks }}
+        <li class="m-0 p-0{{ if gt $index 0 }} border-t border-neutral-200 dark:border-neutral-700{{ end }}">
           <a
-            class="group -mx-3 inline-flex min-h-11 items-center gap-3 rounded-lg px-3 text-neutral-700 no-underline transition-colors hover:bg-neutral-100 hover:text-primary-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-neutral-200 dark:hover:bg-neutral-800 dark:hover:text-primary-400"
-            href="{{ $url | safeURL }}"
+            class="artist-external-link-row flex w-full items-center justify-between gap-4 px-4 py-3 text-neutral-700 no-underline transition dark:text-neutral-200"
+            href="{{ $link.url | safeURL }}"
             target="_blank"
             rel="noopener noreferrer external"
-            aria-label="{{ $label }} (opens in a new tab)">
-            <span class="flex h-5 w-5 shrink-0 items-center justify-center" aria-hidden="true">
-              {{ partial "icon.html" $icon }}
+            aria-label="{{ $link.label }} (opens in a new tab)">
+            <span class="flex min-w-0 items-center gap-3">
+              <span class="artist-external-link-icon flex h-5 w-5 shrink-0 items-center justify-center text-neutral-500 transition dark:text-neutral-400" aria-hidden="true">
+                {{ partial "icon.html" $link.icon }}
+              </span>
+              <span class="truncate font-semibold">{{ $link.label }}</span>
             </span>
-            <span class="font-medium">{{ $label }}</span>
-            <span class="text-sm text-neutral-500 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 dark:text-neutral-400" aria-hidden="true">↗</span>
+            <span class="shrink-0 text-sm text-neutral-500 dark:text-neutral-400" aria-hidden="true">&#8599;</span>
           </a>
         </li>
       {{ end }}


### PR DESCRIPTION
## Summary
- rename the artist links section to Explore Further
- render artist destinations as a single card with full-row clickable list items
- preserve existing artist markdown structure while enforcing platform ordering and accessible focus styling

## Verification
- Ran `git diff --check`
- Checked existing artist shortcode extraction against a real artist file
- Could not run `hugo --minify`: `hugo` is not installed/on PATH in this shell