### PR TITLE
fix(src): remove artist page pagination

### DIFF
--- a/src/layouts/artists/single.html
+++ b/src/layouts/artists/single.html
@@ -39,10 +39,9 @@
     {{/* Artist destinations follow internal discovery content. */}}
     {{ partial "artist-external-links.html" . }}
 
-    {{/* Footer */}}
-    <footer class="pt-8 max-w-prose print:hidden">
-      {{ partial "article-pagination.html" . }}
-      {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
+    {{/* Comments */}}
+    {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
+      <footer class="pt-8 max-w-prose print:hidden">
         {{ if templates.Exists "partials/comments.html" }}
           <div class="pt-3">
             <hr class="border-dotted border-neutral-300 dark:border-neutral-600" />
@@ -53,8 +52,8 @@
         {{ else }}
           {{ warnf "[BLOWFISH] Comments are enabled for %s but no comments partial exists." .File.Path }}
         {{ end }}
-      {{ end }}
-    </footer>
+      </footer>
+    {{ end }}
 
     <script>
       (() => {


### PR DESCRIPTION
## Summary
- remove previous/next pagination from artist pages
- avoid rendering an empty artist footer when comments are disabled
- preserve default Blowfish single-page pagination for other content types

## Verification
- rg finds article-pagination only in the Blowfish default single template
- git diff --check passed, with only the existing Windows CRLF warning
- Hugo build not run locally because hugo is not installed on this PATH