### PR TITLE
Add release taxonomy metadata

### DIFF
--- a/docs/release-front-matter.md
+++ b/docs/release-front-matter.md
@@ -1,0 +1,39 @@
+# Release Front Matter
+
+Release pages support compact music metadata for discovery and taxonomy pages.
+Prefer the plural fields for taxonomy-backed values, while the release
+templates still accept the older singular fields used by existing content.
+
+```yaml
+genres:
+  - Alternative Rock
+  - Stoner Rock
+
+labels:
+  - Matador Records
+
+releaseType: Album
+releaseDate: 2017-08-25
+
+producers:
+  - Mark Ronson
+
+tags:
+  - alternative rock
+  - queens of the stone age
+```
+
+Existing alternatives are also supported for rendering:
+
+- `genre` or `genres`
+- `label` or `labels`
+- `producer` or `producers`
+- `releaseType` or `release_type`
+- `releaseDate`, `release_date`, or `date`
+
+Hugo taxonomy pages are generated from taxonomy fields that exist in front
+matter. Use `genres`, `labels`, `producers`, `tags`, `years`, and
+`release-types` when a release should be grouped on taxonomy pages. Keep
+`releaseType` and `releaseDate` as the human-friendly canonical release fields;
+add `release-types` and `years` alongside them when native Hugo taxonomy
+indexing is wanted.

--- a/src/config/_default/taxonomies.toml
+++ b/src/config/_default/taxonomies.toml
@@ -1,2 +1,7 @@
 genre = "genres"
 tag = "tags"
+category = "categories"
+label = "labels"
+producer = "producers"
+releaseType = "release-types"
+year = "years"

--- a/src/content/releases/q/queens-of-the-stone-age/villains/index.md
+++ b/src/content/releases/q/queens-of-the-stone-age/villains/index.md
@@ -2,7 +2,23 @@
 title: Villains
 artist: Queens Of The Stone Age
 label: Matador Records
+labels:
+  - Matador Records
 release_date: "25 August 2017"
+releaseDate: 2017-08-25
+releaseType: Album
+release-types:
+  - Album
+genres:
+  - Alternative Rock
+  - Stoner Rock
+producers:
+  - Mark Ronson
+years:
+  - "2017"
+tags:
+  - alternative rock
+  - queens of the stone age
 uk_chart_position: 2
 catalogue_number: "MAT 0983"
 for_sale: true

--- a/src/layouts/partials/release/metadata-card.html
+++ b/src/layouts/partials/release/metadata-card.html
@@ -71,73 +71,69 @@
   {{- end -}}
 {{- end -}}
 
