### PR TITLE
feat: add release page hero

### DIFF
--- a/src/layouts/partials/release/hero.html
+++ b/src/layouts/partials/release/hero.html
@@ -1,0 +1,123 @@
+{{/* Release hero card for individual release pages. */}}
+
+{{ $artworkParam := "" }}
+{{ with .Params.artwork }}
+  {{ $artworkParam = . }}
+{{ else }}
+  {{ with .Params.cover }}
+    {{ $artworkParam = . }}
+  {{ else }}
+    {{ with .Params.image }}
+      {{ $artworkParam = . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $artwork := "" }}
+{{ $artworkURL := "" }}
+{{ with $artworkParam }}
+  {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+    {{ $artworkURL = . }}
+  {{ else }}
+    {{ $artwork = $.Resources.GetMatch . }}
+    {{ if not $artwork }}{{ $artwork = $.Resources.GetMatch (path.Base .) }}{{ end }}
+    {{ if not $artwork }}{{ $artwork = resources.Get . }}{{ end }}
+    {{ if not $artwork }}{{ $artworkURL = . | relURL }}{{ end }}
+  {{ end }}
+{{ end }}
+
+{{ if not (or $artwork $artworkURL) }}
+  {{ $images := .Resources.ByType "image" }}
+  {{ range slice "*artwork*" "*cover*" "*image*" "*feature*" "*thumbnail*" }}
+    {{ if not $artwork }}{{ $artwork = $images.GetMatch . }}{{ end }}
+  {{ end }}
+{{ end }}
+
+{{ if not $artworkURL }}
+  {{ with $artwork }}
+    {{ $artworkURL = .RelPermalink }}
+  {{ end }}
+{{ end }}
+
+{{ $artist := "" }}
+{{ with .Params.artist }}
+  {{ $artist = . }}
+{{ else }}
+  {{ with .Params.artists }}
+    {{ if reflect.IsSlice . }}
+      {{ $artist = delimit . ", " }}
+    {{ else }}
+      {{ $artist = . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $releaseDate := .Params.releaseDate | default .Params.release_date }}
+{{ $releaseType := .Params.releaseType | default .Params.release_type }}
+{{ $trackCount := 0 }}
+{{ with .Params.trackCount }}
+  {{ $trackCount = . }}
+{{ else }}
+  {{ with .Params.tracks }}
+    {{ $trackCount = len . }}
+  {{ end }}
+{{ end }}
+
+<section
+  class="mb-10 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70"
+  role="region"
+  aria-labelledby="release-hero-heading">
+  <div class="flex flex-col sm:flex-row">
+    {{ with $artworkURL }}
+      <div class="flex items-center justify-center bg-neutral-100 p-4 dark:bg-neutral-800 sm:w-64 sm:shrink-0">
+        <img
+          src="{{ . }}"
+          alt="{{ $.Title }} artwork"
+          loading="eager"
+          decoding="async"
+          fetchpriority="high"
+          class="nozoom h-auto max-h-96 w-full object-contain">
+      </div>
+    {{ end }}
+
+    <div class="flex flex-1 flex-col justify-center gap-5 p-6 sm:p-8">
+      <div>
+        <h1
+          id="release-hero-heading"
+          class="mt-0 text-3xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral sm:text-4xl lg:text-5xl">
+          {{ .Title | emojify }}
+        </h1>
+        {{ with $artist }}
+          <p class="mt-2 text-lg font-medium text-neutral-700 dark:text-neutral-300">
+            {{ . }}
+          </p>
+        {{ end }}
+      </div>
+
+      {{ if or $releaseDate $releaseType (gt $trackCount 0) }}
+        <dl class="grid gap-4 sm:grid-cols-2">
+          {{ with $releaseDate }}
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Release date</dt>
+              <dd class="mt-1 text-base font-semibold text-neutral-900 dark:text-neutral-200">{{ . }}</dd>
+            </div>
+          {{ end }}
+          {{ with $releaseType }}
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Type</dt>
+              <dd class="mt-1 text-base font-semibold text-neutral-900 dark:text-neutral-200">{{ . }}</dd>
+            </div>
+          {{ end }}
+          {{ if gt $trackCount 0 }}
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Tracks</dt>
+              <dd class="mt-1 text-base font-semibold text-neutral-900 dark:text-neutral-200">
+                {{ $trackCount }} {{ if eq $trackCount 1 }}track{{ else }}tracks{{ end }}
+              </dd>
+            </div>
+          {{ end }}
+        </dl>
+      {{ end }}
+    </div>
+  </div>
+</section>

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -1,0 +1,118 @@
+{{ define "main" }}
+  {{ .Scratch.Set "scope" "single" }}
+  <article>
+    {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
+      <div class="mb-5 max-w-prose">
+        {{ partial "breadcrumbs.html" . }}
+      </div>
+    {{ end }}
+
+    {{ partial "release/hero.html" . }}
+
+    {{/* Body */}}
+    <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
+      {{ $enableToc := site.Params.article.showTableOfContents | default false }}
+      {{ $enableToc = .Params.showTableOfContents | default $enableToc }}
+      {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+      {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+      {{ if $showToc }}
+        <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
+          <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+            {{ partial "toc.html" . }}
+          </div>
+        </div>
+      {{ end }}
+
+      <div class="min-w-0 min-h-0 max-w-fit">
+        {{ partial "series/series.html" . }}
+        <div class="article-content max-w-prose mb-20">
+          {{ .Content }}
+          {{ $defaultReplyByEmail := site.Params.replyByEmail }}
+          {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
+          {{ if $replyByEmail }}
+            <strong class="block mt-8">
+              <a
+                class="email-link m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
+                href="#"
+                data-email="{{ site.Params.Author.email | base64Encode }}"
+                data-subject="{{ replace (printf "Reply to %s" .Title) "\"" "'" }}">
+                {{ i18n "article.reply_by_email" | default "Reply by Email" }}
+              </a>
+              <noscript>
+                <span
+                  class="m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-300">
+                  {{ i18n "article.reply_by_email" | default "Reply by Email" }} (require JavaScript)
+                </span>
+              </noscript>
+            </strong>
+          {{ end }}
+        </div>
+        {{ if (.Params.showAuthorBottom | default (site.Params.article.showAuthorBottom | default false)) }}
+          {{ template "SingleAuthor" . }}
+        {{ end }}
+        {{ partial "series/series-closed.html" . }}
+        {{ partial "sharing-links.html" . }}
+        {{ partial "related.html" . }}
+      </div>
+    </section>
+
+    {{/* Footer */}}
+    <footer class="pt-8 max-w-prose print:hidden">
+      {{ partial "article-pagination.html" . }}
+      {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
+        {{ if templates.Exists "partials/comments.html" }}
+          <div class="pt-3">
+            <hr class="border-dotted border-neutral-300 dark:border-neutral-600" />
+            <div class="pt-3">
+              {{ partial "comments.html" . }}
+            </div>
+          </div>
+        {{ else }}
+          {{ warnf "[BLOWFISH] Comments are enabled for %s but no comments partial exists." .File.Path }}
+        {{ end }}
+      {{ end }}
+    </footer>
+  </article>
+{{ end }}
+
+{{ define "SingleAuthor" }}
+  {{ $authorsData := site.Data.authors }}
+  {{ $taxonomies := site.Taxonomies.authors }}
+  {{ $baseURL := site.BaseURL }}
+  {{ $taxonomyLink := 0 }}
+  {{ $showAuthor := 0 }}
+  {{ $isAuthorBottom := (.Params.showAuthorBottom | default ( site.Params.article.showAuthorBottom | default false)) }}
+
+  {{ if not (strings.HasSuffix $baseURL "/") }}
+    {{ $baseURL = delimit (slice $baseURL "/") "" }}
+  {{ end }}
+
+  {{ if .Params.showAuthor | default (site.Params.article.showAuthor | default true) }}
+    {{ $showAuthor = 1 }}
+    {{ partial "author.html" . }}
+  {{ end }}
+
+  {{ range $author := .Page.Params.authors }}
+    {{ $authorData := index $authorsData $author }}
+    {{- if $authorData -}}
+      {{ range $taxonomyname, $taxonomy := $taxonomies }}
+        {{ if (eq $taxonomyname $author) }}
+          {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
+        {{ end }}
+      {{ end }}
+
+      {{ $finalLink := $taxonomyLink }}
+      {{ $currentLang := site.Language.Lang }}
+      {{ if eq site.LanguagePrefix "" }}
+        {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
+      {{ else }}
+        {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
+      {{ end }}
+      {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
+    {{- end -}}
+  {{ end }}
+
+  {{ if or $taxonomyLink $showAuthor }}
+    <div class="{{ cond $isAuthorBottom "mb-10" "mb-5" }}"></div>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
## Summary
- add a releases-only single template that renders a hero before the release body
- add a reusable release hero partial with artwork, artist, date, type, and track-count support
- preserve existing Blowfish article body/footer behavior below the hero

## Verification
- Built with Hugo 0.146.5 using:
  `hugo --source src --printPathWarnings --panicOnWarning --environment production --baseURL https://example.invalid/`
- Checked rendered release pages for Drums And Wires and Villains.