### PR TITLE
ci: harden github actions security posture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     labels:
       - dependencies
       - github-actions
+      - security
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/codeql-contentops.yml
+++ b/.github/workflows/codeql-contentops.yml
@@ -28,15 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source using v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Initialise CodeQL using v3
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
         with:
           languages: csharp
 
       - name: Setup .NET using v4.3.1
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           global-json-file: ${{ env.DOTNET_DIR }}/global.json
 
@@ -49,4 +49,4 @@ jobs:
         working-directory: ${{ env.DOTNET_DIR }}
 
       - name: Perform CodeQL analysis using v3
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3

--- a/.github/workflows/contentops-ci.yml
+++ b/.github/workflows/contentops-ci.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source using v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET using v4.3.1
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           global-json-file: ${{ env.DOTNET_DIR }}/global.json
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload test results using v4.6.2
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: contentops-test-results
           path: |

--- a/.github/workflows/contentops-release.yml
+++ b/.github/workflows/contentops-release.yml
@@ -34,7 +34,7 @@ jobs:
       release_tag: ${{ steps.version.outputs.release_tag }}
     steps:
       - name: Checkout using v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve version
         id: version
@@ -48,7 +48,7 @@ jobs:
           echo "release_tag=contentops/v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup .NET using v4.3.1
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           global-json-file: ${{ env.DOTNET_DIR }}/global.json
 
@@ -120,7 +120,7 @@ jobs:
           EOF
 
       - name: Upload release assets artifact using v4.6.2
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: contentops-release-assets
           path: |
@@ -133,20 +133,20 @@ jobs:
     needs: build-test-package
     steps:
       - name: Checkout using v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Login to GHCR using v3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx using v3.12.0
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push container using v6.19.2
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: automation/dotnet
           file: automation/dotnet/Dockerfile
@@ -174,14 +174,14 @@ jobs:
     needs: [build-test-package, publish-container]
     steps:
       - name: Download assets artifact using v4.3.0
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: contentops-release-assets
           path: release-assets
 
       - name: Create tag for manual dispatch using v7.1.0
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const tag = '${{ needs.build-test-package.outputs.release_tag }}';
@@ -200,7 +200,7 @@ jobs:
             }
 
       - name: Publish GitHub release using v2.6.1
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ needs.build-test-package.outputs.release_tag }}
           name: ContentOps v${{ needs.build-test-package.outputs.release_version }}

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -49,12 +49,12 @@ jobs:
           sudo ln -sf /opt/dart-sass/sass /usr/local/bin/sass
           sass --version
       - name: Checkout source using v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Cache Hugo build artefacts
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             src/resources/_gen
@@ -64,7 +64,7 @@ jobs:
             hugo-${{ runner.os }}-
       - name: Setup pages using v4.0.0
         id: pages
-        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -77,7 +77,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact using v3.0.1
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./src/public
 
@@ -91,4 +91,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages using v4.0.4
         id: deployment
-        uses: actions/deploy-pages@decdde0ac072f6dcbe43649d82d9c635fff5b4e4
+        uses: actions/deploy-pages@decdde0ac072f6dcbe43649d82d9c635fff5b4e4 # v4.0.4

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -11,9 +11,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout source using v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Lint Markdown using v22.0.0
-        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9
+        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v22.0.0
         with:
           globs: |
             **/*.md

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR metadata with GitHub Script using v7.1.0
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/validate-hugo-content.yml
+++ b/.github/workflows/validate-hugo-content.yml
@@ -31,7 +31,7 @@ jobs:
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Checkout source using v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           submodules: recursive

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,14 @@ If your pull request changes files under `automation/dotnet/`, update [CHANGELOG
 - Releases can be created manually via workflow dispatch.
 - Tag-based releases use the `contentops/v*` naming pattern.
 
+### GitHub Actions Updates
+
+- Dependabot opens pull requests for GitHub Actions updates.
+- Review the upstream action release notes and repository before merging.
+- Confirm each pinned SHA matches the expected release tag.
+- Let the affected workflows pass before merging.
+- Keep non-action Docker image digests under separate review when they are introduced.
+
 ## Additional Repository Standards
 
 - Use British English in documentation and user-facing text.


### PR DESCRIPTION
## Summary
- pin all GitHub Actions workflow `uses:` references to full-length commit SHAs
- add Dependabot-friendly version comments beside each pinned action
- add the `security` label to GitHub Actions Dependabot PRs
- document the review flow for pinned action updates

Closes #511.

## Validation
- `rg -n uses:\\s*[^@]+@(v[0-9]+|main|master|HEAD) .github/workflows` returned no mutable action refs
- custom PowerShell audit confirmed every workflow `uses:` ref is SHA-pinned with a version comment
- `rg -n secrets\\.|GITHUB_TOKEN .github/workflows` confirmed existing secret usage remains limited to `${{ secrets.GITHUB_TOKEN }}`
- `git diff --check` passed

## Notes
- Local YAML parser validation was not run because Python, Node, Ruby, yq, and ConvertFrom-Yaml are unavailable in this environment.
- The Trivy Docker image in the release workflow is intentionally left as-is; non-action image digest pinning can be handled separately.