### PR TITLE
feat(src): add release tracklist card

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -253,3 +253,113 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 .dark .artist-external-link-row:hover .artist-external-link-icon {
   color: rgba(var(--color-primary-400), 1);
 }
+
+/* Release tracklist: scoped card/list-group treatment for structured release
+   front matter without changing show playlists or artist pages. */
+
+.release-tracklist {
+  margin: 2rem 0 2.5rem;
+  overflow: hidden;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.75rem;
+  background-color: rgba(250, 250, 250, 0.72); /* neutral-50/72 */
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+}
+
+.dark .release-tracklist {
+  border-color: #404040; /* neutral-700 */
+  background-color: rgba(23, 23, 23, 0.66); /* neutral-900/66 */
+}
+
+.release-tracklist__heading {
+  margin: 0;
+  padding: 1.25rem 1.25rem 0.95rem;
+  color: #262626; /* neutral-800 */
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.dark .release-tracklist__heading {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.release-tracklist__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.release-tracklist__row {
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: baseline;
+  border-top: 1px solid #e5e5e5; /* neutral-200 */
+  padding: 0.85rem 1.25rem;
+}
+
+.dark .release-tracklist__row {
+  border-top-color: #404040; /* neutral-700 */
+}
+
+.release-tracklist__number {
+  color: #737373; /* neutral-500 */
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1.5;
+}
+
+.dark .release-tracklist__number {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.release-tracklist__title {
+  min-width: 0;
+  color: #171717; /* neutral-900 */
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.5;
+}
+
+.dark .release-tracklist__title {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.release-tracklist__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.release-tracklist__title a:hover {
+  color: rgba(var(--color-primary-600), 1);
+  text-decoration: underline;
+}
+
+.dark .release-tracklist__title a:hover {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.release-tracklist__duration {
+  grid-column: 2;
+  color: #737373; /* neutral-500 */
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.dark .release-tracklist__duration {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+@media (min-width: 640px) {
+  .release-tracklist__row {
+    grid-template-columns: 2.5rem minmax(0, 1fr) auto;
+  }
+
+  .release-tracklist__duration {
+    grid-column: auto;
+    justify-self: end;
+  }
+}

--- a/src/layouts/partials/release/tracklist.html
+++ b/src/layouts/partials/release/tracklist.html
@@ -1,0 +1,46 @@
+{{- $tracks := .Params.tracks -}}
+{{- if and $tracks (reflect.IsSlice $tracks) (gt (len $tracks) 0) -}}
+  <section class="release-tracklist not-prose" role="region" aria-labelledby="tracklist">
+    <h2 id="tracklist" class="release-tracklist__heading">Tracklist</h2>
+    <ol class="release-tracklist__list">
+      {{- range $index, $track := $tracks -}}
+        {{- $title := "" -}}
+        {{- $duration := "" -}}
+        {{- $number := add $index 1 -}}
+        {{- $link := "" -}}
+
+        {{- if reflect.IsMap $track -}}
+          {{- $title = index $track "title" | default (index $track "name") | default "" -}}
+          {{- $duration = index $track "duration" | default (index $track "length") | default "" -}}
+          {{- $number = index $track "trackNumber" | default (index $track "tracknumber") | default (index $track "track_number") | default (index $track "number") | default $number -}}
+          {{- $link = index $track "url" | default (index $track "page") | default (index $track "slug") | default "" -}}
+        {{- else -}}
+          {{- $title = $track -}}
+        {{- end -}}
+
+        {{- $title = printf "%v" $title | strings.TrimSpace -}}
+        {{- $duration = printf "%v" $duration | strings.TrimSpace -}}
+        {{- $link = printf "%v" $link | strings.TrimSpace -}}
+        {{- if and $link (not (or (strings.HasPrefix $link "http://") (strings.HasPrefix $link "https://") (strings.HasPrefix $link "/"))) -}}
+          {{- $link = printf "/%s" $link -}}
+        {{- end -}}
+
+        {{- if $title -}}
+          <li class="release-tracklist__row">
+            <span class="release-tracklist__number">{{ printf "%02d" (int $number) }}</span>
+            <span class="release-tracklist__title">
+              {{- if $link -}}
+                <a href="{{ $link | relURL }}">{{ $title }}</a>
+              {{- else -}}
+                {{ $title }}
+              {{- end -}}
+            </span>
+            {{- with $duration -}}
+              <span class="release-tracklist__duration">{{ . }}</span>
+            {{- end -}}
+          </li>
+        {{- end -}}
+      {{- end -}}
+    </ol>
+  </section>
+{{- end -}}

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -39,6 +39,17 @@
           {{ if $startsWithAboutHeading }}
             {{ $releaseContent = delimit (after 1 (split $releaseContent `</h2>`)) `</h2>` | strings.TrimSpace }}
           {{ end }}
+          {{ $hasStructuredTracks := and .Params.tracks (reflect.IsSlice .Params.tracks) (gt (len .Params.tracks) 0) }}
+          {{ if $hasStructuredTracks }}
+            {{ $releaseContent = replaceRE `(?is)<h2\b[^>]*>\s*Tracklist.*?</h2>\s*.*?(?=<h2\b|$)` "" $releaseContent | strings.TrimSpace }}
+          {{ end }}
+          {{ $releaseAboutContent := $releaseContent }}
+          {{ $releaseAfterAboutContent := "" }}
+          {{ if and $hasStructuredTracks (in $releaseContent "<h2") }}
+            {{ $releaseContentParts := split $releaseContent "<h2" }}
+            {{ $releaseAboutContent = index $releaseContentParts 0 | strings.TrimSpace }}
+            {{ $releaseAfterAboutContent = printf "<h2%s" (delimit (after 1 $releaseContentParts) "<h2") | strings.TrimSpace }}
+          {{ end }}
 
           <h2 class="relative group">{{ $releaseAboutHeading | emojify }}
             <div id="{{ $releaseAboutAnchor }}" class="anchor"></div>
@@ -52,7 +63,13 @@
               </span>
             {{ end }}
           </h2>
-          {{ $releaseContent | safeHTML }}
+          {{ $releaseAboutContent | safeHTML }}
+          {{ if $hasStructuredTracks }}
+            {{ partial "release/tracklist.html" . }}
+          {{ end }}
+          {{ with $releaseAfterAboutContent }}
+            {{ . | safeHTML }}
+          {{ end }}
           {{ $defaultReplyByEmail := site.Params.replyByEmail }}
           {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
           {{ if $replyByEmail }}


### PR DESCRIPTION
## Summary
- add a release-only structured Tracklist partial for string and map front matter tracks
- render the card after About content while avoiding duplicate Markdown Tracklist sections when structured tracks exist
- add scoped Blowfish-style card/list styling for release track rows, numbers, links, and durations

## Verification
- `C:\Users\COLING~1\AppData\Local\Temp\hugo-0.146.5\bin\hugo.exe --source src --printPathWarnings --panicOnWarning --environment production --baseURL https://example.invalid/`