### PR TITLE
Improve footer navigation links

### DIFF
--- a/src/config/_default/menus.toml
+++ b/src/config/_default/menus.toml
@@ -1,20 +1,34 @@
 [[footer]]
-  identifier = "facebook"
-  pre = "facebook"
-  title = "Sundown Sessions on Facebook"
-  url = "https://www.facebook.com/sundownsessionsuk"
+  identifier = "listen-again"
+  name = "Listen Again"
+  title = "Browse Sundown Sessions shows"
+  url = "/shows/"
   weight = 10
 
 [[footer]]
-  identifier = "instagram"
-  pre = "instagram"
-  title = "Sundown Sessions on Instagram"
-  url = "https://www.instagram.com/sundownsessionsshow"
+  identifier = "mixcloud"
+  name = "Mixcloud"
+  title = "Sundown Sessions on Mixcloud"
+  url = "https://www.mixcloud.com/sundownsessions/"
   weight = 20
 
 [[footer]]
-  identifier = "mixcloud"
-  pre = "mixcloud"
-  title = "Sundown Sessions on Mixcloud"
-  url = "https://www.mixcloud.com/sundownsessions/"
+  identifier = "instagram"
+  name = "Instagram"
+  title = "Sundown Sessions on Instagram"
+  url = "https://www.instagram.com/sundownsessionsshow"
   weight = 30
+
+[[footer]]
+  identifier = "facebook"
+  name = "Facebook"
+  title = "Sundown Sessions on Facebook"
+  url = "https://www.facebook.com/sundownsessionsuk"
+  weight = 40
+
+[[footer]]
+  identifier = "contact"
+  name = "Contact"
+  title = "Contact Sundown Sessions"
+  url = "/contact/"
+  weight = 50

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -1,0 +1,82 @@
+<footer id="site-footer" class="py-10 print:hidden">
+  {{/* Footer menu */}}
+  {{ if .Site.Params.footer.showMenu | default true }}
+    {{ $listenURL := .Site.Params.listen_live_stream_url | default "" }}
+    {{ $hasListenURL := and (ne $listenURL "") (ne $listenURL "#") }}
+    {{ if or $hasListenURL .Site.Menus.footer }}
+      <nav class="pb-4 text-base font-medium text-neutral-500 dark:text-neutral-400" aria-label="Footer">
+        <ul class="flex list-none flex-wrap justify-center gap-x-5 gap-y-2 p-0 sm:justify-start">
+          {{ if $hasListenURL }}
+            <li class="flex">
+              <a
+                class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2"
+                href="{{ $listenURL }}"
+                {{ if or (strings.HasPrefix $listenURL "http:") (strings.HasPrefix $listenURL "https:") }}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                {{ end }}
+                title="Listen to Sundown Sessions live">
+                Listen Live
+              </a>
+            </li>
+          {{ end }}
+          {{ range .Site.Menus.footer }}
+            {{ $isExternal := or (strings.HasPrefix .URL "http:") (strings.HasPrefix .URL "https:") }}
+            <li class="flex">
+              <a
+                class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2"
+                href="{{ .URL }}"
+                {{ if $isExternal }}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                {{ end }}
+                title="{{ .Title }}">
+                {{ .Name | markdownify }}
+              </a>
+            </li>
+          {{ end }}
+        </ul>
+      </nav>
+    {{ end }}
+  {{ end }}
+  <div class="flex flex-col items-center justify-between gap-2 text-center sm:flex-row sm:text-left">
+    {{/* Copyright */}}
+    {{ if .Site.Params.footer.showCopyright | default true }}
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">
+        {{- with replace .Site.Params.copyright "{ year }" now.Year }}
+          {{ . | markdownify }}
+        {{- else }}
+          &copy;
+          {{ now.Format "2006" }}
+          {{ .Site.Params.Author.name | markdownify }}
+        {{- end }}
+      </p>
+    {{ end }}
+
+    {{/* Theme attribution */}}
+    {{ if .Site.Params.footer.showThemeAttribution | default true }}
+      <p class="text-xs text-neutral-500 dark:text-neutral-400">
+        {{ $hugo := printf `<a class="hover:underline hover:decoration-primary-400 hover:text-primary-500"
+          href="https://gohugo.io/" target="_blank" rel="noopener noreferrer">Hugo</a>`
+        }}
+        {{ $blowfish := printf `<a class="hover:underline hover:decoration-primary-400 hover:text-primary-500"
+          href="https://blowfish.page/" target="_blank" rel="noopener noreferrer">Blowfish</a>`
+        }}
+        {{ i18n "footer.powered_by" (dict "Hugo" $hugo "Theme" $blowfish) | safeHTML }}
+      </p>
+    {{ end }}
+  </div>
+  {{ if not .Site.Params.disableImageZoom | default true }}
+    <script>
+      mediumZoom(document.querySelectorAll("img:not(.nozoom)"), {
+        margin: 24,
+        background: "rgba(0,0,0,0.5)",
+        scrollOffset: 0,
+      });
+    </script>
+  {{ end }}
+  {{/* Extend footer - eg. for extra scripts, etc. */}}
+  {{ if templates.Exists "partials/extend-footer.html" }}
+    {{ partialCached "extend-footer.html" . }}
+  {{ end }}
+</footer>


### PR DESCRIPTION
## Summary
- replaces the icon-only footer presentation with labelled text links
- adds a local Blowfish footer override that keeps the vendored theme untouched
- conditionally shows Listen Live only when a real stream URL is configured

Closes #533

## Testing
- `git diff --check`
- source check confirmed footer icon metadata was removed and the override does not render icon partials
- not run: `hugo --environment production` because `hugo` is not available in this shell