### PR TITLE
Add featured shows to release pages

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -380,6 +380,112 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: #a3a3a3; /* neutral-400 */
 }
 
+/* Release featured shows: compact list-group treatment placed between the
+   structured tracklist and onward discovery links. */
+
+.release-featured-shows {
+  margin: 2rem 0 2.5rem;
+  overflow: hidden;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.75rem;
+  background-color: rgba(250, 250, 250, 0.72); /* neutral-50/72 */
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+}
+
+.dark .release-featured-shows {
+  border-color: #404040; /* neutral-700 */
+  background-color: rgba(23, 23, 23, 0.66); /* neutral-900/66 */
+}
+
+.release-featured-shows__heading {
+  margin: 0;
+  padding: 1.25rem 1.25rem 0.95rem;
+  color: #262626; /* neutral-800 */
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.dark .release-featured-shows__heading {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.release-featured-shows__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.release-featured-shows__row {
+  border-top: 1px solid #e5e5e5; /* neutral-200 */
+}
+
+.dark .release-featured-shows__row {
+  border-top-color: #404040; /* neutral-700 */
+}
+
+.release-featured-shows__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.9rem 1.25rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.release-featured-shows__link:hover,
+.release-featured-shows__link:focus-visible {
+  background-color: rgba(var(--color-neutral-100), 1);
+  color: rgba(var(--color-primary-600), 1);
+  text-decoration: none;
+}
+
+.dark .release-featured-shows__link:hover,
+.dark .release-featured-shows__link:focus-visible {
+  background-color: rgba(var(--color-neutral-800), 1);
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.release-featured-shows__link:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-600), 1);
+  outline-offset: -2px;
+}
+
+.release-featured-shows__title {
+  min-width: 0;
+  color: #171717; /* neutral-900 */
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.release-featured-shows__link:hover .release-featured-shows__title,
+.release-featured-shows__link:focus-visible .release-featured-shows__title {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.dark .release-featured-shows__title {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.release-featured-shows__date,
+.release-featured-shows__note {
+  color: #737373; /* neutral-500 */
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.dark .release-featured-shows__date,
+.dark .release-featured-shows__note {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.release-featured-shows__note {
+  margin: -0.35rem 1.25rem 0.9rem;
+}
+
 @media (min-width: 640px) {
   .release-tracklist__row {
     grid-template-columns: 2.5rem minmax(0, 1fr) auto;
@@ -388,5 +494,16 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   .release-tracklist__duration {
     grid-column: auto;
     justify-self: end;
+  }
+
+  .release-featured-shows__link {
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .release-featured-shows__date {
+    flex: none;
   }
 }

--- a/src/layouts/partials/release/featured-shows.html
+++ b/src/layouts/partials/release/featured-shows.html
@@ -1,0 +1,211 @@
+{{/* Featured in Shows for release pages.
+     Prefers explicit release front matter, then falls back to scanning show
+     markdown and included track-info files for release shortcode references. */}}
+
+{{- $configuredShows := .Params.featuredInShows | default .Params.featured_in_shows | default .Params.shows -}}
+{{- $featuredShows := slice -}}
+{{- $seenShows := dict -}}
+{{- $showsSection := site.GetPage "shows" -}}
+{{- $showPages := where site.RegularPages "Section" "shows" -}}
+
+{{- with $configuredShows -}}
+  {{- $entries := . -}}
+  {{- if not (reflect.IsSlice $entries) -}}
+    {{- $entries = slice $entries -}}
+  {{- end -}}
+
+  {{- range $entry := $entries -}}
+    {{- $showRef := "" -}}
+    {{- $customTitle := "" -}}
+    {{- $customDate := "" -}}
+    {{- $note := "" -}}
+
+    {{- if reflect.IsMap $entry -}}
+      {{- $showRef = index $entry "show" | default (index $entry "page") | default (index $entry "path") | default (index $entry "slug") | default (index $entry "url") | default "" -}}
+      {{- $customTitle = index $entry "title" | default "" -}}
+      {{- $customDate = index $entry "date" | default "" -}}
+      {{- $note = index $entry "note" | default "" -}}
+    {{- else -}}
+      {{- $showRef = $entry -}}
+    {{- end -}}
+
+    {{- $showRef = printf "%v" $showRef | strings.TrimSpace -}}
+    {{- $showPage := "" -}}
+    {{- $fileLink := "" -}}
+    {{- $fileTitle := "" -}}
+    {{- $fileDate := "" -}}
+    {{- if $showRef -}}
+      {{- $trimmedRef := strings.TrimSuffix "/" (strings.TrimPrefix "/" $showRef) -}}
+      {{- $candidatePaths := slice $trimmedRef (printf "shows/%s" $trimmedRef) (printf "shows/%s/index.md" $trimmedRef) (printf "/shows/%s" $trimmedRef) (printf "/shows/%s/index.md" $trimmedRef) -}}
+      {{- if strings.HasPrefix $trimmedRef "shows/" -}}
+        {{- $candidatePaths = slice $trimmedRef -}}
+      {{- end -}}
+
+      {{- range $candidatePath := $candidatePaths -}}
+        {{- if not $showPage -}}
+          {{- $showPage = site.GetPage $candidatePath -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- if and (not $showPage) $showPages -}}
+        {{- $normalizedRef := lower $trimmedRef -}}
+        {{- range $showPages -}}
+          {{- $contentPath := "" -}}
+          {{- with .File -}}{{- $contentPath = strings.TrimSuffix "/" (replace .Path "\\" "/") -}}{{- end -}}
+          {{- $contentBundlePath := strings.TrimSuffix "/index.md" $contentPath -}}
+          {{- $contentBaseName := "" -}}
+          {{- with .File -}}{{- $contentBaseName = .ContentBaseName -}}{{- end -}}
+          {{- $contentDirName := "" -}}
+          {{- with .File -}}{{- $contentDirName = path.Base (strings.TrimSuffix "/" .Dir) -}}{{- end -}}
+          {{- if or
+            (eq (lower (strings.TrimSuffix "/" (strings.TrimPrefix "/" .RelPermalink))) $normalizedRef)
+            (eq (lower .Slug) $normalizedRef)
+            (eq (lower .Title) $normalizedRef)
+            (eq (lower $contentPath) $normalizedRef)
+            (eq (lower $contentBundlePath) $normalizedRef)
+            (eq (lower (path.Base $contentBundlePath)) $normalizedRef)
+            (eq (lower (printf "shows/%s" $contentBaseName)) $normalizedRef)
+            (eq (lower $contentDirName) $normalizedRef)
+            (eq (lower (printf "shows/%s" $contentDirName)) $normalizedRef)
+          -}}
+            {{- $showPage = . -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- if not $showPage -}}
+        {{- $bundleRef := strings.TrimPrefix "shows/" $trimmedRef -}}
+        {{- $bundleRef = strings.TrimSuffix "/index.md" $bundleRef -}}
+        {{- $showIndexPath := printf "content/shows/%s/index.md" $bundleRef -}}
+        {{- if fileExists $showIndexPath -}}
+          {{- $showMarkdown := readFile $showIndexPath -}}
+          {{- $frontMatterTitle := replaceRE `(?s).*?title:\s*['"]?([^'"\r\n]+).*` "$1" $showMarkdown -}}
+          {{- $frontMatterSlug := replaceRE `(?s).*?slug:\s*['"]?([^'"\r\n]+).*` "$1" $showMarkdown -}}
+          {{- $frontMatterDate := replaceRE `(?s).*?date:\s*['"]?([^'"\r\n]+).*` "$1" $showMarkdown -}}
+          {{- if ne $frontMatterTitle $showMarkdown -}}
+            {{- $fileTitle = $frontMatterTitle -}}
+          {{- end -}}
+          {{- if ne $frontMatterSlug $showMarkdown -}}
+            {{- $fileLink = printf "/shows/%s/" $frontMatterSlug -}}
+          {{- else -}}
+            {{- $fileLink = printf "/shows/%s/" $bundleRef -}}
+          {{- end -}}
+          {{- if ne $frontMatterDate $showMarkdown -}}
+            {{- $fileDate = $frontMatterDate -}}
+          {{- end -}}
+          {{- if strings.HasPrefix $fileTitle "Show #" -}}
+            {{- $fileTitle = replace $fileTitle "Show #" "Sundown Sessions #" -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+
+    {{- $link := "" -}}
+    {{- $title := printf "%v" $customTitle | strings.TrimSpace -}}
+    {{- $date := $customDate -}}
+    {{- $sortDate := printf "%v" $customDate -}}
+    {{- if $showPage -}}
+      {{- $link = $showPage.RelPermalink -}}
+      {{- if not $title -}}{{- $title = partial "release/show-card-title.html" $showPage -}}{{- end -}}
+      {{- if not $date -}}{{- $date = $showPage.Date -}}{{- end -}}
+      {{- $sortDate = time.Format "2006-01-02T15:04:05Z07:00" $showPage.Date -}}
+    {{- else if $fileLink -}}
+      {{- $link = $fileLink -}}
+      {{- if not $title -}}{{- $title = $fileTitle -}}{{- end -}}
+      {{- if not $date -}}{{- $date = $fileDate -}}{{- end -}}
+      {{- $sortDate = $fileDate -}}
+    {{- else if $showRef -}}
+      {{- $link = $showRef -}}
+      {{- if not (or (strings.HasPrefix $link "http://") (strings.HasPrefix $link "https://") (strings.HasPrefix $link "/")) -}}
+        {{- $link = printf "/%s" $link -}}
+      {{- end -}}
+      {{- if not $title -}}{{- $title = $showRef -}}{{- end -}}
+    {{- end -}}
+
+    {{- if and $link $title -}}
+      {{- $dedupeKey := $link -}}
+      {{- if not (index $seenShows $dedupeKey) -}}
+        {{- $featuredShows = $featuredShows | append (dict "page" $showPage "link" $link "title" $title "date" $date "sortDate" $sortDate "note" $note) -}}
+        {{- $seenShows = merge $seenShows (dict $dedupeKey true) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if and (eq (len $featuredShows) 0) $showPages -}}
+  {{- $releaseSlug := .Params.release_slug | default .Slug | default "" -}}
+  {{- if and (not $releaseSlug) .File -}}
+    {{- $releaseSlug = path.Base (strings.TrimSuffix "/" .File.Dir) -}}
+  {{- end -}}
+  {{- $artist := .Params.artist | default "" -}}
+  {{- if reflect.IsSlice $artist -}}{{- $artist = delimit $artist " " -}}{{- end -}}
+  {{- $artistSlug := .Params.artist_slug | default ($artist | urlize) -}}
+  {{- $releasePath := "" -}}
+  {{- with .File -}}{{- $releasePath = strings.TrimSuffix "/" (replace .Path "\\" "/") -}}{{- end -}}
+  {{- $needles := slice
+    (printf "--%s" $releaseSlug)
+    (printf "--%s--%s" $artist $releaseSlug)
+    (printf "--%s--%s" $artistSlug $releaseSlug)
+    $releasePath
+    .RelPermalink
+  -}}
+
+  {{- range $showPages -}}
+    {{- $showPage := . -}}
+    {{- $showText := .RawContent -}}
+    {{- with .File -}}
+      {{- $trackInfoPath := printf "content/%s/track-info.md" (strings.TrimSuffix "/index.md" (replace .Path "\\" "/")) -}}
+      {{- if fileExists $trackInfoPath -}}
+        {{- $showText = printf "%s\n%s" $showText (readFile $trackInfoPath) -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $showText = lower $showText -}}
+    {{- $matched := false -}}
+    {{- range $needle := $needles -}}
+      {{- $needle = printf "%v" $needle | lower | strings.TrimSpace -}}
+      {{- if and (not $matched) $needle (in $showText $needle) -}}
+        {{- $matched = true -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $matched -}}
+      {{- $dedupeKey := $showPage.RelPermalink -}}
+      {{- if not (index $seenShows $dedupeKey) -}}
+        {{- $featuredShows = $featuredShows | append (dict "page" $showPage "link" $showPage.RelPermalink "title" (partial "release/show-card-title.html" $showPage) "date" $showPage.Date "sortDate" (time.Format "2006-01-02T15:04:05Z07:00" $showPage.Date) "note" "") -}}
+        {{- $seenShows = merge $seenShows (dict $dedupeKey true) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if gt (len $featuredShows) 0 -}}
+  {{- $featuredShows = sort $featuredShows "sortDate" "desc" -}}
+  <section class="release-featured-shows not-prose" role="region" aria-labelledby="featured-in-shows">
+    <h2 id="featured-in-shows" class="release-featured-shows__heading">Featured in Shows</h2>
+    <ul class="release-featured-shows__list">
+      {{- range $show := $featuredShows -}}
+        {{- $href := $show.link -}}
+        {{- if not (or (strings.HasPrefix $href "http://") (strings.HasPrefix $href "https://")) -}}
+          {{- $href = $href | relURL -}}
+        {{- end -}}
+        <li class="release-featured-shows__row">
+          <a class="release-featured-shows__link" href="{{ $href }}">
+            <span class="release-featured-shows__title">{{ $show.title }}</span>
+            {{- with $show.date -}}
+              <span class="release-featured-shows__date">
+                {{- $dateText := printf "%v" . -}}
+                {{- if or (in $dateText "UTC") (in $dateText "+0000") (and (in $dateText "T") (in $dateText "Z")) -}}
+                  {{- time.Format (site.Params.dateFormat | default "2 January 2006") . -}}
+                {{- else -}}
+                  {{- $dateText -}}
+                {{- end -}}
+              </span>
+            {{- end -}}
+          </a>
+          {{- with $show.note -}}
+            <p class="release-featured-shows__note">{{ . }}</p>
+          {{- end -}}
+        </li>
+      {{- end -}}
+    </ul>
+  </section>
+{{- end -}}

--- a/src/layouts/partials/release/show-card-title.html
+++ b/src/layouts/partials/release/show-card-title.html
@@ -1,0 +1,7 @@
+{{- $cardTitle := .Title | emojify -}}
+{{- $titleParts := split .Title ": " -}}
+{{- $titleBase := index $titleParts 0 -}}
+{{- if strings.HasPrefix $titleBase "Show #" -}}
+  {{- $cardTitle = replace $titleBase "Show #" "Sundown Sessions #" -}}
+{{- end -}}
+{{- return $cardTitle -}}

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -67,6 +67,7 @@
           {{ if $hasStructuredTracks }}
             {{ partial "release/tracklist.html" . }}
           {{ end }}
+          {{ partial "release/featured-shows.html" . }}
           {{ with $releaseAfterAboutContent }}
             {{ . | safeHTML }}
           {{ end }}


### PR DESCRIPTION
## Summary
- add a Release-only `Featured in Shows` section after the tracklist
- resolve shows from `featuredInShows`, `featured_in_shows`, existing `shows` front matter, and release references in show notes
- style the section as a compact Blowfish-friendly list group

## Verification
- `hugo --gc --minify` with Hugo 0.157.0
- confirmed `Fandango!` links to the matching Sundown Sessions show

Note: the build still reports the existing `_build` front matter deprecation warning.