### PR TITLE
feat(src): add release artist profile section

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -281,6 +281,118 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
     );
 }
 
+/* Release artists: compact creator profile links between release metadata and
+   the About section. */
+
+.release-artists {
+  max-width: 65ch;
+  margin: 0 0 2.5rem;
+  overflow: hidden;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.75rem;
+  background-color: rgba(250, 250, 250, 0.72); /* neutral-50/72 */
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+}
+
+.dark .release-artists {
+  border-color: #404040; /* neutral-700 */
+  background-color: rgba(23, 23, 23, 0.66); /* neutral-900/66 */
+}
+
+.release-artists__heading {
+  margin: 0;
+  padding: 1.25rem 1.25rem 0.95rem;
+  color: #262626; /* neutral-800 */
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.dark .release-artists__heading {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.release-artists__list {
+  margin: 0;
+  padding: 0;
+}
+
+.release-artists__item {
+  border-top: 1px solid #e5e5e5; /* neutral-200 */
+}
+
+.dark .release-artists__item {
+  border-top-color: #404040; /* neutral-700 */
+}
+
+.release-artists__body {
+  padding: 1rem 1.25rem 1.1rem;
+}
+
+.release-artists__name {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.dark .release-artists__name {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.release-artists__name a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.release-artists__name a:hover,
+.release-artists__name a:focus-visible {
+  color: rgba(var(--color-primary-600), 1);
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+}
+
+.dark .release-artists__name a:hover,
+.dark .release-artists__name a:focus-visible {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.release-artists__summary {
+  display: -webkit-box;
+  margin: 0.45rem 0 0;
+  overflow: hidden;
+  color: #525252; /* neutral-600 */
+  font-size: 0.92rem;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.dark .release-artists__summary {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.release-artists__profile-link {
+  display: inline-flex;
+  margin-top: 0.65rem;
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.4;
+  text-decoration: none;
+}
+
+.release-artists__profile-link:hover,
+.release-artists__profile-link:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+}
+
+.dark .release-artists__profile-link {
+  color: rgba(var(--color-primary-400), 1);
+}
+
 /* Release tracklist: scoped card/list-group treatment for structured release
    front matter without changing show playlists or artist pages. */
 

--- a/src/layouts/partials/release/artists.html
+++ b/src/layouts/partials/release/artists.html
@@ -1,0 +1,163 @@
+{{- $artistItems := slice -}}
+
+{{- with .Params.artists -}}
+  {{- if reflect.IsSlice . -}}
+    {{- $artistItems = . -}}
+  {{- else -}}
+    {{- $artistItems = slice . -}}
+  {{- end -}}
+{{- else -}}
+  {{- with .Params.artist -}}
+    {{- if reflect.IsSlice . -}}
+      {{- $artistItems = . -}}
+    {{- else -}}
+      {{- $artistItems = slice . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $artists := slice -}}
+{{- $artistSection := site.GetPage "artists" -}}
+{{- $artistPages := slice -}}
+{{- with $artistSection -}}
+  {{- $artistPages = .RegularPagesRecursive -}}
+{{- else -}}
+  {{- $artistPages = where site.RegularPages "Section" "artists" -}}
+{{- end -}}
+
+{{- range $artistItems -}}
+  {{- $name := "" -}}
+  {{- $pageRef := "" -}}
+  {{- $slug := "" -}}
+  {{- $artistPage := false -}}
+
+  {{- if reflect.IsMap . -}}
+    {{- $name = index . "title" | default (index . "name") | default (index . "artist") -}}
+    {{- $pageRef = index . "page" | default (index . "url") -}}
+    {{- $slug = index . "slug" | default (index . "artist_slug") -}}
+  {{- else -}}
+    {{- $name = printf "%v" . -}}
+    {{- $slug = $.Params.artist_slug -}}
+  {{- end -}}
+
+  {{- if $name -}}
+    {{- $name = printf "%v" $name | strings.TrimSpace -}}
+  {{- else -}}
+    {{- $name = "" -}}
+  {{- end -}}
+  {{- if $pageRef -}}
+    {{- $pageRef = printf "%v" $pageRef | strings.TrimSpace -}}
+  {{- else -}}
+    {{- $pageRef = "" -}}
+  {{- end -}}
+  {{- if $slug -}}
+    {{- $slug = printf "%v" $slug | strings.TrimSpace -}}
+  {{- else -}}
+    {{- $slug = "" -}}
+  {{- end -}}
+
+  {{- if and (not $slug) $name -}}
+    {{- $slug = urlize $name -}}
+  {{- end -}}
+
+  {{- with $pageRef -}}
+    {{- $cleanRef := strings.TrimSuffix "/" (strings.TrimPrefix "/" .) -}}
+    {{- $lookupRefs := slice . $cleanRef (printf "/%s/" $cleanRef) -}}
+    {{- range $lookupRefs -}}
+      {{- if not $artistPage -}}
+        {{- with site.GetPage . -}}
+          {{- if eq .Section "artists" -}}
+            {{- $artistPage = . -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if and (not $artistPage) $slug -}}
+    {{- $slugPath := strings.TrimSuffix "/" (strings.TrimPrefix "/" $slug) -}}
+    {{- $slugBase := path.Base $slugPath -}}
+    {{- if $slugBase -}}
+      {{- $firstChar := substr $slugBase 0 1 | lower -}}
+      {{- $lookupRefs := slice
+        (printf "artists/%s" $slugPath)
+        (printf "artists/%s/%s" $firstChar $slugBase)
+        (printf "/artists/%s/" $slugPath)
+        (printf "/artists/%s/%s/" $firstChar $slugBase)
+      -}}
+      {{- range $lookupRefs -}}
+        {{- if not $artistPage -}}
+          {{- with site.GetPage . -}}
+            {{- if eq .Section "artists" -}}
+              {{- $artistPage = . -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if and (not $artistPage) (or $slug $name) -}}
+    {{- $slugCandidate := $slug | default (urlize $name) -}}
+    {{- $nameCandidate := urlize $name -}}
+    {{- range $artistPages -}}
+      {{- if not $artistPage -}}
+        {{- $pageSlug := .Slug | default (path.Base .RelPermalink) | urlize -}}
+        {{- $fileSlug := "" -}}
+        {{- with .File -}}
+          {{- $fileSlug = path.Base (strings.TrimSuffix "/" .Dir) | urlize -}}
+        {{- end -}}
+        {{- $titleSlug := .Title | urlize -}}
+        {{- if or
+          (and $slugCandidate (or (eq $slugCandidate $pageSlug) (eq $slugCandidate $fileSlug) (eq $slugCandidate $titleSlug)))
+          (and $nameCandidate (eq $nameCandidate $titleSlug))
+        -}}
+          {{- $artistPage = . -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if or $name $artistPage -}}
+    {{- if and (not $name) $artistPage -}}
+      {{- $name = $artistPage.Title -}}
+    {{- end -}}
+    {{- $artists = $artists | append (dict "name" $name "page" $artistPage) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if gt (len $artists) 0 -}}
+  {{- $heading := cond (eq (len $artists) 1) "Artist" "Artists" -}}
+  <section
+    class="release-artists"
+    role="region"
+    aria-labelledby="release-artists-heading">
+    <h2 id="release-artists-heading" class="release-artists__heading">{{ $heading }}</h2>
+    <div class="release-artists__list" role="list">
+      {{- range $artists }}
+        {{- $artistPage := .page -}}
+        {{- $summary := "" -}}
+        {{- with $artistPage -}}
+          {{- $summary = .Summary | plainify | strings.TrimSpace -}}
+        {{- end -}}
+        <article class="release-artists__item" role="listitem">
+          <div class="release-artists__body">
+            <h3 class="release-artists__name">
+              {{- if $artistPage -}}
+                <a href="{{ $artistPage.RelPermalink }}">{{ .name | emojify }}</a>
+              {{- else -}}
+                {{ .name | emojify }}
+              {{- end -}}
+            </h3>
+            {{- with $summary }}
+              <p class="release-artists__summary">{{ . }}</p>
+            {{- end }}
+            {{- with $artistPage }}
+              <a class="release-artists__profile-link" href="{{ .RelPermalink }}">View Artist Profile &rarr;</a>
+            {{- end }}
+          </div>
+        </article>
+      {{- end }}
+    </div>
+  </section>
+{{- end -}}

--- a/src/layouts/partials/release/metadata-card.html
+++ b/src/layouts/partials/release/metadata-card.html
@@ -1,20 +1,52 @@
 {{- $fields := slice -}}
 
 {{- $artist := "" -}}
+{{- $artistNames := slice -}}
 {{- with .Params.artist -}}
   {{- if reflect.IsSlice . -}}
-    {{- $artist = delimit . ", " -}}
+    {{- range . -}}
+      {{- if reflect.IsMap . -}}
+        {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "page") | default (index . "url") | default (index . "slug")) -}}
+          {{- $artistNames = $artistNames | append . -}}
+        {{- end -}}
+      {{- else -}}
+        {{- $artistNames = $artistNames | append . -}}
+      {{- end -}}
+    {{- end -}}
   {{- else -}}
-    {{- $artist = . -}}
+    {{- if reflect.IsMap . -}}
+      {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "page") | default (index . "url") | default (index . "slug")) -}}
+        {{- $artistNames = $artistNames | append . -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $artistNames = $artistNames | append . -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
   {{- with .Params.artists -}}
     {{- if reflect.IsSlice . -}}
-      {{- $artist = delimit . ", " -}}
+      {{- range . -}}
+        {{- if reflect.IsMap . -}}
+          {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "page") | default (index . "url") | default (index . "slug")) -}}
+            {{- $artistNames = $artistNames | append . -}}
+          {{- end -}}
+        {{- else -}}
+          {{- $artistNames = $artistNames | append . -}}
+        {{- end -}}
+      {{- end -}}
     {{- else -}}
-      {{- $artist = . -}}
+      {{- if reflect.IsMap . -}}
+        {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "page") | default (index . "url") | default (index . "slug")) -}}
+          {{- $artistNames = $artistNames | append . -}}
+        {{- end -}}
+      {{- else -}}
+        {{- $artistNames = $artistNames | append . -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
+{{- end -}}
+{{- with $artistNames -}}
+  {{- $artist = delimit . ", " -}}
 {{- end -}}
 {{- with $artist -}}
   {{- $fields = $fields | append (dict "term" "Artist" "value" .) -}}

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -9,6 +9,7 @@
 
     {{ partial "release/hero.html" . }}
     {{ partial "release/metadata-card.html" . }}
+    {{ partial "release/artists.html" . }}
 
     {{/* Body */}}
     <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">


### PR DESCRIPTION
## Summary
- add a release-only Artist/Artists section after Release Details
- resolve artist front matter to Artist pages without rendering broken links
- display compact artist summaries and profile links using scoped release styles
- keep Release Details artist text readable for richer `artists` front matter

## Verification
- `git diff --check`
- Not run: `hugo --gc --minify` because `hugo` is not installed/on PATH in this environment