### PR TITLE
feat(src): add release Explore Further links

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -254,6 +254,35 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: rgba(var(--color-primary-400), 1);
 }
 
+/* Shared Explore Further list-group interactions for external links. */
+
+.explore-further__row:hover,
+.explore-further__row:focus-visible {
+  background-color: rgba(var(--color-neutral-100), 1);
+  color: rgba(var(--color-primary-600), 1);
+}
+
+.explore-further__row:hover .explore-further__icon,
+.explore-further__row:focus-visible .explore-further__icon {
+  color: rgba(var(--color-primary-600), 1);
+}
+
+.explore-further__row:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-600), 1);
+  outline-offset: -2px;
+}
+
+.dark .explore-further__row:hover,
+.dark .explore-further__row:focus-visible {
+  background-color: rgba(var(--color-neutral-800), 1);
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.dark .explore-further__row:hover .explore-further__icon,
+.dark .explore-further__row:focus-visible .explore-further__icon {
+  color: rgba(var(--color-primary-400), 1);
+}
+
 /* Release hero: optional artwork-derived accent for individual release pages.
    The CSS variable is only emitted when front matter provides a colour. */
 

--- a/src/layouts/partials/artist-external-links.html
+++ b/src/layouts/partials/artist-external-links.html
@@ -56,36 +56,11 @@
   {{ end }}
 {{ end }}
 
-{{ if $orderedLinks }}
-  <section
-    class="mb-10 w-full max-w-none not-prose"
-    role="region"
-    aria-labelledby="artist-external-links-heading">
-    <h2
-      id="artist-external-links-heading"
-      class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">
-      Explore Further
-    </h2>
-
-    <ul class="m-0 overflow-hidden rounded-xl border border-neutral-300 bg-white p-0 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
-      {{ range $index, $link := $orderedLinks }}
-        <li class="m-0 p-0{{ if gt $index 0 }} border-t border-neutral-200 dark:border-neutral-700{{ end }}">
-          <a
-            class="artist-external-link-row flex w-full items-center justify-between gap-4 px-4 py-3 text-neutral-700 no-underline transition dark:text-neutral-200"
-            href="{{ $link.url | safeURL }}"
-            target="_blank"
-            rel="noopener noreferrer external"
-            aria-label="{{ $link.label }} (opens in a new tab)">
-            <span class="flex min-w-0 items-center gap-3">
-              <span class="artist-external-link-icon flex h-5 w-5 shrink-0 items-center justify-center text-neutral-500 transition dark:text-neutral-400" aria-hidden="true">
-                {{ partial "icon.html" $link.icon }}
-              </span>
-              <span class="truncate font-semibold">{{ $link.label }}</span>
-            </span>
-            <span class="shrink-0 text-sm text-neutral-500 dark:text-neutral-400" aria-hidden="true">&#8599;</span>
-          </a>
-        </li>
-      {{ end }}
-    </ul>
-  </section>
-{{ end }}
+{{ partial "components/explore-further.html" (dict
+  "links" $orderedLinks
+  "heading" "Explore Further"
+  "headingId" "artist-external-links-heading"
+  "sectionClass" "mb-10 w-full max-w-none not-prose"
+  "rowClass" "artist-external-link-row"
+  "iconClass" "artist-external-link-icon"
+) }}

--- a/src/layouts/partials/components/explore-further.html
+++ b/src/layouts/partials/components/explore-further.html
@@ -1,0 +1,47 @@
+{{- $links := .links | default slice -}}
+{{- if gt (len $links) 0 -}}
+  {{- $heading := .heading | default "Explore Further" -}}
+  {{- $headingId := .headingId | default "explore-further-heading" -}}
+  {{- $sectionClass := .sectionClass | default "explore-further mb-10 w-full max-w-none not-prose" -}}
+  {{- $rowClass := .rowClass | default "explore-further__row" -}}
+  {{- $iconClass := .iconClass | default "explore-further__icon" -}}
+  <section
+    class="{{ $sectionClass }}"
+    role="region"
+    aria-labelledby="{{ $headingId }}">
+    <h2
+      id="{{ $headingId }}"
+      class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">
+      {{ $heading }}
+    </h2>
+
+    <ul class="m-0 overflow-hidden rounded-xl border border-neutral-300 bg-white p-0 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      {{- range $index, $link := $links }}
+        {{- $label := $link.label | default "External Link" -}}
+        {{- $description := $link.description | default "" -}}
+        {{- $icon := $link.icon | default "link" -}}
+        <li class="m-0 p-0{{ if gt $index 0 }} border-t border-neutral-200 dark:border-neutral-700{{ end }}">
+          <a
+            class="{{ $rowClass }} flex w-full items-center justify-between gap-4 px-4 py-3 text-neutral-700 no-underline transition dark:text-neutral-200"
+            href="{{ $link.url | safeURL }}"
+            target="_blank"
+            rel="noopener noreferrer external"
+            aria-label="{{ $label }} (opens in a new tab)">
+            <span class="flex min-w-0 items-center gap-3">
+              <span class="{{ $iconClass }} flex h-5 w-5 shrink-0 items-center justify-center text-neutral-500 transition dark:text-neutral-400" aria-hidden="true">
+                {{ partial "icon.html" $icon }}
+              </span>
+              <span class="min-w-0">
+                <span class="block truncate font-semibold">{{ $label }}</span>
+                {{- with $description }}
+                  <span class="mt-0.5 block text-sm font-medium text-neutral-500 dark:text-neutral-400">{{ . }}</span>
+                {{- end }}
+              </span>
+            </span>
+            <span class="shrink-0 text-sm text-neutral-500 dark:text-neutral-400" aria-hidden="true">&#8599;</span>
+          </a>
+        </li>
+      {{- end }}
+    </ul>
+  </section>
+{{- end -}}

--- a/src/layouts/partials/release/explore-further.html
+++ b/src/layouts/partials/release/explore-further.html
@@ -1,0 +1,173 @@
+{{- $rawLinks := slice -}}
+
+{{- $labelAliases := dict
+  "official" "Official Website"
+  "official-website" "Official Website"
+  "website" "Official Website"
+  "site" "Official Website"
+  "bandcamp" "Bandcamp"
+  "musicbrainz" "MusicBrainz"
+  "discogs" "Discogs"
+  "spotify" "Spotify"
+  "apple" "Apple Music"
+  "apple-music" "Apple Music"
+  "youtube" "YouTube Music"
+  "youtube-music" "YouTube Music"
+  "soundcloud" "SoundCloud"
+  "lastfm" "Last.fm"
+  "last-fm" "Last.fm"
+  "wikipedia" "Wikipedia"
+-}}
+
+{{- $domainAliases := dict
+  "bandcamp.com" "Bandcamp"
+  "discogs.com" "Discogs"
+  "musicbrainz.org" "MusicBrainz"
+  "open.spotify.com" "Spotify"
+  "spotify.com" "Spotify"
+  "music.apple.com" "Apple Music"
+  "apple.com" "Apple Music"
+  "music.youtube.com" "YouTube Music"
+  "youtube.com" "YouTube Music"
+  "youtu.be" "YouTube Music"
+  "soundcloud.com" "SoundCloud"
+  "last.fm" "Last.fm"
+  "wikipedia.org" "Wikipedia"
+-}}
+
+{{- $icons := dict
+  "Official Website" "globe"
+  "Bandcamp" "music"
+  "MusicBrainz" "music"
+  "Discogs" "music"
+  "Spotify" "spotify"
+  "Apple Music" "apple"
+  "YouTube Music" "youtube"
+  "SoundCloud" "music"
+  "Last.fm" "music"
+  "Wikipedia" "globe"
+-}}
+
+{{- $orders := dict
+  "Official Website" 1
+  "Bandcamp" 2
+  "MusicBrainz" 3
+  "Discogs" 4
+  "Spotify" 5
+  "Apple Music" 6
+  "YouTube Music" 7
+  "SoundCloud" 8
+  "Last.fm" 9
+  "Wikipedia" 10
+-}}
+
+{{- $normaliseKey := "" -}}
+{{- $appendLink := false -}}
+
+{{- with .Params.links -}}
+  {{- if reflect.IsMap . -}}
+    {{- range $key, $value := . -}}
+      {{- $url := "" -}}
+      {{- $label := $key -}}
+      {{- $description := "" -}}
+      {{- if reflect.IsMap $value -}}
+        {{- $url = index $value "url" | default (index $value "href") | default (index $value "link") | default "" -}}
+        {{- $label = index $value "label" | default (index $value "title") | default (index $value "name") | default $key -}}
+        {{- $description = index $value "description" | default (index $value "summary") | default (index $value "text") | default "" -}}
+      {{- else -}}
+        {{- $url = $value -}}
+      {{- end -}}
+      {{- with $url -}}
+        {{- $rawLinks = $rawLinks | append (dict "url" . "label" $label "description" $description) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else if reflect.IsSlice . -}}
+    {{- range . -}}
+      {{- if reflect.IsMap . -}}
+        {{- $url := index . "url" | default (index . "href") | default (index . "link") | default "" -}}
+        {{- $label := index . "label" | default (index . "title") | default (index . "name") | default "" -}}
+        {{- $description := index . "description" | default (index . "summary") | default (index . "text") | default "" -}}
+        {{- with $url -}}{{- $rawLinks = $rawLinks | append (dict "url" . "label" $label "description" $description) -}}{{- end -}}
+      {{- else -}}
+        {{- $rawLinks = $rawLinks | append (dict "url" . "label" "" "description" "") -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $rawLinks = $rawLinks | append (dict "url" . "label" "" "description" "") -}}
+  {{- end -}}
+{{- end -}}
+
+{{- range $field := slice .Params.externalLinks .Params.external_links -}}
+  {{- with $field -}}
+    {{- $entries := . -}}
+    {{- if not (reflect.IsSlice $entries) -}}{{- $entries = slice $entries -}}{{- end -}}
+    {{- range $entries -}}
+      {{- if reflect.IsMap . -}}
+        {{- $url := index . "url" | default (index . "href") | default (index . "link") | default "" -}}
+        {{- $label := index . "label" | default (index . "title") | default (index . "name") | default "" -}}
+        {{- $description := index . "description" | default (index . "summary") | default (index . "text") | default "" -}}
+        {{- with $url -}}{{- $rawLinks = $rawLinks | append (dict "url" . "label" $label "description" $description) -}}{{- end -}}
+      {{- else -}}
+        {{- $rawLinks = $rawLinks | append (dict "url" . "label" "" "description" "") -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $externalSection := "" -}}
+{{- range split .RawContent "\n## " -}}
+  {{- $section := . | strings.TrimSpace -}}
+  {{- if or (hasPrefix $section "External Links") (hasPrefix $section "## External Links") (hasPrefix $section "Explore Further") (hasPrefix $section "## Explore Further") -}}
+    {{- $externalSection = $section -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $linkPattern := `(?m)^\s*-\s+\{\{<\s*new-tab-link\s+"(?:([^":\[]+):\s+)?\[([^\]]+)\]\((https?://[^)]+)\)"\s*>\}\}\s*$` -}}
+{{- range findRESubmatch $linkPattern $externalSection -}}
+  {{- $prefixLabel := printf "%v" (index . 1 | default "") | strings.TrimSpace -}}
+  {{- $linkLabel := printf "%v" (index . 2 | default "") | strings.TrimSpace -}}
+  {{- $url := printf "%v" (index . 3 | default "") | strings.TrimSpace -}}
+  {{- $label := $prefixLabel | default $linkLabel -}}
+  {{- if $url -}}{{- $rawLinks = $rawLinks | append (dict "url" $url "label" $label "description" "") -}}{{- end -}}
+{{- end -}}
+
+{{- $seen := dict -}}
+{{- $links := slice -}}
+{{- range $rawLinks -}}
+  {{- $url := printf "%v" .url | strings.TrimSpace -}}
+  {{- if and $url (or (strings.HasPrefix $url "http://") (strings.HasPrefix $url "https://")) -}}
+    {{- $dedupeKey := lower (strings.TrimSuffix "/" $url) -}}
+    {{- if not (index $seen $dedupeKey) -}}
+      {{- $label := printf "%v" (.label | default "") | strings.TrimSpace -}}
+      {{- $description := printf "%v" (.description | default "") | strings.TrimSpace -}}
+      {{- $labelKey := lower $label | replaceRE `[^a-z0-9]+` "-" | strings.TrimSuffix "-" | strings.TrimPrefix "-" -}}
+      {{- with index $labelAliases $labelKey -}}{{- $label = . -}}{{- end -}}
+
+      {{- $host := lower (replaceRE `^https?://([^/:?#]+).*$` "$1" $url) -}}
+      {{- $detectedLabel := "" -}}
+      {{- range $domain, $domainLabel := $domainAliases -}}
+        {{- if and (not $detectedLabel) (or (eq $host $domain) (strings.HasSuffix $host (printf ".%s" $domain))) -}}
+          {{- $detectedLabel = $domainLabel -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if or (not $label) (eq $label $url) -}}
+        {{- $label = $detectedLabel | default (replaceRE `^www\.` "" $host) | default "External Link" -}}
+      {{- end -}}
+
+      {{- $order := index $orders $label | default 100 -}}
+      {{- $icon := index $icons $label | default "link" -}}
+      {{- $links = $links | append (dict "url" $url "label" $label "description" $description "icon" $icon "sortKey" (printf "%03d-%s" $order (lower $label))) -}}
+      {{- $seen = merge $seen (dict $dedupeKey true) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $links = sort $links "sortKey" -}}
+{{- partial "components/explore-further.html" (dict
+  "links" $links
+  "heading" "Explore Further"
+  "headingId" "release-explore-further-heading"
+  "sectionClass" "release-explore-further mb-10 max-w-prose not-prose"
+  "rowClass" "explore-further__row"
+  "iconClass" "explore-further__icon"
+) -}}

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -31,6 +31,7 @@
           {{ $releaseAboutHeading := partial "release/about-heading.html" . | strings.TrimSpace }}
           {{ $releaseAboutAnchor := anchorize $releaseAboutHeading }}
           {{ $releaseContent := .Content | strings.TrimSpace }}
+          {{ $releaseContent = replaceRE `(?is)<h2\b[^>]*>\s*(External Links|Explore Further)\s*.*?</h2>\s*.*?(?=<h2\b|$)` "" $releaseContent | strings.TrimSpace }}
           {{ $aboutHeadings := slice "About" "About the Release" "About the Album" "About the EP" "About the Single" }}
           {{ $startsWithAboutHeading := false }}
           {{ if hasPrefix $releaseContent "<h2" }}
@@ -69,6 +70,7 @@
             {{ partial "release/tracklist.html" . }}
           {{ end }}
           {{ partial "release/featured-shows.html" . }}
+          {{ partial "release/explore-further.html" . }}
           {{ with $releaseAfterAboutContent }}
             {{ . | safeHTML }}
           {{ end }}


### PR DESCRIPTION
## Summary
- add a release-only Explore Further card for external music/resource links
- support `links`, `externalLinks`, and `external_links` front matter shapes
- detect friendly labels from known domains and order links consistently
- strip legacy body External Links/Explore Further sections to avoid duplicate rendering
- share the card renderer with Artist Explore Further while preserving artist extraction behaviour

## Verification
- `git diff --check`
- Not run: `hugo --environment production` because `hugo` is not installed/on PATH in this environment