### PR TITLE
Replace release pagination with discovery recommendations

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -627,6 +627,130 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   margin: -0.35rem 1.25rem 0.9rem;
 }
 
+/* Release discovery: responsive onward recommendations for non-sequential
+   release pages. Artwork is contained so sleeve art is never cropped. */
+
+.release-discover-more {
+  margin: 2rem 0 2.5rem;
+  max-width: 72rem;
+}
+
+.release-discover-more__heading {
+  margin: 0 0 1rem;
+  color: #262626; /* neutral-800 */
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.dark .release-discover-more__heading {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.release-discover-more__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.release-discover-card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  border-radius: 0.75rem;
+  background-color: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.dark .release-discover-card {
+  border-color: #404040; /* neutral-700 */
+  background-color: rgba(23, 23, 23, 0.8); /* neutral-900/80 */
+}
+
+.release-discover-card:hover,
+.release-discover-card:focus-within {
+  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  transform: translateY(-0.125rem);
+}
+
+.release-discover-card__link {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  color: inherit;
+  text-decoration: none;
+}
+
+.release-discover-card__link:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-600), 1);
+  outline-offset: -2px;
+}
+
+.release-discover-card__media {
+  display: flex;
+  aspect-ratio: 1 / 1;
+  align-items: center;
+  justify-content: center;
+  background-color: #f5f5f5; /* neutral-100 */
+  padding: 0.75rem;
+}
+
+.dark .release-discover-card__media {
+  background-color: #262626; /* neutral-800 */
+}
+
+.release-discover-card__media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.release-discover-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem;
+}
+
+.release-discover-card__title {
+  color: #171717; /* neutral-900 */
+  font-size: 1rem;
+  font-weight: 750;
+  line-height: 1.35;
+}
+
+.release-discover-card__link:hover .release-discover-card__title,
+.release-discover-card__link:focus-visible .release-discover-card__title {
+  color: rgba(var(--color-primary-600), 1);
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+}
+
+.dark .release-discover-card__title {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.dark .release-discover-card__link:hover .release-discover-card__title,
+.dark .release-discover-card__link:focus-visible .release-discover-card__title {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.release-discover-card__artist,
+.release-discover-card__meta {
+  color: #737373; /* neutral-500 */
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.dark .release-discover-card__artist,
+.dark .release-discover-card__meta {
+  color: #a3a3a3; /* neutral-400 */
+}
+
 @media (min-width: 640px) {
   .release-tracklist__row {
     grid-template-columns: 2.5rem minmax(0, 1fr) auto;
@@ -646,5 +770,15 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 
   .release-featured-shows__date {
     flex: none;
+  }
+
+  .release-discover-more__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .release-discover-more__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/src/layouts/partials/release/discover-more.html
+++ b/src/layouts/partials/release/discover-more.html
@@ -1,0 +1,241 @@
+{{/* Release recommendations for individual release pages.
+     Signals are intentionally additive so future fields can be folded in by
+     adding another score component without changing the rendered cards. */}}
+
+{{- $current := . -}}
+{{- $currentArtists := slice -}}
+{{- with $current.Params.artist -}}
+  {{- if reflect.IsSlice . -}}
+    {{- range . -}}
+      {{- if reflect.IsMap . -}}
+        {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug")) -}}
+          {{- $currentArtists = $currentArtists | append (urlize (printf "%v" .)) -}}
+        {{- end -}}
+      {{- else -}}
+        {{- $currentArtists = $currentArtists | append (urlize (printf "%v" .)) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else if reflect.IsMap . -}}
+    {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug")) -}}
+      {{- $currentArtists = $currentArtists | append (urlize (printf "%v" .)) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $currentArtists = $currentArtists | append (urlize (printf "%v" .)) -}}
+  {{- end -}}
+{{- else with $current.Params.artists -}}
+  {{- if reflect.IsSlice . -}}
+    {{- range . -}}
+      {{- if reflect.IsMap . -}}
+        {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug")) -}}
+          {{- $currentArtists = $currentArtists | append (urlize (printf "%v" .)) -}}
+        {{- end -}}
+      {{- else -}}
+        {{- $currentArtists = $currentArtists | append (urlize (printf "%v" .)) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $currentArtists = $currentArtists | append (urlize (printf "%v" .)) -}}
+  {{- end -}}
+{{- end -}}
+{{- with $current.File -}}
+  {{- $releaseDir := strings.TrimSuffix "/" (replace .Dir "\\" "/") -}}
+  {{- $artistDir := path.Base (path.Dir $releaseDir) -}}
+  {{- with $artistDir -}}{{- $currentArtists = $currentArtists | append (urlize .) -}}{{- end -}}
+{{- end -}}
+{{- $currentArtistBag := printf "|%s|" (delimit (uniq $currentArtists) "|") -}}
+
+{{- $currentGenres := slice -}}
+{{- range $field := slice $current.Params.genre $current.Params.genres -}}
+  {{- with $field -}}
+    {{- if reflect.IsSlice . -}}
+      {{- range . -}}{{- $currentGenres = $currentGenres | append (urlize (printf "%v" .)) -}}{{- end -}}
+    {{- else -}}
+      {{- $currentGenres = $currentGenres | append (urlize (printf "%v" .)) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $currentShows := slice -}}
+{{- with ($current.Params.featuredInShows | default $current.Params.featured_in_shows | default $current.Params.shows) -}}
+  {{- $entries := . -}}
+  {{- if not (reflect.IsSlice $entries) -}}{{- $entries = slice $entries -}}{{- end -}}
+  {{- range $entry := $entries -}}
+    {{- $showRef := "" -}}
+    {{- if reflect.IsMap $entry -}}
+      {{- $showRef = index $entry "show" | default (index $entry "page") | default (index $entry "path") | default (index $entry "slug") | default (index $entry "url") | default "" -}}
+    {{- else -}}
+      {{- $showRef = $entry -}}
+    {{- end -}}
+    {{- with $showRef -}}{{- $currentShows = $currentShows | append (urlize (printf "%v" .)) -}}{{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $currentType := urlize (printf "%v" ($current.Params.releaseType | default $current.Params.release_type | default "")) -}}
+{{- $currentYear := 0 -}}
+{{- $currentDate := $current.Params.releaseDate | default $current.Params.release_date | default $current.Params.date -}}
+{{- with $currentDate -}}
+  {{- with (findRE `[12][0-9]{3}` (printf "%v" .) 1) -}}{{- $currentYear = int (index . 0) -}}{{- end -}}
+{{- end -}}
+{{- if and (eq $currentYear 0) (not $current.Date.IsZero) -}}{{- $currentYear = int (time.Format "2006" $current.Date) -}}{{- end -}}
+{{- $currentDecade := 0 -}}
+{{- if gt $currentYear 0 -}}{{- $currentDecade = div $currentYear 10 -}}{{- end -}}
+
+{{- $recommendations := slice -}}
+{{- range $candidate := where site.RegularPages "Section" "releases" -}}
+  {{- if ne $candidate.RelPermalink $current.RelPermalink -}}
+    {{- $candidateArtists := slice -}}
+    {{- with $candidate.Params.artist -}}
+      {{- if reflect.IsSlice . -}}
+        {{- range . -}}
+          {{- if reflect.IsMap . -}}
+            {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug")) -}}{{- $candidateArtists = $candidateArtists | append (urlize (printf "%v" .)) -}}{{- end -}}
+          {{- else -}}
+            {{- $candidateArtists = $candidateArtists | append (urlize (printf "%v" .)) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- else if reflect.IsMap . -}}
+        {{- with (index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug")) -}}{{- $candidateArtists = $candidateArtists | append (urlize (printf "%v" .)) -}}{{- end -}}
+      {{- else -}}
+        {{- $candidateArtists = $candidateArtists | append (urlize (printf "%v" .)) -}}
+      {{- end -}}
+    {{- else with $candidate.Params.artists -}}
+      {{- if reflect.IsSlice . -}}
+        {{- range . -}}{{- $candidateArtists = $candidateArtists | append (urlize (printf "%v" .)) -}}{{- end -}}
+      {{- else -}}
+        {{- $candidateArtists = $candidateArtists | append (urlize (printf "%v" .)) -}}
+      {{- end -}}
+    {{- end -}}
+    {{- with $candidate.File -}}
+      {{- $releaseDir := strings.TrimSuffix "/" (replace .Dir "\\" "/") -}}
+      {{- $artistDir := path.Base (path.Dir $releaseDir) -}}
+      {{- with $artistDir -}}{{- $candidateArtists = $candidateArtists | append (urlize .) -}}{{- end -}}
+    {{- end -}}
+
+    {{- $sameArtist := false -}}
+    {{- range uniq $candidateArtists -}}
+      {{- if and (not $sameArtist) (in $currentArtistBag (printf "|%s|" .)) -}}{{- $sameArtist = true -}}{{- end -}}
+    {{- end -}}
+
+    {{- $sameGenre := false -}}
+    {{- $candidateGenres := slice -}}
+    {{- range $field := slice $candidate.Params.genre $candidate.Params.genres -}}
+      {{- with $field -}}
+        {{- if reflect.IsSlice . -}}
+          {{- range . -}}{{- $candidateGenres = $candidateGenres | append (urlize (printf "%v" .)) -}}{{- end -}}
+        {{- else -}}
+          {{- $candidateGenres = $candidateGenres | append (urlize (printf "%v" .)) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $currentGenreBag := printf "|%s|" (delimit (uniq $currentGenres) "|") -}}
+    {{- range uniq $candidateGenres -}}
+      {{- if and (not $sameGenre) (in $currentGenreBag (printf "|%s|" .)) -}}{{- $sameGenre = true -}}{{- end -}}
+    {{- end -}}
+
+    {{- $sameShow := false -}}
+    {{- $candidateShows := slice -}}
+    {{- with ($candidate.Params.featuredInShows | default $candidate.Params.featured_in_shows | default $candidate.Params.shows) -}}
+      {{- $entries := . -}}
+      {{- if not (reflect.IsSlice $entries) -}}{{- $entries = slice $entries -}}{{- end -}}
+      {{- range $entry := $entries -}}
+        {{- $showRef := "" -}}
+        {{- if reflect.IsMap $entry -}}
+          {{- $showRef = index $entry "show" | default (index $entry "page") | default (index $entry "path") | default (index $entry "slug") | default (index $entry "url") | default "" -}}
+        {{- else -}}
+          {{- $showRef = $entry -}}
+        {{- end -}}
+        {{- with $showRef -}}{{- $candidateShows = $candidateShows | append (urlize (printf "%v" .)) -}}{{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $currentShowBag := printf "|%s|" (delimit (uniq $currentShows) "|") -}}
+    {{- range uniq $candidateShows -}}
+      {{- if and (not $sameShow) (in $currentShowBag (printf "|%s|" .)) -}}{{- $sameShow = true -}}{{- end -}}
+    {{- end -}}
+
+    {{- $candidateType := urlize (printf "%v" ($candidate.Params.releaseType | default $candidate.Params.release_type | default "")) -}}
+    {{- $sameType := and $currentType $candidateType (eq $currentType $candidateType) -}}
+
+    {{- $candidateYear := 0 -}}
+    {{- $candidateDate := $candidate.Params.releaseDate | default $candidate.Params.release_date | default $candidate.Params.date -}}
+    {{- with $candidateDate -}}
+      {{- with (findRE `[12][0-9]{3}` (printf "%v" .) 1) -}}{{- $candidateYear = int (index . 0) -}}{{- end -}}
+    {{- end -}}
+    {{- if and (eq $candidateYear 0) (not $candidate.Date.IsZero) -}}{{- $candidateYear = int (time.Format "2006" $candidate.Date) -}}{{- end -}}
+    {{- $candidateDecade := 0 -}}
+    {{- if gt $candidateYear 0 -}}{{- $candidateDecade = div $candidateYear 10 -}}{{- end -}}
+    {{- $sameEra := and (gt $currentDecade 0) (eq $currentDecade $candidateDecade) -}}
+
+    {{- $score := 0 -}}
+    {{- if $sameArtist -}}{{- $score = add $score 10000 -}}{{- end -}}
+    {{- if $sameGenre -}}{{- $score = add $score 1000 -}}{{- end -}}
+    {{- if $sameShow -}}{{- $score = add $score 100 -}}{{- end -}}
+    {{- if $sameType -}}{{- $score = add $score 10 -}}{{- end -}}
+    {{- if $sameEra -}}{{- $score = add $score 1 -}}{{- end -}}
+
+    {{- if gt $score 0 -}}
+      {{- $sortKey := printf "%05d-%04d-%s" (sub 99999 $score) (sub 9999 $candidateYear) (urlize $candidate.Title) -}}
+      {{- $recommendations = $recommendations | append (dict "page" $candidate "score" $score "sortKey" $sortKey "year" $candidateYear) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $recommendations = first 6 (sort $recommendations "sortKey") -}}
+{{- if gt (len $recommendations) 0 -}}
+  <section class="release-discover-more not-prose" role="region" aria-labelledby="release-discover-more-heading">
+    <h2 id="release-discover-more-heading" class="release-discover-more__heading">Discover More Releases</h2>
+    <div class="release-discover-more__grid">
+      {{- range $item := $recommendations -}}
+        {{- $release := $item.page -}}
+        {{- $artworkParam := $release.Params.artwork | default $release.Params.cover | default $release.Params.image | default $release.Params.featureimage | default $release.Params.featured_image -}}
+        {{- $artwork := "" -}}
+        {{- $artworkURL := "" -}}
+        {{- with $artworkParam -}}
+          {{- if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") -}}
+            {{- $artworkURL = . -}}
+          {{- else -}}
+            {{- $artwork = $release.Resources.GetMatch . -}}
+            {{- if not $artwork -}}{{- $artwork = $release.Resources.GetMatch (path.Base .) -}}{{- end -}}
+            {{- if not $artwork -}}{{- $artwork = resources.Get . -}}{{- end -}}
+            {{- if not $artwork -}}{{- $artworkURL = . | relURL -}}{{- end -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if not (or $artwork $artworkURL) -}}
+          {{- $images := $release.Resources.ByType "image" -}}
+          {{- range slice "*artwork*" "*cover*" "*image*" "*feature*" "*thumbnail*" -}}
+            {{- if not $artwork -}}{{- $artwork = $images.GetMatch . -}}{{- end -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if not $artworkURL -}}{{- with $artwork -}}{{- $artworkURL = .RelPermalink -}}{{- end -}}{{- end -}}
+
+        {{- $artist := "" -}}
+        {{- with $release.Params.artist -}}
+          {{- if reflect.IsSlice . -}}{{- $artist = delimit . ", " -}}{{- else -}}{{- $artist = printf "%v" . -}}{{- end -}}
+        {{- else with $release.Params.artists -}}
+          {{- if reflect.IsSlice . -}}{{- $artist = delimit . ", " -}}{{- else -}}{{- $artist = printf "%v" . -}}{{- end -}}
+        {{- end -}}
+        {{- $releaseType := $release.Params.releaseType | default $release.Params.release_type | default "" -}}
+
+        <article class="release-discover-card">
+          <a class="release-discover-card__link" href="{{ $release.RelPermalink }}">
+            {{- with $artworkURL -}}
+              <span class="release-discover-card__media">
+                <img src="{{ . }}" alt="{{ $release.Title }} artwork" loading="lazy" decoding="async">
+              </span>
+            {{- end -}}
+            <span class="release-discover-card__body">
+              <span class="release-discover-card__title">{{ $release.Title | emojify }}</span>
+              {{- with $artist -}}<span class="release-discover-card__artist">{{ . }}</span>{{- end -}}
+              {{- if or (gt $item.year 0) $releaseType -}}
+                <span class="release-discover-card__meta">
+                  {{- if gt $item.year 0 -}}{{ $item.year }}{{- end -}}
+                  {{- if and (gt $item.year 0) $releaseType }} &bull; {{ end -}}
+                  {{- with $releaseType -}}{{ . }}{{- end -}}
+                </span>
+              {{- end -}}
+            </span>
+          </a>
+        </article>
+      {{- end -}}
+    </div>
+  </section>
+{{- end -}}

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -31,7 +31,7 @@
           {{ $releaseAboutHeading := partial "release/about-heading.html" . | strings.TrimSpace }}
           {{ $releaseAboutAnchor := anchorize $releaseAboutHeading }}
           {{ $releaseContent := .Content | strings.TrimSpace }}
-          {{ $releaseContent = replaceRE `(?is)<h2\b[^>]*>\s*(External Links|Explore Further)\s*.*?</h2>\s*.*?(?=<h2\b|$)` "" $releaseContent | strings.TrimSpace }}
+          {{ $releaseContent = replaceRE `(?is)<h2\b[^>]*>\s*(External Links|Explore Further)\s*.*?</h2>\s*.*?(<h2\b|$)` "$2" $releaseContent | strings.TrimSpace }}
           {{ $aboutHeadings := slice "About" "About the Release" "About the Album" "About the EP" "About the Single" }}
           {{ $startsWithAboutHeading := false }}
           {{ if hasPrefix $releaseContent "<h2" }}
@@ -43,7 +43,7 @@
           {{ end }}
           {{ $hasStructuredTracks := and .Params.tracks (reflect.IsSlice .Params.tracks) (gt (len .Params.tracks) 0) }}
           {{ if $hasStructuredTracks }}
-            {{ $releaseContent = replaceRE `(?is)<h2\b[^>]*>\s*Tracklist.*?</h2>\s*.*?(?=<h2\b|$)` "" $releaseContent | strings.TrimSpace }}
+            {{ $releaseContent = replaceRE `(?is)<h2\b[^>]*>\s*Tracklist.*?</h2>\s*.*?(<h2\b|$)` "$1" $releaseContent | strings.TrimSpace }}
           {{ end }}
           {{ $releaseAboutContent := $releaseContent }}
           {{ $releaseAfterAboutContent := "" }}
@@ -71,6 +71,7 @@
           {{ end }}
           {{ partial "release/featured-shows.html" . }}
           {{ partial "release/explore-further.html" . }}
+          {{ partial "release/discover-more.html" . }}
           {{ with $releaseAfterAboutContent }}
             {{ . | safeHTML }}
           {{ end }}
@@ -103,10 +104,9 @@
       </div>
     </section>
 
-    {{/* Footer */}}
-    <footer class="pt-8 max-w-prose print:hidden">
-      {{ partial "article-pagination.html" . }}
-      {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
+    {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
+      {{/* Footer */}}
+      <footer class="pt-8 max-w-prose print:hidden">
         {{ if templates.Exists "partials/comments.html" }}
           <div class="pt-3">
             <hr class="border-dotted border-neutral-300 dark:border-neutral-600" />
@@ -117,8 +117,8 @@
         {{ else }}
           {{ warnf "[BLOWFISH] Comments are enabled for %s but no comments partial exists." .File.Path }}
         {{ end }}
-      {{ end }}
-    </footer>
+      </footer>
+    {{ end }}
   </article>
 {{ end }}
 


### PR DESCRIPTION
## Summary
- remove previous/next pagination from individual release pages only
- add a release-specific Discover More Releases partial with deterministic scored recommendations
- add responsive Blowfish-style release cards with contained artwork
- fix release-template regexes that blocked Hugo's regexp engine during validation

## Validation
- `.tmp-hugo\hugo.exe --gc --minify --source src`
- spot-checked rendered release output for recommendations and no previous/next arrows
- spot-checked rendered show output still retains previous/next navigation

Note: Hugo still reports the existing `_build` front matter deprecation warning.