### PR TITLE
Refine release about headings

### DIFF
--- a/src/layouts/partials/release/about-heading.html
+++ b/src/layouts/partials/release/about-heading.html
@@ -1,0 +1,15 @@
+{{- $releaseType := .Params.releaseType | default .Params.release_type | default .Params.type | default "" -}}
+{{- $normalisedType := printf "%v" $releaseType | lower | strings.TrimSpace -}}
+{{- $normalisedType = replaceRE `[-_]` " " $normalisedType -}}
+{{- $normalisedType = replaceRE `\s+` " " $normalisedType -}}
+{{- $normalisedType = replaceRE `\breleases?\b` "" $normalisedType | strings.TrimSpace -}}
+
+{{- if in (slice "album" "albums" "lp" "lps" "studio album" "studio albums") $normalisedType -}}
+  About the Album
+{{- else if in (slice "ep" "eps" "e.p." "e.p.s") $normalisedType -}}
+  About the EP
+{{- else if in (slice "single" "singles") $normalisedType -}}
+  About the Single
+{{- else -}}
+  About the Release
+{{- end -}}

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -26,7 +26,32 @@
       <div class="min-w-0 min-h-0 max-w-fit">
         {{ partial "series/series.html" . }}
         <div class="article-content max-w-prose mb-20">
-          {{ .Content }}
+          {{ $releaseAboutHeading := partial "release/about-heading.html" . | strings.TrimSpace }}
+          {{ $releaseAboutAnchor := anchorize $releaseAboutHeading }}
+          {{ $releaseContent := .Content | strings.TrimSpace }}
+          {{ $aboutHeadings := slice "About" "About the Release" "About the Album" "About the EP" "About the Single" }}
+          {{ $startsWithAboutHeading := false }}
+          {{ if hasPrefix $releaseContent "<h2" }}
+            {{ $firstContentHeading := index (split $releaseContent `</h2>`) 0 | plainify | strings.TrimSpace | replaceRE `\s*#\s*$` "" }}
+            {{ $startsWithAboutHeading = in $aboutHeadings $firstContentHeading }}
+          {{ end }}
+          {{ if $startsWithAboutHeading }}
+            {{ $releaseContent = delimit (after 1 (split $releaseContent `</h2>`)) `</h2>` | strings.TrimSpace }}
+          {{ end }}
+
+          <h2 class="relative group">{{ $releaseAboutHeading | emojify }}
+            <div id="{{ $releaseAboutAnchor }}" class="anchor"></div>
+            {{ if .Params.showHeadingAnchors | default (.Site.Params.article.showHeadingAnchors | default true) }}
+              <span
+                class="absolute top-0 w-6 transition-opacity opacity-0 -start-6 not-prose group-hover:opacity-100 select-none">
+                <a
+                  class="text-primary-300 dark:text-neutral-700 !no-underline"
+                  href="#{{ $releaseAboutAnchor }}"
+                  aria-label="{{ i18n "article.anchor_label" }}">#</a>
+              </span>
+            {{ end }}
+          </h2>
+          {{ $releaseContent | safeHTML }}
           {{ $defaultReplyByEmail := site.Params.replyByEmail }}
           {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
           {{ if $replyByEmail }}


### PR DESCRIPTION
## Summary
- add a release about-heading partial that selects Album, EP, Single, or Release wording from release type metadata
- render the heading in the Release single template above body content
- avoid duplicate About headings when release Markdown already starts with an equivalent heading

## Validation
- `hugo --environment production` using portable Hugo v0.141.0
- confirmed generated Release pages no longer render a generic body `About` heading
- confirmed Artist, Show, and Track output is unaffected