-{{- $releaseType := .Params.releaseType | default .Params.release_type | default .Params.type -}}
-{{- with $releaseType -}}
-  {{- $releaseTypeText := . -}}
-  {{- if reflect.IsSlice . -}}
-    {{- $releaseTypeText = delimit . ", " -}}
+{{- $releaseYear := "" -}}
+{{- with $releaseDate -}}
+  {{- if reflect.IsMap . -}}
+  {{- else if reflect.IsSlice . -}}
+  {{- else -}}
+    {{- $dateText := printf "%v" . -}}
+    {{- if or (in $dateText "UTC") (in $dateText "+0000") -}}
+      {{- $releaseYear = time.Format "2006" . -}}
+    {{- else -}}
+      {{- $yearMatches := findRE `\b(1[89][0-9]{2}|20[0-9]{2})\b` $dateText 1 -}}
+      {{- if gt (len $yearMatches) 0 -}}
+        {{- $releaseYear = index $yearMatches 0 -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
-  {{- $fields = $fields | append (dict "term" "Type" "value" $releaseTypeText) -}}
+{{- end -}}
+{{- with $releaseYear -}}
+  {{- $fields = $fields | append (dict "term" "Year" "values" (slice .) "taxonomyPath" "years") -}}
 {{- end -}}
 
-{{- $label := "" -}}
+{{- $releaseType := .Params.releaseType | default .Params.release_type | default .Params.type -}}
+{{- with $releaseType -}}
+  {{- $fields = $fields | append (dict "term" "Release Type" "values" . "taxonomyPath" "release-types") -}}
+{{- end -}}
+
+{{- $label := false -}}
 {{- with .Params.label -}}
-  {{- if reflect.IsSlice . -}}
-    {{- $label = delimit . ", " -}}
-  {{- else -}}
-    {{- $label = . -}}
-  {{- end -}}
+  {{- $label = . -}}
 {{- else -}}
   {{- with .Params.labels -}}
-    {{- if reflect.IsSlice . -}}
-      {{- $label = delimit . ", " -}}
-    {{- else -}}
-      {{- $label = . -}}
-    {{- end -}}
+    {{- $label = . -}}
   {{- end -}}
 {{- end -}}
 {{- with $label -}}
-  {{- $fields = $fields | append (dict "term" "Label" "value" .) -}}
+  {{- $fields = $fields | append (dict "term" "Label" "values" . "taxonomyPath" "labels") -}}
 {{- end -}}
 
-{{- $producer := "" -}}
+{{- $producer := false -}}
 {{- with .Params.producer -}}
-  {{- if reflect.IsSlice . -}}
-    {{- $producer = delimit . ", " -}}
-  {{- else -}}
-    {{- $producer = . -}}
-  {{- end -}}
+  {{- $producer = . -}}
 {{- else -}}
   {{- with .Params.producers -}}
-    {{- if reflect.IsSlice . -}}
-      {{- $producer = delimit . ", " -}}
-    {{- else -}}
-      {{- $producer = . -}}
-    {{- end -}}
+    {{- $producer = . -}}
   {{- end -}}
 {{- end -}}
 {{- with $producer -}}
-  {{- $fields = $fields | append (dict "term" "Producer" "value" .) -}}
+  {{- $fields = $fields | append (dict "term" "Producer" "values" . "taxonomyPath" "producers") -}}
 {{- end -}}
 
-{{- $genre := "" -}}
+{{- $genre := false -}}
 {{- with .Params.genre -}}
-  {{- if reflect.IsSlice . -}}
-    {{- $genre = delimit . ", " -}}
-  {{- else -}}
-    {{- $genre = . -}}
-  {{- end -}}
+  {{- $genre = . -}}
 {{- else -}}
   {{- with .Params.genres -}}
-    {{- if reflect.IsSlice . -}}
-      {{- $genre = delimit . ", " -}}
-    {{- else -}}
-      {{- $genre = . -}}
-    {{- end -}}
+    {{- $genre = . -}}
   {{- end -}}
 {{- end -}}
 {{- with $genre -}}
-  {{- $fields = $fields | append (dict "term" "Genre" "value" .) -}}
+  {{- $fields = $fields | append (dict "term" "Genre" "values" . "taxonomyPath" "genres") -}}
+{{- end -}}
+
+{{- with .Params.tags -}}
+  {{- $fields = $fields | append (dict "term" "Tags" "values" . "taxonomyPath" "tags") -}}
 {{- end -}}
 
 {{- $trackCount := .Params.trackCount | default .Params.track_count -}}
@@ -178,7 +174,11 @@
             {{ .term }}
           </dt>
           <dd class="mt-1 break-words text-base font-medium text-neutral-900 dark:text-neutral-100">
-            {{ .value }}
+            {{- if isset . "values" -}}
+              {{ partial "release/metadata-link-list.html" (dict "values" .values "taxonomyPath" .taxonomyPath) }}
+            {{- else -}}
+              {{ .value }}
+            {{- end -}}
           </dd>
         </div>
       {{- end }}

--- a/src/layouts/partials/release/metadata-link-list.html
+++ b/src/layouts/partials/release/metadata-link-list.html
@@ -1,0 +1,44 @@
+{{- $taxonomyPath := .taxonomyPath | default "" -}}
+{{- $rawValues := .values -}}
+{{- $values := slice -}}
+
+{{- with $rawValues -}}
+  {{- if reflect.IsSlice . -}}
+    {{- range . -}}
+      {{- $values = $values | append . -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $values = $values | append . -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $cleanValues := slice -}}
+{{- range $values -}}
+  {{- $value := "" -}}
+  {{- if reflect.IsMap . -}}
+    {{- $value = index . "title" | default (index . "name") | default (index . "label") | default (index . "value") | default "" -}}
+  {{- else -}}
+    {{- $value = printf "%v" . -}}
+  {{- end -}}
+  {{- $value = $value | strings.TrimSpace -}}
+  {{- if $value -}}
+    {{- $cleanValues = $cleanValues | append $value -}}
+  {{- end -}}
+{{- end -}}
+
+{{- range $index, $value := $cleanValues -}}
+  {{- if gt $index 0 -}}
+    <span class="mx-1 text-neutral-400" aria-hidden="true">&middot;</span>
+  {{- end -}}
+  {{- $termPage := false -}}
+  {{- with $taxonomyPath -}}
+    {{- $termPage = site.GetPage (printf "/%s/%s" . ($value | urlize)) -}}
+  {{- end -}}
+  {{- with $termPage -}}
+    <a
+      class="decoration-primary-500 hover:underline hover:underline-offset-2"
+      href="{{ .RelPermalink }}">{{ $value }}</a>
+  {{- else -}}
+    <span>{{ $value }}</span>
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Summary
- add release taxonomy mappings for labels, producers, release types, years, categories, while preserving existing genres and tags
- render release metadata values as taxonomy links when term pages exist
- add Villains as a representative taxonomy-backed release and document the preferred release front matter pattern

## Verification
- git diff --cached --check
- Not run: hugo --environment production, because hugo is not installed/on PATH in this environment