### PR TITLE
Add artwork accent to release hero

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -254,6 +254,33 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: rgba(var(--color-primary-400), 1);
 }
 
+/* Release hero: optional artwork-derived accent for individual release pages.
+   The CSS variable is only emitted when front matter provides a colour. */
+
+.release-hero {
+  position: relative;
+}
+
+.release-hero--accent {
+  border-top-color: var(--release-accent);
+  border-top-width: 3px;
+  background-image:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--release-accent) 8%, transparent),
+      transparent 34%
+    );
+}
+
+.dark .release-hero--accent {
+  background-image:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--release-accent) 6%, transparent),
+      transparent 36%
+    );
+}
+
 /* Release tracklist: scoped card/list-group treatment for structured release
    front matter without changing show playlists or artist pages. */
 

--- a/src/layouts/partials/release/hero.html
+++ b/src/layouts/partials/release/hero.html
@@ -54,6 +54,22 @@
 
 {{ $releaseDate := .Params.releaseDate | default .Params.release_date }}
 {{ $releaseType := .Params.releaseType | default .Params.release_type }}
+{{ $accentColor := "" }}
+{{ with .Params.artworkAccent }}
+  {{ $accentColor = . }}
+{{ else }}
+  {{ with .Params.artwork_accent }}
+    {{ $accentColor = . }}
+  {{ else }}
+    {{ with .Params.accentColor }}
+      {{ $accentColor = . }}
+    {{ else }}
+      {{ with .Params.accent_color }}
+        {{ $accentColor = . }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
 {{ $trackCount := 0 }}
 {{ with .Params.trackCount }}
   {{ $trackCount = . }}
@@ -64,7 +80,8 @@
 {{ end }}
 
 <section
-  class="mb-10 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70"
+  class="release-hero{{ with $accentColor }} release-hero--accent{{ end }} mb-10 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70"
+  {{ with $accentColor }}style="--release-accent: {{ . | safeCSS }};"{{ end }}
   role="region"
   aria-labelledby="release-hero-heading">
   <div class="flex flex-col sm:flex-row">


### PR DESCRIPTION
## Summary
- resolve optional release artwork accent colours from front matter in the requested priority order
- add a scoped release hero CSS treatment using a subtle top border and faint tint
- preserve neutral Blowfish card styling when no accent colour is provided

## Testing
- Not run: Hugo is not installed/on PATH in this shell