### PR TITLE
feat(src): generate missing release pages

### DIFF
--- a/reports/missing-release-pages-report.md
+++ b/reports/missing-release-pages-report.md
@@ -1,0 +1,39 @@
+# Missing Release Pages Report
+
+- Shows scanned: 35
+- Tracks processed: 403
+- Playlist entries parsed: 134
+- Releases identified: 325
+- Release pages created: 249
+- Existing releases skipped: 73
+- Potential duplicates: 3
+- Metadata requiring manual review: 73
+- Errors: 0
+
+## Created
+
+- 249 release pages were generated under `src/content/releases`.
+- 176 generated pages include MusicBrainz metadata and links.
+- 73 generated pages were created from local show metadata only and should be manually reviewed when richer release metadata is needed.
+
+## Potential Duplicates
+
+- Suede - Dog Man Star (30th Anniversary Edition): `src/content/releases/s/suede/dog-man-star-30th-anniversary-edition/index.md`, `src/content/releases/s/suede/dog-man-star/index.md`
+- The Move - Shazam: `src/content/releases/t/the-move/shazam/index.md`, `src/content/releases/t/the-move/shazam-2007-remaster/index.md`
+- The Move - Shazam (2007 Remaster): `src/content/releases/t/the-move/shazam-2007-remaster/index.md`, `src/content/releases/t/the-move/shazam/index.md`
+
+## Manual Review
+
+- 73 generated pages do not have a confident MusicBrainz match.
+- Find them with:
+
+```powershell
+$files = git ls-files --others --exclude-standard 'src/content/releases/**/index.md'
+foreach ($file in $files) {
+  if ((Get-Content -Raw $file) -notmatch 'musicbrainz.org') { $file }
+}
+```
+
+## Errors
+
+- None

--- a/scripts/generate-missing-release-pages.ps1
+++ b/scripts/generate-missing-release-pages.ps1
@@ -1,0 +1,598 @@
+param(
+    [string]$SiteRoot = "src",
+    [switch]$Enrich,
+    [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-NormalisedKey {
+    param([AllowNull()][string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
+
+    $normalised = $Value.Normalize([Text.NormalizationForm]::FormKD).ToLowerInvariant()
+    $normalised = $normalised -replace "&", " and "
+    $normalised = $normalised -replace "[\u2018\u2019\u201A\u201B']", ""
+    $normalised = $normalised -replace "[^a-z0-9]+", " "
+    $normalised = $normalised -replace "\s+", " "
+    return $normalised.Trim()
+}
+
+function ConvertTo-Slug {
+    param([string]$Value)
+    $key = ConvertTo-NormalisedKey $Value
+    $slug = $key -replace "\s+", "-"
+    if ([string]::IsNullOrWhiteSpace($slug)) { return "unknown" }
+    return $slug
+}
+
+function ConvertTo-ReleaseTitleMatchKey {
+    param([AllowNull()][string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
+
+    $title = $Value
+    $title = $title -replace "\s*\((?i:[^)]*(remaster|remastered|deluxe|expanded|anniversary|bonus|version|original album mix|legacy edition)[^)]*)\)", ""
+    $title = $title -replace "\s+(?i:remaster(ed)?|deluxe edition|expanded edition|bonus remix version|legacy edition|original album mix)$", ""
+    $title = $title -replace "\s+-\s+(?i:remaster(ed)?|deluxe edition|expanded edition|bonus remix version|legacy edition|original album mix)$", ""
+    return ConvertTo-NormalisedKey $title
+}
+
+function Get-FrontMatter {
+    param([string]$Path)
+    $text = Get-Content -Raw -LiteralPath $Path
+    if ($text -notmatch "(?s)^---\r?\n(.*?)\r?\n---") {
+        return @{}
+    }
+
+    $frontMatter = $Matches[1]
+    $values = @{}
+    $currentKey = $null
+    foreach ($line in ($frontMatter -split "\r?\n")) {
+        if ($line -match "^\s*#") { continue }
+        if ($line -match "^([A-Za-z0-9_-]+):\s*(.*)$") {
+            $currentKey = $Matches[1]
+            $raw = $Matches[2].Trim()
+            if ($raw -eq "") {
+                $values[$currentKey] = @()
+            } else {
+                $values[$currentKey] = ($raw -replace '^["'']|["'']$', "")
+            }
+            continue
+        }
+        if ($currentKey -and $line -match "^\s*-\s*(.+?)\s*$") {
+            $item = $Matches[1] -replace '^["'']|["'']$', ""
+            if ($values[$currentKey] -isnot [System.Collections.IList]) {
+                $values[$currentKey] = @($values[$currentKey])
+            }
+            $values[$currentKey] += $item
+        }
+    }
+
+    return $values
+}
+
+function Add-ReleaseKey {
+    param(
+        [hashtable]$Index,
+        [string]$Key,
+        [string]$Path
+    )
+    if ([string]::IsNullOrWhiteSpace($Key)) { return }
+    if (-not $Index.ContainsKey($Key)) {
+        $Index[$Key] = New-Object System.Collections.Generic.List[string]
+    }
+    $Index[$Key].Add($Path)
+}
+
+function Get-ExistingReleaseIndex {
+    param([string]$ReleasesRoot)
+    $index = @{}
+    $entries = New-Object System.Collections.Generic.List[object]
+
+    if (-not (Test-Path -LiteralPath $ReleasesRoot)) {
+        return [pscustomobject]@{ Index = $index; Entries = $entries }
+    }
+
+    foreach ($file in Get-ChildItem -LiteralPath $ReleasesRoot -Recurse -Filter "index.md") {
+        $frontMatter = Get-FrontMatter $file.FullName
+        $title = [string]($frontMatter["title"])
+        $artist = [string]($frontMatter["artist"])
+        if ([string]::IsNullOrWhiteSpace($artist) -and $frontMatter["artists"]) {
+            $artist = [string]($frontMatter["artists"] | Select-Object -First 1)
+        }
+
+        $releaseSlug = Split-Path -Leaf (Split-Path -Parent $file.FullName)
+        $artistSlug = Split-Path -Leaf (Split-Path -Parent (Split-Path -Parent $file.FullName))
+        $relativePath = Resolve-Path -LiteralPath $file.FullName -Relative
+
+        foreach ($key in @(
+            "pair:$(ConvertTo-NormalisedKey $artist)|$(ConvertTo-NormalisedKey $title)",
+            "canonical-pair:$(ConvertTo-NormalisedKey $artist)|$(ConvertTo-ReleaseTitleMatchKey $title)",
+            "pair:$(ConvertTo-NormalisedKey $artistSlug)|$(ConvertTo-NormalisedKey $releaseSlug)"
+        )) {
+            Add-ReleaseKey $index $key $relativePath
+        }
+
+        foreach ($aliasField in @("aliases", "alias")) {
+            if ($frontMatter[$aliasField]) {
+                foreach ($alias in @($frontMatter[$aliasField])) {
+                    Add-ReleaseKey $index "pair:$(ConvertTo-NormalisedKey $artist)|$(ConvertTo-NormalisedKey $alias)" $relativePath
+                    Add-ReleaseKey $index "canonical-pair:$(ConvertTo-NormalisedKey $artist)|$(ConvertTo-ReleaseTitleMatchKey $alias)" $relativePath
+                }
+            }
+        }
+
+        $entries.Add([pscustomobject]@{
+            Title = $title
+            Artist = $artist
+            ReleaseSlug = $releaseSlug
+            ArtistSlug = $artistSlug
+            Path = $relativePath
+        })
+    }
+
+    return [pscustomobject]@{ Index = $index; Entries = $entries }
+}
+
+function Split-MarkdownTableRow {
+    param([string]$Line)
+    $trimmed = $Line.Trim()
+    if (-not ($trimmed.StartsWith("|") -and $trimmed.EndsWith("|"))) { return @() }
+    $inner = $trimmed.Substring(1, $trimmed.Length - 2)
+    return @($inner -split "\|").ForEach({ $_.Trim() })
+}
+
+function Remove-MarkdownMarkup {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
+    $clean = $Value -replace "\{\{<[^>]+>\}\}", ""
+    $clean = $clean -replace "\[([^\]]+)\]\([^)]+\)", '$1'
+    $clean = $clean -replace "\*\*|__|_", ""
+    return ($clean -replace "\s+", " ").Trim()
+}
+
+function Get-TitleArtistFromCell {
+    param([string]$Cell)
+    if ($Cell -match '\{\{<\s*title\s+"([^"]+)"\s*>\}\}') {
+        $parts = $Matches[1] -split "--"
+        if ($parts.Count -ge 2) {
+            return [pscustomobject]@{
+                Track = $parts[0].Trim()
+                Artist = $parts[1].Trim()
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        Track = (Remove-MarkdownMarkup $Cell)
+        Artist = ""
+    }
+}
+
+function Get-ReleaseFromAlbumCell {
+    param(
+        [string]$Cell,
+        [string]$FallbackArtist
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Cell)) { return $null }
+    if ($Cell -match "\[RECORD LABEL\]|\[.*?\]|\bTBC\b|^\s*-+\s*$") { return $null }
+
+    if ($Cell -match '\{\{<\s*release\s+"([^"]+)"\s*>\}\}') {
+        $parts = $Matches[1] -split "--"
+        if ($parts.Count -ge 2) {
+            $titleWithYear = $parts[0].Trim()
+            $year = ""
+            $title = $titleWithYear
+            if ($titleWithYear -match "^(.*?)\s*\((\d{4})\)\s*$") {
+                $title = $Matches[1].Trim()
+                $year = $Matches[2]
+            }
+
+            return [pscustomobject]@{
+                Title = $title
+                Artist = $parts[1].Trim()
+                Slug = if ($parts.Count -ge 3) { ConvertTo-Slug $parts[2] } else { ConvertTo-Slug $title }
+                Year = $year
+                Source = "release-shortcode"
+            }
+        }
+    }
+
+    $clean = Remove-MarkdownMarkup $Cell
+    if ([string]::IsNullOrWhiteSpace($clean)) { return $null }
+
+    $year = ""
+    $title = $clean
+    if ($clean -match "^(.*?)\s*\((\d{4})\)\s*$") {
+        $title = $Matches[1].Trim()
+        $year = $Matches[2]
+    }
+
+    if ($title -match "^(single|n/?a|unknown|non[- ]album)$") { return $null }
+    if ([string]::IsNullOrWhiteSpace($FallbackArtist)) { return $null }
+
+    return [pscustomobject]@{
+        Title = $title
+        Artist = $FallbackArtist
+        Slug = ConvertTo-Slug $title
+        Year = $year
+        Source = "track-info-album-cell"
+    }
+}
+
+function Get-ShowPlaylistEntries {
+    param([string]$ShowsRoot)
+    $entries = New-Object System.Collections.Generic.List[object]
+    $playlistFiles = Get-ChildItem -LiteralPath $ShowsRoot -Recurse -File |
+        Where-Object { $_.Name -match "^playlist(\s|\(|\.|$)" -or $_.Name -eq "playlist" }
+
+    foreach ($file in $playlistFiles) {
+        $showId = Split-Path -Leaf $file.DirectoryName
+        foreach ($line in Get-Content -LiteralPath $file.FullName) {
+            if ($line -match "^\s*\d+[\.\)]\s*(.+?)\s+-\s+(.+?)\s+-\s+\d{1,2}:\d{2}") {
+                $entries.Add([pscustomobject]@{
+                    Show = $showId
+                    Artist = $Matches[1].Trim()
+                    Track = $Matches[2].Trim()
+                    Source = $file.FullName
+                })
+            }
+        }
+    }
+
+    return $entries
+}
+
+function Get-ReleaseCandidates {
+    param([string]$ShowsRoot)
+    $candidates = @{}
+    $tracksProcessed = 0
+
+    foreach ($file in Get-ChildItem -LiteralPath $ShowsRoot -Recurse -Filter "track-info.md") {
+        $showId = Split-Path -Leaf $file.DirectoryName
+        foreach ($line in Get-Content -LiteralPath $file.FullName) {
+            if ($line -notmatch "^\s*\|\s*\d+\s*\|") { continue }
+            $cells = Split-MarkdownTableRow $line
+            if ($cells.Count -lt 4) { continue }
+
+            $trackInfo = Get-TitleArtistFromCell $cells[1]
+            $release = Get-ReleaseFromAlbumCell $cells[2] $trackInfo.Artist
+            $tracksProcessed++
+            if (-not $release) { continue }
+
+            $artistKey = ConvertTo-NormalisedKey $release.Artist
+            $titleKey = ConvertTo-NormalisedKey $release.Title
+            $candidateKey = "$artistKey|$titleKey"
+
+            if (-not $candidates.ContainsKey($candidateKey)) {
+                $candidates[$candidateKey] = [pscustomobject]@{
+                    Title = $release.Title
+                    Artist = $release.Artist
+                    Slug = $release.Slug
+                    Year = $release.Year
+                    Sources = New-Object System.Collections.Generic.HashSet[string]
+                    Shows = New-Object System.Collections.Generic.HashSet[string]
+                    FeaturedTracks = New-Object System.Collections.Generic.HashSet[string]
+                }
+            }
+
+            [void]$candidates[$candidateKey].Sources.Add($release.Source)
+            [void]$candidates[$candidateKey].Shows.Add($showId)
+            if ($trackInfo.Track) {
+                [void]$candidates[$candidateKey].FeaturedTracks.Add($trackInfo.Track)
+            }
+            if (-not $candidates[$candidateKey].Year -and $release.Year) {
+                $candidates[$candidateKey].Year = $release.Year
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        Candidates = $candidates.Values
+        TracksProcessed = $tracksProcessed
+    }
+}
+
+function Find-ExistingRelease {
+    param(
+        [hashtable]$Index,
+        [object]$Candidate
+    )
+    $keys = @(
+        "pair:$(ConvertTo-NormalisedKey $Candidate.Artist)|$(ConvertTo-NormalisedKey $Candidate.Title)",
+        "canonical-pair:$(ConvertTo-NormalisedKey $Candidate.Artist)|$(ConvertTo-ReleaseTitleMatchKey $Candidate.Title)",
+        "pair:$(ConvertTo-NormalisedKey (ConvertTo-Slug $Candidate.Artist))|$(ConvertTo-NormalisedKey $Candidate.Slug)"
+    )
+
+    $matches = New-Object System.Collections.Generic.HashSet[string]
+    foreach ($key in $keys) {
+        if ($Index.ContainsKey($key)) {
+            foreach ($path in $Index[$key]) {
+                [void]$matches.Add($path)
+            }
+        }
+    }
+
+    return @($matches)
+}
+
+function Get-MusicBrainzJson {
+    param([string]$Uri)
+    Start-Sleep -Milliseconds 1100
+    return Invoke-RestMethod -Uri $Uri -Headers @{
+        "User-Agent" = "SundownSessionsReleaseGenerator/1.0 (https://github.com/colin-gourlay/sundown-sessions)"
+    }
+}
+
+function Get-MusicBrainzMetadata {
+    param([object]$Candidate)
+    $query = [uri]::EscapeDataString(("release:`"{0}`" AND artist:`"{1}`"" -f $Candidate.Title, $Candidate.Artist))
+    $rgUri = "https://musicbrainz.org/ws/2/release-group/?query=$query&fmt=json&limit=5"
+    $groups = Get-MusicBrainzJson $rgUri
+    $candidateTitleKey = ConvertTo-NormalisedKey $Candidate.Title
+    $candidateArtistKey = ConvertTo-NormalisedKey $Candidate.Artist
+    $group = @($groups.'release-groups') |
+        Where-Object {
+            (ConvertTo-NormalisedKey $_.title) -eq $candidateTitleKey -and
+            (ConvertTo-NormalisedKey (@($_.'artist-credit' | ForEach-Object { $_.name }) -join " ")) -match [regex]::Escape($candidateArtistKey)
+        } |
+        Select-Object -First 1
+
+    if (-not $group) { return $null }
+
+    $releaseUri = "https://musicbrainz.org/ws/2/release?release-group=$($group.id)&inc=media+recordings+labels+artist-credits&fmt=json&limit=10"
+    $releaseResult = Get-MusicBrainzJson $releaseUri
+    $release = @($releaseResult.releases) |
+        Sort-Object @{ Expression = { if ($_.status -eq "Official") { 0 } else { 1 } } }, @{ Expression = { if ($_.date) { $_.date } else { "9999" } } } |
+        Select-Object -First 1
+
+    $tracks = @()
+    $durationMs = 0
+    if ($release -and $release.media) {
+        foreach ($medium in @($release.media)) {
+            foreach ($track in @($medium.tracks)) {
+                $title = [string]$track.title
+                if ([string]::IsNullOrWhiteSpace($title)) { continue }
+                $duration = ""
+                if ($track.length) {
+                    $durationMs += [int64]$track.length
+                    $ts = [TimeSpan]::FromMilliseconds([int64]$track.length)
+                    $duration = "{0:mm\:ss}" -f $ts
+                    if ($ts.TotalHours -ge 1) { $duration = "{0:h\:mm\:ss}" -f $ts }
+                }
+                $tracks += [pscustomobject]@{
+                    Title = $title
+                    Number = [int]$track.position
+                    Duration = $duration
+                }
+            }
+        }
+    }
+
+    $labels = @()
+    if ($release -and $release.'label-info') {
+        foreach ($labelInfo in @($release.'label-info')) {
+            if ($labelInfo.label.name) { $labels += [string]$labelInfo.label.name }
+        }
+    }
+
+    $genres = @()
+    if ($group.tags) {
+        $genres = @($group.tags | Sort-Object count -Descending | Select-Object -First 5 | ForEach-Object { $_.name })
+    }
+
+    $duration = ""
+    if ($durationMs -gt 0) {
+        $ts = [TimeSpan]::FromMilliseconds($durationMs)
+        $duration = "{0:h\:mm\:ss}" -f $ts
+    }
+
+    return [pscustomobject]@{
+        ReleaseDate = if ($group.'first-release-date') { [string]$group.'first-release-date' } elseif ($release.date) { [string]$release.date } else { "" }
+        ReleaseType = [string]$group.'primary-type'
+        Labels = @($labels | Where-Object { $_ } | Select-Object -Unique)
+        Genres = @($genres | Where-Object { $_ } | Select-Object -Unique)
+        Tracks = $tracks
+        Duration = $duration
+        Links = @{ MusicBrainz = "https://musicbrainz.org/release-group/$($group.id)" }
+    }
+}
+
+function ConvertTo-YamlString {
+    param([string]$Value)
+    $escaped = $Value -replace '"', '\"'
+    return '"' + $escaped + '"'
+}
+
+function Add-YamlScalar {
+    param([System.Text.StringBuilder]$Builder, [string]$Key, [AllowNull()][string]$Value)
+    if (-not [string]::IsNullOrWhiteSpace($Value)) {
+        [void]$Builder.AppendLine("$($Key): $(ConvertTo-YamlString $Value)")
+    }
+}
+
+function Add-YamlList {
+    param([System.Text.StringBuilder]$Builder, [string]$Key, [array]$Values)
+    $clean = @($Values | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } | Select-Object -Unique)
+    if ($clean.Count -eq 0) { return }
+    [void]$Builder.AppendLine("$($Key):")
+    foreach ($value in $clean) {
+        [void]$Builder.AppendLine("  - $(ConvertTo-YamlString ([string]$value))")
+    }
+}
+
+function New-ReleasePageContent {
+    param(
+        [object]$Candidate,
+        [AllowNull()][object]$Metadata
+    )
+
+    $releaseDate = ""
+    if ($Metadata -and $Metadata.ReleaseDate) { $releaseDate = $Metadata.ReleaseDate }
+    elseif ($Candidate.Year) { $releaseDate = [string]$Candidate.Year }
+
+    $builder = [System.Text.StringBuilder]::new()
+    [void]$builder.AppendLine("---")
+    Add-YamlScalar $builder "title" $Candidate.Title
+    Add-YamlScalar $builder "artist" $Candidate.Artist
+    Add-YamlScalar $builder "releaseDate" $releaseDate
+    if ($Metadata) {
+        Add-YamlScalar $builder "releaseType" $Metadata.ReleaseType
+        Add-YamlList $builder "genres" $Metadata.Genres
+        Add-YamlList $builder "labels" $Metadata.Labels
+        Add-YamlScalar $builder "duration" $Metadata.Duration
+    }
+    $sortedShows = @($Candidate.Shows) | Sort-Object { [int]($_ -replace "\D", "") }, { $_ }
+    Add-YamlList $builder "featuredInShows" $sortedShows
+    Add-YamlList $builder "shows" $sortedShows
+
+    if ($Metadata -and $Metadata.Tracks.Count -gt 0) {
+        [void]$builder.AppendLine("tracks:")
+        foreach ($track in $Metadata.Tracks) {
+            [void]$builder.AppendLine("  - title: $(ConvertTo-YamlString $track.Title)")
+            if ($track.Number) { [void]$builder.AppendLine("    trackNumber: $($track.Number)") }
+            if ($track.Duration) { [void]$builder.AppendLine("    duration: $(ConvertTo-YamlString $track.Duration)") }
+        }
+    }
+
+    if ($Metadata -and $Metadata.Links.Count -gt 0) {
+        [void]$builder.AppendLine("links:")
+        foreach ($key in ($Metadata.Links.Keys | Sort-Object)) {
+            [void]$builder.AppendLine("  $($key): $(ConvertTo-YamlString $Metadata.Links[$key])")
+        }
+    }
+
+    Add-YamlScalar $builder "lastmod" (Get-Date -Format "yyyy-MM-dd")
+    [void]$builder.AppendLine("---")
+    [void]$builder.AppendLine()
+    [void]$builder.AppendLine("## About")
+    [void]$builder.AppendLine()
+
+    $showCount = @($Candidate.Shows).Count
+    $trackNames = @($Candidate.FeaturedTracks) | Sort-Object
+    $trackText = ""
+    if ($trackNames.Count -gt 0) {
+        $trackText = " Featured tracks include " + (($trackNames | Select-Object -First 3) -join ", ") + "."
+    }
+
+    $dateText = if ($releaseDate) { " released in $releaseDate" } else { "" }
+    [void]$builder.AppendLine(("{0} is a release by {1}{2}. It has been featured on {3} Sundown Sessions show{4}.{5}" -f $Candidate.Title, $Candidate.Artist, $dateText, $showCount, $(if ($showCount -eq 1) { "" } else { "s" }), $trackText))
+    [void]$builder.AppendLine()
+
+    if (-not ($Metadata -and $Metadata.Tracks.Count -gt 0) -and $trackNames.Count -gt 0) {
+        [void]$builder.AppendLine("## Tracks Featured on Sundown Sessions")
+        [void]$builder.AppendLine()
+        foreach ($track in $trackNames) {
+            [void]$builder.AppendLine("- $track")
+        }
+        [void]$builder.AppendLine()
+    }
+
+    return $builder.ToString()
+}
+
+$sitePath = Join-Path (Get-Location) $SiteRoot
+$showsRoot = Join-Path $sitePath "content/shows"
+$releasesRoot = Join-Path $sitePath "content/releases"
+$reportPath = Join-Path (Get-Location) "reports/missing-release-pages-report.md"
+
+$existing = Get-ExistingReleaseIndex $releasesRoot
+$playlistEntries = Get-ShowPlaylistEntries $showsRoot
+$candidateResult = Get-ReleaseCandidates $showsRoot
+
+$created = New-Object System.Collections.Generic.List[string]
+$skipped = New-Object System.Collections.Generic.List[string]
+$duplicates = New-Object System.Collections.Generic.List[string]
+$manualReview = New-Object System.Collections.Generic.List[string]
+$errors = New-Object System.Collections.Generic.List[string]
+
+foreach ($candidate in ($candidateResult.Candidates | Sort-Object Artist, Title)) {
+    $matches = Find-ExistingRelease $existing.Index $candidate
+    if ($matches.Count -gt 1) {
+        $duplicates.Add("$($candidate.Artist) - $($candidate.Title): $($matches -join ', ')")
+        continue
+    }
+    if ($matches.Count -eq 1) {
+        $skipped.Add("$($candidate.Artist) - $($candidate.Title)")
+        continue
+    }
+
+    $metadata = $null
+    if ($Enrich) {
+        try {
+            $metadata = Get-MusicBrainzMetadata $candidate
+            if (-not $metadata) {
+                $manualReview.Add("$($candidate.Artist) - $($candidate.Title): MusicBrainz match not found")
+            }
+        } catch {
+            $manualReview.Add("$($candidate.Artist) - $($candidate.Title): MusicBrainz lookup failed")
+            $errors.Add("$($candidate.Artist) - $($candidate.Title): $($_.Exception.Message)")
+        }
+    } else {
+        $manualReview.Add("$($candidate.Artist) - $($candidate.Title): not externally enriched")
+    }
+
+    $artistSlug = ConvertTo-Slug $candidate.Artist
+    $releaseSlug = ConvertTo-Slug $candidate.Slug
+    $first = $artistSlug.Substring(0, 1)
+    if ($first -notmatch "[a-z0-9]") { $first = "0" }
+    $directory = Join-Path $releasesRoot (Join-Path $first (Join-Path $artistSlug $releaseSlug))
+    $path = Join-Path $directory "index.md"
+
+    if (Test-Path -LiteralPath $path) {
+        $skipped.Add("$($candidate.Artist) - $($candidate.Title)")
+        continue
+    }
+
+    $content = New-ReleasePageContent $candidate $metadata
+    if (-not $WhatIf) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+        Set-Content -LiteralPath $path -Value $content -Encoding UTF8
+    }
+    $createdPath = Resolve-Path -LiteralPath $path -Relative -ErrorAction SilentlyContinue
+    if (-not $createdPath) { $createdPath = $path }
+    $created.Add([string]$createdPath)
+}
+
+if (-not $WhatIf) {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $reportPath) | Out-Null
+}
+
+$report = [System.Text.StringBuilder]::new()
+[void]$report.AppendLine("# Missing Release Pages Report")
+[void]$report.AppendLine()
+[void]$report.AppendLine("- Shows scanned: $((Get-ChildItem -LiteralPath $showsRoot -Directory).Count)")
+[void]$report.AppendLine("- Tracks processed: $($candidateResult.TracksProcessed)")
+[void]$report.AppendLine("- Playlist entries parsed: $($playlistEntries.Count)")
+[void]$report.AppendLine("- Releases identified: $($candidateResult.Candidates.Count)")
+[void]$report.AppendLine("- Release pages created: $($created.Count)")
+[void]$report.AppendLine("- Existing releases skipped: $($skipped.Count)")
+[void]$report.AppendLine("- Potential duplicates: $($duplicates.Count)")
+[void]$report.AppendLine("- Metadata requiring manual review: $($manualReview.Count)")
+[void]$report.AppendLine("- Errors: $($errors.Count)")
+[void]$report.AppendLine()
+
+foreach ($section in @(
+    @{ Title = "Created"; Items = $created },
+    @{ Title = "Potential Duplicates"; Items = $duplicates },
+    @{ Title = "Manual Review"; Items = $manualReview },
+    @{ Title = "Errors"; Items = $errors }
+)) {
+    [void]$report.AppendLine("## $($section.Title)")
+    [void]$report.AppendLine()
+    if ($section.Items.Count -eq 0) {
+        [void]$report.AppendLine("- None")
+    } else {
+        foreach ($item in $section.Items) {
+            [void]$report.AppendLine("- $item")
+        }
+    }
+    [void]$report.AppendLine()
+}
+
+if (-not $WhatIf) {
+    Set-Content -LiteralPath $reportPath -Value $report.ToString() -Encoding UTF8
+}
+
+Write-Output $report.ToString()

--- a/src/content/releases/a/adam-and-the-ants/john-peel-session/index.md
+++ b/src/content/releases/a/adam-and-the-ants/john-peel-session/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "John Peel Session"
+artist: "Adam & The Ants"
+releaseDate: "1979"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+John Peel Session is a release by Adam & The Ants released in 1979. It has been featured on 1 Sundown Sessions show. Featured tracks include Ligotage.
+
+## Tracks Featured on Sundown Sessions
+
+- Ligotage
+
+

--- a/src/content/releases/a/adam-ant/vive-le-rock/index.md
+++ b/src/content/releases/a/adam-ant/vive-le-rock/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "Vive Le Rock"
+artist: "Adam Ant"
+releaseDate: "1985-09-02"
+releaseType: "Album"
+genres:
+  - "pop rock"
+  - "rock"
+  - "pop"
+  - "new wave"
+  - "synthpop"
+labels:
+  - "CBS"
+duration: "0:39:53"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Vive Le Rock"
+    trackNumber: 1
+    duration: "03:39"
+  - title: "Miss Thing"
+    trackNumber: 2
+    duration: "03:08"
+  - title: "Razor Keen"
+    trackNumber: 3
+    duration: "03:49"
+  - title: "Rip Down"
+    trackNumber: 4
+    duration: "03:23"
+  - title: "Scorpio Rising"
+    trackNumber: 5
+    duration: "04:05"
+  - title: "Apollo 9"
+    trackNumber: 6
+    duration: "03:22"
+  - title: "Hell's Eight Acres"
+    trackNumber: 7
+    duration: "03:52"
+  - title: "Mohair Lockeroom Pin-Up Boys"
+    trackNumber: 8
+    duration: "03:14"
+  - title: "No Zap"
+    trackNumber: 9
+    duration: "03:14"
+  - title: "P.O.E."
+    trackNumber: 10
+    duration: "03:25"
+  - title: "Apollo 9 (a cappella reprise)"
+    trackNumber: 11
+    duration: "01:29"
+  - title: "Human Bondage Den"
+    trackNumber: 12
+    duration: "03:08"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6633ffa1-a37a-3712-89ec-e0429ac73883"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Vive Le Rock is a release by Adam Ant released in 1985-09-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Miss Thing.
+
+

--- a/src/content/releases/a/aimee-mann/im-with-stupid/index.md
+++ b/src/content/releases/a/aimee-mann/im-with-stupid/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "I'm With Stupid"
+artist: "Aimee Mann"
+releaseDate: "1995"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+I'm With Stupid is a release by Aimee Mann released in 1995. It has been featured on 1 Sundown Sessions show. Featured tracks include Sugarcoated.
+
+## Tracks Featured on Sundown Sessions
+
+- Sugarcoated
+
+

--- a/src/content/releases/a/air-traffic/fractured-life/index.md
+++ b/src/content/releases/a/air-traffic/fractured-life/index.md
@@ -1,0 +1,63 @@
+﻿---
+title: "Fractured Life"
+artist: "Air Traffic"
+releaseDate: "2007-07-02"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "rock"
+  - "2007"
+  - "rock and indie"
+  - "british"
+labels:
+  - "EMI"
+  - "Tiny Consumer"
+duration: "0:55:45"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Just Abuse Me"
+    trackNumber: 1
+    duration: "02:32"
+  - title: "Charlotte"
+    trackNumber: 2
+    duration: "02:24"
+  - title: "Shooting Star"
+    trackNumber: 3
+    duration: "04:08"
+  - title: "No More Running Away"
+    trackNumber: 4
+    duration: "04:22"
+  - title: "Empty Space"
+    trackNumber: 5
+    duration: "03:37"
+  - title: "Time Goes By"
+    trackNumber: 6
+    duration: "04:06"
+  - title: "I Like That"
+    trackNumber: 7
+    duration: "02:26"
+  - title: "Never Even Told Me Her Name"
+    trackNumber: 8
+    duration: "02:44"
+  - title: "Get in Line"
+    trackNumber: 9
+    duration: "02:06"
+  - title: "I Can’t Understand"
+    trackNumber: 10
+    duration: "04:25"
+  - title: "Your Fractured Life / Pee Wee Martini"
+    trackNumber: 11
+    duration: "22:55"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/5025278f-dbe6-33ef-b0e0-af42a6246d2a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Fractured Life is a release by Air Traffic released in 2007-07-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Shooting Star.
+
+

--- a/src/content/releases/a/alice-cooper/billion-dollar-babies/index.md
+++ b/src/content/releases/a/alice-cooper/billion-dollar-babies/index.md
@@ -1,0 +1,31 @@
+﻿---
+title: "Billion Dollar Babies"
+artist: "Alice Cooper"
+releaseDate: "1973"
+releaseType: "Single"
+genres:
+  - "rock"
+labels:
+  - "Warner Bros. Records"
+duration: "0:05:20"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Billion Dollar Babies"
+    trackNumber: 1
+    duration: "03:00"
+  - title: "Mary Ann"
+    trackNumber: 2
+    duration: "02:20"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/440555f6-70a1-3a12-9f6f-671cd84cfb34"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Billion Dollar Babies is a release by Alice Cooper released in 1973. It has been featured on 1 Sundown Sessions show. Featured tracks include No More Mr. Nice Guy.
+
+

--- a/src/content/releases/a/alphabeat/fantastic-six/index.md
+++ b/src/content/releases/a/alphabeat/fantastic-six/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Fantastic Six"
+artist: "Alphabeat"
+releaseDate: "2007"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Fantastic Six is a release by Alphabeat released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include Fantastic Six.
+
+## Tracks Featured on Sundown Sessions
+
+- Fantastic Six
+
+

--- a/src/content/releases/a/angelfish/angelfish/index.md
+++ b/src/content/releases/a/angelfish/angelfish/index.md
@@ -1,0 +1,61 @@
+﻿---
+title: "Angelfish"
+artist: "Angelfish"
+releaseDate: "1993"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "alternative rock"
+  - "post rock"
+  - "alternative"
+  - "post-rock"
+labels:
+  - "Radioactive Records"
+duration: "0:35:45"
+featuredInShows:
+  - "4"
+  - "13"
+shows:
+  - "4"
+  - "13"
+tracks:
+  - title: "Dogs in a Cage"
+    trackNumber: 1
+    duration: "02:33"
+  - title: "Suffocate Me"
+    trackNumber: 2
+    duration: "03:40"
+  - title: "You Can Love Her"
+    trackNumber: 3
+    duration: "03:48"
+  - title: "King of the World"
+    trackNumber: 4
+    duration: "03:01"
+  - title: "Sleep With Me"
+    trackNumber: 5
+    duration: "03:21"
+  - title: "Heartbreak to Hate"
+    trackNumber: 6
+    duration: "04:15"
+  - title: "The Sun Won’t Shine"
+    trackNumber: 7
+    duration: "03:51"
+  - title: "Mummy Can’t Drive"
+    trackNumber: 8
+    duration: "03:26"
+  - title: "Tomorrow Forever"
+    trackNumber: 9
+    duration: "03:28"
+  - title: "The End"
+    trackNumber: 10
+    duration: "04:22"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/b355c98b-66b4-359a-b3ea-32969a617fd0"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Angelfish is a release by Angelfish released in 1993. It has been featured on 2 Sundown Sessions shows. Featured tracks include Mummy Can't Drive, Suffocate Me.
+
+

--- a/src/content/releases/a/attic-lights/friday-night-lights/index.md
+++ b/src/content/releases/a/attic-lights/friday-night-lights/index.md
@@ -1,0 +1,53 @@
+﻿---
+title: "Friday Night Lights"
+artist: "Attic Lights"
+releaseDate: "2008-10-13"
+releaseType: "Album"
+labels:
+  - "Universal Island Records"
+duration: "0:34:47"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "Never Get Sick Of The Sea"
+    trackNumber: 1
+    duration: "03:24"
+  - title: "Bring You Down"
+    trackNumber: 2
+    duration: "03:41"
+  - title: "Wendy"
+    trackNumber: 3
+    duration: "03:29"
+  - title: "Send Those Dark Eyes This Way"
+    trackNumber: 4
+    duration: "02:44"
+  - title: "Nothing But Love"
+    trackNumber: 5
+    duration: "03:48"
+  - title: "God"
+    trackNumber: 6
+    duration: "03:10"
+  - title: "The Dirty Thirst"
+    trackNumber: 7
+    duration: "03:34"
+  - title: "Walkie Talkie"
+    trackNumber: 8
+    duration: "02:33"
+  - title: "Late Night Sunshine"
+    trackNumber: 9
+    duration: "03:59"
+  - title: "Winter On"
+    trackNumber: 10
+    duration: "04:20"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/a86a9a6d-e035-3f54-bf8e-be80466f1562"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Friday Night Lights is a release by Attic Lights released in 2008-10-13. It has been featured on 1 Sundown Sessions show. Featured tracks include The Dirty Thirst.
+
+

--- a/src/content/releases/b/bad-manners/ska-n-b/index.md
+++ b/src/content/releases/b/bad-manners/ska-n-b/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Ska 'N' B"
+artist: "Bad Manners"
+releaseDate: "1980"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Ska 'N' B is a release by Bad Manners released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include Ne-Ne, Na-Na, Na-Na, Nu-Nu.
+
+## Tracks Featured on Sundown Sessions
+
+- Ne-Ne, Na-Na, Na-Na, Nu-Nu
+
+

--- a/src/content/releases/b/balaam-and-the-angel/forces-of-evil-ep/index.md
+++ b/src/content/releases/b/balaam-and-the-angel/forces-of-evil-ep/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Forces of Evil EP"
+artist: "Balaam And The Angel"
+releaseDate: "2024"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Forces of Evil EP is a release by Balaam And The Angel released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Forces of Evil.
+
+## Tracks Featured on Sundown Sessions
+
+- Forces of Evil
+
+

--- a/src/content/releases/b/balaam-and-the-angel/live-free-or-die/index.md
+++ b/src/content/releases/b/balaam-and-the-angel/live-free-or-die/index.md
@@ -1,0 +1,66 @@
+﻿---
+title: "Live Free Or Die"
+artist: "Balaam And The Angel"
+releaseDate: "1988"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "glam"
+  - "new wave"
+  - "rock"
+  - "alternative rock"
+labels:
+  - "Virgin"
+duration: "0:44:15"
+featuredInShows:
+  - "15"
+  - "20"
+shows:
+  - "15"
+  - "20"
+tracks:
+  - title: "I'll Show You Something Special"
+    trackNumber: 1
+    duration: "04:26"
+  - title: "I Love The Things You Do to Me"
+    trackNumber: 2
+    duration: "04:07"
+  - title: "Big City Fun Time Girl"
+    trackNumber: 3
+    duration: "03:37"
+  - title: "On the Run"
+    trackNumber: 4
+    duration: "03:05"
+  - title: "It Goes On"
+    trackNumber: 5
+    duration: "04:35"
+  - title: "Live Free or Die"
+    trackNumber: 6
+    duration: "04:02"
+  - title: "Long Time Loving You"
+    trackNumber: 7
+    duration: "03:54"
+  - title: "Would I Die for You"
+    trackNumber: 8
+    duration: "04:45"
+  - title: "I Won't Be Afraid"
+    trackNumber: 9
+    duration: "04:17"
+  - title: "Running Out of Time"
+    trackNumber: 10
+    duration: "04:03"
+  - title: "You Took My Soul"
+    trackNumber: 11
+  - title: "As Tears Go By"
+    trackNumber: 12
+    duration: "03:24"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/b2590da4-4630-49b5-ba7f-1182c7e6afdc"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Live Free Or Die is a release by Balaam And The Angel released in 1988. It has been featured on 2 Sundown Sessions shows. Featured tracks include I Feel Love, I'll Show You Something Special.
+
+

--- a/src/content/releases/b/balaam-and-the-angel/the-greatest-story-ever-told/index.md
+++ b/src/content/releases/b/balaam-and-the-angel/the-greatest-story-ever-told/index.md
@@ -1,0 +1,63 @@
+﻿---
+title: "The Greatest Story Ever Told"
+artist: "Balaam And The Angel"
+releaseDate: "1986"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "pop"
+  - "rock"
+labels:
+  - "Virgin"
+duration: "0:42:13"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+tracks:
+  - title: "New Kind of Love"
+    trackNumber: 1
+    duration: "04:01"
+  - title: "Don’t Look Down"
+    trackNumber: 2
+    duration: "03:09"
+  - title: "She Knows"
+    trackNumber: 3
+    duration: "03:45"
+  - title: "Burn Me Down"
+    trackNumber: 4
+    duration: "03:59"
+  - title: "Light of the World"
+    trackNumber: 5
+    duration: "03:10"
+  - title: "Slow Down"
+    trackNumber: 6
+    duration: "04:29"
+  - title: "The Wave"
+    trackNumber: 7
+    duration: "03:26"
+  - title: "Warm Again"
+    trackNumber: 8
+    duration: "03:06"
+  - title: "Never End"
+    trackNumber: 9
+    duration: "03:21"
+  - title: "Nothing There at All"
+    trackNumber: 10
+    duration: "02:42"
+  - title: "Walk Away"
+    trackNumber: 11
+    duration: "03:45"
+  - title: "Day and Night"
+    trackNumber: 12
+    duration: "03:16"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/bb623768-6336-4297-811f-bddaf9636ae3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Greatest Story Ever Told is a release by Balaam And The Angel released in 1986. It has been featured on 1 Sundown Sessions show. Featured tracks include The Wave.
+
+

--- a/src/content/releases/b/bauhaus/go-away-white/index.md
+++ b/src/content/releases/b/bauhaus/go-away-white/index.md
@@ -1,0 +1,60 @@
+﻿---
+title: "Go Away White"
+artist: "Bauhaus"
+releaseDate: "2008-03-03"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "rock"
+  - "hard rock"
+  - "gothic rock"
+labels:
+  - "Cooking Vinyl"
+duration: "0:48:58"
+featuredInShows:
+  - "7"
+  - "20"
+shows:
+  - "7"
+  - "20"
+tracks:
+  - title: "Too Much 21st Century"
+    trackNumber: 1
+    duration: "03:53"
+  - title: "Adrenalin"
+    trackNumber: 2
+    duration: "05:39"
+  - title: "Undone"
+    trackNumber: 3
+    duration: "04:46"
+  - title: "International Bulletproof Talent"
+    trackNumber: 4
+    duration: "04:02"
+  - title: "Endless Summer of the Damned"
+    trackNumber: 5
+    duration: "04:44"
+  - title: "Saved"
+    trackNumber: 6
+    duration: "06:27"
+  - title: "Mirror Remains"
+    trackNumber: 7
+    duration: "04:58"
+  - title: "Black Stone Heart"
+    trackNumber: 8
+    duration: "04:32"
+  - title: "The Dog’s a Vapour"
+    trackNumber: 9
+    duration: "06:49"
+  - title: "Zikir"
+    trackNumber: 10
+    duration: "03:04"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/04297c80-a4af-3c3d-8736-0b10ddeb2370"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Go Away White is a release by Bauhaus released in 2008-03-03. It has been featured on 2 Sundown Sessions shows. Featured tracks include International Bullet Proof Talent, Too Much 21st Century.
+
+

--- a/src/content/releases/b/becky-becky/art-school-dancing/index.md
+++ b/src/content/releases/b/becky-becky/art-school-dancing/index.md
@@ -1,0 +1,26 @@
+﻿---
+title: "Art School Dancing"
+artist: "Becky Becky"
+releaseDate: "2015"
+featuredInShows:
+  - "1"
+  - "4"
+  - "6"
+shows:
+  - "1"
+  - "4"
+  - "6"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Art School Dancing is a release by Becky Becky released in 2015. It has been featured on 3 Sundown Sessions shows. Featured tracks include Champagne on Christmas Day, House of the Black Madonna (live), Sparrow.
+
+## Tracks Featured on Sundown Sessions
+
+- Champagne on Christmas Day
+- House of the Black Madonna (live)
+- Sparrow
+
+

--- a/src/content/releases/b/becky-becky/good-morning-midnight/index.md
+++ b/src/content/releases/b/becky-becky/good-morning-midnight/index.md
@@ -1,0 +1,55 @@
+﻿---
+title: "Good Morning, Midnight"
+artist: "Becky Becky"
+releaseDate: "2014-05-01"
+releaseType: "Album"
+genres:
+  - "electronic"
+labels:
+  - "FEINT"
+duration: "0:47:04"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+tracks:
+  - title: "Quite Like Old Times"
+    trackNumber: 1
+    duration: "05:10"
+  - title: "I Remember, I Remember..."
+    trackNumber: 2
+    duration: "03:54"
+  - title: "House of the Black Madonna"
+    trackNumber: 3
+    duration: "04:16"
+  - title: "Tigers Are Better-Looking"
+    trackNumber: 4
+    duration: "03:42"
+  - title: "Mask"
+    trackNumber: 5
+    duration: "03:58"
+  - title: "Fire & Wings"
+    trackNumber: 6
+    duration: "04:09"
+  - title: "When the Dead Come Alive"
+    trackNumber: 7
+    duration: "06:24"
+  - title: "Let Them Call It Jazz"
+    trackNumber: 8
+    duration: "04:59"
+  - title: "Darkness"
+    trackNumber: 9
+    duration: "05:34"
+  - title: "Sophia"
+    trackNumber: 10
+    duration: "04:58"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/64d8d0bc-8c02-4430-b33f-0aabf377d2e0"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Good Morning, Midnight is a release by Becky Becky released in 2014-05-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Tigers Are Better-Looking.
+
+

--- a/src/content/releases/b/big-country/the-crossing/index.md
+++ b/src/content/releases/b/big-country/the-crossing/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "The Crossing"
+artist: "Big Country"
+releaseDate: "1983-07-19"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "adult alternative pop/rock"
+  - "punk/new wave"
+  - "alternative/indie rock"
+  - "pop/rock"
+labels:
+  - "Mercury Records"
+duration: "0:48:59"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "In a Big Country"
+    trackNumber: 1
+    duration: "04:44"
+  - title: "Inwards"
+    trackNumber: 2
+    duration: "04:38"
+  - title: "Chance"
+    trackNumber: 3
+    duration: "04:24"
+  - title: "1000 Stars"
+    trackNumber: 4
+    duration: "03:53"
+  - title: "The Storm"
+    trackNumber: 5
+    duration: "06:21"
+  - title: "Harvest Home"
+    trackNumber: 6
+    duration: "04:20"
+  - title: "Lost Patrol"
+    trackNumber: 7
+    duration: "04:53"
+  - title: "Close Action"
+    trackNumber: 8
+    duration: "04:16"
+  - title: "Fields of Fire"
+    trackNumber: 9
+    duration: "03:32"
+  - title: "Porrohman"
+    trackNumber: 10
+    duration: "07:53"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/54459dcf-4964-3c22-ad08-bb2f4dfa4131"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Crossing is a release by Big Country released in 1983-07-19. It has been featured on 1 Sundown Sessions show. Featured tracks include The Storm.
+
+

--- a/src/content/releases/b/billie-eilish/no-time-to-die/index.md
+++ b/src/content/releases/b/billie-eilish/no-time-to-die/index.md
@@ -1,0 +1,33 @@
+﻿---
+title: "No Time To Die"
+artist: "Billie Eilish"
+releaseDate: "2020-02-13"
+releaseType: "Single"
+genres:
+  - "indie pop"
+  - "pop"
+  - "theme"
+  - "ballad"
+  - "alternative"
+labels:
+  - "Darkroom Records"
+  - "Interscope Records"
+duration: "0:04:02"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "No Time to Die"
+    trackNumber: 1
+    duration: "04:02"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/21991306-db33-4cb1-a722-801b2e310401"
+lastmod: "2026-06-25"
+---
+
+## About
+
+No Time To Die is a release by Billie Eilish released in 2020-02-13. It has been featured on 1 Sundown Sessions show. Featured tracks include No Time To Die.
+
+

--- a/src/content/releases/b/billy-mackenzie/transmission-impossible/index.md
+++ b/src/content/releases/b/billy-mackenzie/transmission-impossible/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "Transmission Impossible"
+artist: "Billy Mackenzie"
+releaseDate: "2004"
+releaseType: "Album"
+labels:
+  - "One Little Indian Records"
+duration: "1:00:28"
+featuredInShows:
+  - "3"
+shows:
+  - "3"
+tracks:
+  - title: "Wild Is The Wind"
+    trackNumber: 1
+    duration: "03:56"
+  - title: "Nocturne Seven"
+    trackNumber: 2
+    duration: "04:35"
+  - title: "Satellite Life"
+    trackNumber: 3
+    duration: "03:13"
+  - title: "Never Turn Your Back On Mother Earth"
+    trackNumber: 4
+    duration: "03:05"
+  - title: "Fourteen Mirrors"
+    trackNumber: 5
+    duration: "04:52"
+  - title: "And This She Knows"
+    trackNumber: 6
+    duration: "03:30"
+  - title: "Liberty Lounge"
+    trackNumber: 7
+    duration: "06:04"
+  - title: "Blue It Is"
+    trackNumber: 8
+    duration: "05:04"
+  - title: "When The World Was Young"
+    trackNumber: 9
+    duration: "05:52"
+  - title: "Beyond The Sun"
+    trackNumber: 10
+    duration: "03:28"
+  - title: "Sing That Song Again"
+    trackNumber: 11
+    duration: "04:58"
+  - title: "At The Edge Of The World"
+    trackNumber: 12
+    duration: "06:58"
+  - title: "Winter Academy"
+    trackNumber: 13
+    duration: "04:19"
+  - title: "Wild Is The Wind (Outtake)"
+    trackNumber: 14
+    duration: "00:34"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/55bdb6cc-6055-4c8e-9c33-948eed8eabd6"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Transmission Impossible is a release by Billy Mackenzie released in 2004. It has been featured on 1 Sundown Sessions show. Featured tracks include Never Turn Your Back On Mother Earth.
+
+

--- a/src/content/releases/b/black/wonderful-life/index.md
+++ b/src/content/releases/b/black/wonderful-life/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Wonderful Life"
+artist: "Black"
+releaseDate: "1987-09-22"
+releaseType: "Album"
+genres:
+  - "pop"
+  - "sophisti-pop"
+  - "new wave"
+  - "pop rock"
+  - "rock"
+labels:
+  - "A&M Records"
+duration: "0:44:53"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Wonderful Life"
+    trackNumber: 1
+    duration: "04:47"
+  - title: "Everything's Coming Up Roses"
+    trackNumber: 2
+    duration: "04:06"
+  - title: "Sometimes For The Asking"
+    trackNumber: 3
+    duration: "04:08"
+  - title: "Finder"
+    trackNumber: 4
+    duration: "04:14"
+  - title: "Paradise"
+    trackNumber: 5
+    duration: "04:52"
+  - title: "I'm Not Afraid"
+    trackNumber: 6
+    duration: "05:01"
+  - title: "I Just Grew Tired"
+    trackNumber: 7
+    duration: "04:15"
+  - title: "Blue"
+    trackNumber: 8
+    duration: "03:39"
+  - title: "Just Making Memories"
+    trackNumber: 9
+    duration: "04:27"
+  - title: "Sweetest Smile"
+    trackNumber: 10
+    duration: "05:19"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/64839f7b-2623-3422-877f-ce1b9b8b217e"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Wonderful Life is a release by Black released in 1987-09-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Blue.
+
+

--- a/src/content/releases/c/chris-isaak/chris-isaak/index.md
+++ b/src/content/releases/c/chris-isaak/chris-isaak/index.md
@@ -1,0 +1,61 @@
+﻿---
+title: "Chris Isaak"
+artist: "Chris Isaak"
+releaseDate: "1986-12"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "blues rock"
+  - "rockabilly"
+  - "rock and roll"
+labels:
+  - "Warner Bros. Records"
+duration: "0:36:16"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "You Owe Me Some Kind of Love"
+    trackNumber: 1
+    duration: "03:52"
+  - title: "Heart Full of Soul"
+    trackNumber: 2
+    duration: "03:20"
+  - title: "Blue Hotel"
+    trackNumber: 3
+    duration: "03:12"
+  - title: "Lie to Me"
+    trackNumber: 4
+    duration: "04:13"
+  - title: "Fade Away"
+    trackNumber: 5
+    duration: "04:16"
+  - title: "Wild Love"
+    trackNumber: 6
+    duration: "02:56"
+  - title: "This Love Will Last"
+    trackNumber: 7
+    duration: "02:46"
+  - title: "You Took My Heart"
+    trackNumber: 8
+    duration: "02:30"
+  - title: "Cryin’"
+    trackNumber: 9
+    duration: "02:32"
+  - title: "Lovers Game"
+    trackNumber: 10
+    duration: "02:55"
+  - title: "Waiting for the Rain to Fall"
+    trackNumber: 11
+    duration: "03:39"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/221c72d2-5f0e-3d48-a487-f03ee609a469"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Chris Isaak is a release by Chris Isaak released in 1986-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Heart Full of Soul.
+
+

--- a/src/content/releases/c/christina-perri/lovestrong/index.md
+++ b/src/content/releases/c/christina-perri/lovestrong/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "lovestrong."
+artist: "Christina Perri"
+releaseDate: "2011-01-01"
+releaseType: "Album"
+genres:
+  - "pop"
+  - "ballad"
+  - "pop rock"
+  - "rock"
+  - "chamber pop"
+labels:
+  - "Atlantic"
+duration: "0:49:25"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+tracks:
+  - title: "Bluebird"
+    trackNumber: 1
+    duration: "03:49"
+  - title: "Arms"
+    trackNumber: 2
+    duration: "04:21"
+  - title: "Bang Bang Bang"
+    trackNumber: 3
+    duration: "03:05"
+  - title: "Distance"
+    trackNumber: 4
+    duration: "03:56"
+  - title: "Jar of Hearts"
+    trackNumber: 5
+    duration: "04:07"
+  - title: "Mine"
+    trackNumber: 6
+    duration: "03:33"
+  - title: "Interlude"
+    trackNumber: 7
+    duration: "00:50"
+  - title: "Penguin"
+    trackNumber: 8
+    duration: "04:36"
+  - title: "Miles"
+    trackNumber: 9
+    duration: "04:04"
+  - title: "The Lonely"
+    trackNumber: 10
+    duration: "03:53"
+  - title: "Sad Song"
+    trackNumber: 11
+    duration: "04:29"
+  - title: "Tragedy"
+    trackNumber: 12
+    duration: "04:42"
+  - title: "Distance"
+    trackNumber: 13
+    duration: "03:55"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/b104f901-89c5-4ddc-b0ae-ad11850f2b3d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+lovestrong. is a release by Christina Perri released in 2011-01-01. It has been featured on 1 Sundown Sessions show. Featured tracks include jar of hearts.
+
+

--- a/src/content/releases/c/cigarettes-after-sex/k/index.md
+++ b/src/content/releases/c/cigarettes-after-sex/k/index.md
@@ -1,0 +1,31 @@
+﻿---
+title: "K."
+artist: "Cigarettes After Sex"
+releaseDate: "2016-11-15"
+releaseType: "Single"
+genres:
+  - "alternative pop"
+  - "ambient pop"
+  - "pop"
+  - "dream pop"
+labels:
+  - "Partisan Records"
+duration: "0:05:16"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "K."
+    trackNumber: 1
+    duration: "05:16"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/bf11ed51-1e04-4da0-8240-deaffe56bd55"
+lastmod: "2026-06-25"
+---
+
+## About
+
+K. is a release by Cigarettes After Sex released in 2016-11-15. It has been featured on 1 Sundown Sessions show. Featured tracks include K..
+
+

--- a/src/content/releases/c/cosmic-rough-riders/enjoy-the-melodic-sunshine/index.md
+++ b/src/content/releases/c/cosmic-rough-riders/enjoy-the-melodic-sunshine/index.md
@@ -1,0 +1,81 @@
+﻿---
+title: "Enjoy the Melodic Sunshine"
+artist: "Cosmic Rough Riders"
+releaseDate: "2000-11-06"
+releaseType: "Album"
+genres:
+  - "folk rock"
+  - "psychedelic rock"
+  - "alternative rock"
+  - "rock"
+  - "pop"
+labels:
+  - "Poptones"
+  - "Trama"
+duration: "0:48:47"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+tracks:
+  - title: "Brothers Gather Round"
+    trackNumber: 1
+    duration: "01:12"
+  - title: "The Gun Isn’t Loaded"
+    trackNumber: 2
+    duration: "02:52"
+  - title: "Glastonbury Revisited"
+    trackNumber: 3
+    duration: "02:47"
+  - title: "Baby, You’re So Free"
+    trackNumber: 4
+    duration: "03:46"
+  - title: "Value of Life"
+    trackNumber: 5
+    duration: "02:39"
+  - title: "Revolution (In the Summertime?)"
+    trackNumber: 6
+    duration: "03:22"
+  - title: "Have You Heard the News Today?"
+    trackNumber: 7
+    duration: "02:52"
+  - title: "Sometime"
+    trackNumber: 8
+    duration: "03:32"
+  - title: "Melanie"
+    trackNumber: 9
+    duration: "03:24"
+  - title: "The Rain Inside"
+    trackNumber: 10
+    duration: "03:23"
+  - title: "The Charm"
+    trackNumber: 11
+    duration: "02:04"
+  - title: "The Loser"
+    trackNumber: 12
+    duration: "02:26"
+  - title: "You’ve Got Me"
+    trackNumber: 13
+    duration: "03:10"
+  - title: "Emily Darling"
+    trackNumber: 14
+    duration: "02:48"
+  - title: "Morning Sun"
+    trackNumber: 15
+    duration: "00:55"
+  - title: "Annie"
+    trackNumber: 16
+    duration: "03:57"
+  - title: "Universal Thing"
+    trackNumber: 17
+    duration: "03:38"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/65475e01-ccb4-3ad5-82cb-24d49c78d17c"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Enjoy the Melodic Sunshine is a release by Cosmic Rough Riders released in 2000-11-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Revolution (In the Summertime?).
+
+

--- a/src/content/releases/c/cousteaux/cousteau/index.md
+++ b/src/content/releases/c/cousteaux/cousteau/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Cousteau"
+artist: "CousteauX"
+releaseDate: "2000"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Cousteau is a release by CousteauX released in 2000. It has been featured on 1 Sundown Sessions show. Featured tracks include Last Good Day Of The Year.
+
+## Tracks Featured on Sundown Sessions
+
+- Last Good Day Of The Year
+
+

--- a/src/content/releases/c/creedence-clearwater-revival/creedence-clearwater-revival-expanded-edition/index.md
+++ b/src/content/releases/c/creedence-clearwater-revival/creedence-clearwater-revival-expanded-edition/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Creedence Clearwater Revival (Expanded Edition)"
+artist: "Creedence Clearwater Revival"
+releaseDate: "1968"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Creedence Clearwater Revival (Expanded Edition) is a release by Creedence Clearwater Revival released in 1968. It has been featured on 1 Sundown Sessions show. Featured tracks include I Put A Spell On You.
+
+## Tracks Featured on Sundown Sessions
+
+- I Put A Spell On You
+
+

--- a/src/content/releases/d/dark-hearts/talk-to-me-of-poison/index.md
+++ b/src/content/releases/d/dark-hearts/talk-to-me-of-poison/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Talk to Me of Poison"
+artist: "Dark Hearts"
+releaseDate: "2024"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Talk to Me of Poison is a release by Dark Hearts released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Talk to Me of Poison.
+
+## Tracks Featured on Sundown Sessions
+
+- Talk to Me of Poison
+
+

--- a/src/content/releases/d/dave-edmunds/repeat-when-necessary/index.md
+++ b/src/content/releases/d/dave-edmunds/repeat-when-necessary/index.md
@@ -1,0 +1,63 @@
+﻿---
+title: "Repeat When Necessary"
+artist: "Dave Edmunds"
+releaseDate: "1979-06-08"
+releaseType: "Album"
+genres:
+  - "pub rock"
+  - "rock & roll"
+  - "rock"
+  - "rock and roll"
+labels:
+  - "Swan Song"
+duration: "0:33:59"
+featuredInShows:
+  - "6"
+  - "15"
+shows:
+  - "6"
+  - "15"
+tracks:
+  - title: "Girls Talk"
+    trackNumber: 1
+    duration: "03:25"
+  - title: "Crawling From the Wreckage"
+    trackNumber: 2
+    duration: "02:53"
+  - title: "The Creature From the Black Lagoon"
+    trackNumber: 3
+    duration: "03:42"
+  - title: "Sweet Little Lisa"
+    trackNumber: 4
+    duration: "03:38"
+  - title: "Dynamite"
+    trackNumber: 5
+    duration: "02:33"
+  - title: "Queen of Hearts"
+    trackNumber: 6
+    duration: "03:17"
+  - title: "Home in My Hand"
+    trackNumber: 7
+    duration: "03:20"
+  - title: "Goodbye Mr. Good Guy"
+    trackNumber: 8
+    duration: "02:40"
+  - title: "Take Me for a Little While"
+    trackNumber: 9
+    duration: "02:39"
+  - title: "We Were Both Wrong"
+    trackNumber: 10
+    duration: "02:42"
+  - title: "Bad Is Bad"
+    trackNumber: 11
+    duration: "03:10"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/17b6f43e-0f1b-3e24-84e7-c01ae0dbc047"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Repeat When Necessary is a release by Dave Edmunds released in 1979-06-08. It has been featured on 2 Sundown Sessions shows. Featured tracks include Crawling From The Wreckage, Girls Talk.
+
+

--- a/src/content/releases/d/dave-gahan/paper-monsters-u-s-version/index.md
+++ b/src/content/releases/d/dave-gahan/paper-monsters-u-s-version/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Paper Monsters (U.S. Version)"
+artist: "Dave Gahan"
+releaseDate: "2003"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Paper Monsters (U.S. Version) is a release by Dave Gahan released in 2003. It has been featured on 1 Sundown Sessions show. Featured tracks include Dirty Sticky Floors.
+
+## Tracks Featured on Sundown Sessions
+
+- Dirty Sticky Floors
+
+

--- a/src/content/releases/d/david-bowie/laughing-with-liza/index.md
+++ b/src/content/releases/d/david-bowie/laughing-with-liza/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Laughing with Liza"
+artist: "David Bowie"
+releaseDate: "2023"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Laughing with Liza is a release by David Bowie released in 2023. It has been featured on 1 Sundown Sessions show. Featured tracks include The Laughing Gnome.
+
+## Tracks Featured on Sundown Sessions
+
+- The Laughing Gnome
+
+

--- a/src/content/releases/d/david-latto/geordie-munro/index.md
+++ b/src/content/releases/d/david-latto/geordie-munro/index.md
@@ -1,0 +1,24 @@
+﻿---
+title: "Geordie Munro"
+artist: "David Latto"
+releaseDate: "2022"
+featuredInShows:
+  - "1"
+  - "2"
+  - "3"
+shows:
+  - "1"
+  - "2"
+  - "3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Geordie Munro is a release by David Latto released in 2022. It has been featured on 3 Sundown Sessions shows. Featured tracks include Geordie Munro.
+
+## Tracks Featured on Sundown Sessions
+
+- Geordie Munro
+
+

--- a/src/content/releases/d/dean-martin/dino-the-essential-dean-martin/index.md
+++ b/src/content/releases/d/dean-martin/dino-the-essential-dean-martin/index.md
@@ -1,0 +1,120 @@
+﻿---
+title: "Dino: The Essential Dean Martin"
+artist: "Dean Martin"
+releaseDate: "2004-01-06"
+releaseType: "Album"
+genres:
+  - "vocal"
+  - "big band"
+  - "swing"
+  - "pop"
+  - "ballad"
+labels:
+  - "Capitol Records"
+  - "EMI"
+duration: "1:18:13"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Ain’t That a Kick in the Head"
+    trackNumber: 1
+    duration: "02:24"
+  - title: "That’s Amore"
+    trackNumber: 2
+    duration: "03:07"
+  - title: "Memories Are Made of This"
+    trackNumber: 3
+    duration: "02:16"
+  - title: "Just in Time"
+    trackNumber: 4
+    duration: "02:13"
+  - title: "Sway"
+    trackNumber: 5
+    duration: "02:42"
+  - title: "I’d Cry Like a Baby"
+    trackNumber: 6
+    duration: "02:35"
+  - title: "Volare (Nel blu dipinto di blu)"
+    trackNumber: 7
+    duration: "02:59"
+  - title: "Under the Bridges of Paris"
+    trackNumber: 8
+    duration: "02:46"
+  - title: "Love Me, Love Me"
+    trackNumber: 9
+    duration: "02:34"
+  - title: "If"
+    trackNumber: 10
+    duration: "02:46"
+  - title: "Mambo Italiano"
+    trackNumber: 11
+    duration: "02:19"
+  - title: "Let Me Go Lover"
+    trackNumber: 12
+    duration: "03:00"
+  - title: "Standing on the Corner"
+    trackNumber: 13
+    duration: "02:47"
+  - title: "You Belong to Me"
+    trackNumber: 14
+    duration: "03:02"
+  - title: "Powder Your Face With Sunshine (Smile! Smile! Smile!)"
+    trackNumber: 15
+    duration: "02:32"
+  - title: "Innamorata (Sweetheart)"
+    trackNumber: 16
+    duration: "02:24"
+  - title: "I’ll Always Love You (Day After Day)"
+    trackNumber: 17
+    duration: "02:33"
+  - title: "Kiss"
+    trackNumber: 18
+    duration: "02:22"
+  - title: "You’re Nobody ’Til Somebody Loves You"
+    trackNumber: 19
+    duration: "02:12"
+  - title: "Return to Me (Ritorna‐Me)"
+    trackNumber: 20
+    duration: "02:23"
+  - title: "The Door Is Still Open (to My Heart)"
+    trackNumber: 21
+    duration: "02:53"
+  - title: "Houston"
+    trackNumber: 22
+    duration: "02:41"
+  - title: "Send Me the Pillow You Dream On"
+    trackNumber: 23
+    duration: "02:29"
+  - title: "Everybody Loves Somebody"
+    trackNumber: 24
+    duration: "02:45"
+  - title: "In the Chapel in the Moonlight"
+    trackNumber: 25
+    duration: "02:32"
+  - title: "I Will"
+    trackNumber: 26
+    duration: "02:22"
+  - title: "Little Old Wine Drinker, Me"
+    trackNumber: 27
+    duration: "02:48"
+  - title: "Somewhere There’s a Someone"
+    trackNumber: 28
+    duration: "02:14"
+  - title: "In the Misty Moonlight"
+    trackNumber: 29
+    duration: "02:44"
+  - title: "Gentle on My Mind"
+    trackNumber: 30
+    duration: "02:35"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/aa057e81-3c57-3907-87d1-aadb872c3181"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Dino: The Essential Dean Martin is a release by Dean Martin released in 2004-01-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Return To Me.
+
+

--- a/src/content/releases/d/death-cult/ghost-dance/index.md
+++ b/src/content/releases/d/death-cult/ghost-dance/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "Ghost Dance"
+artist: "Death Cult"
+releaseDate: "1996"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "rock"
+labels:
+  - "Beggars Banquet"
+duration: "0:35:44"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Gods Zoo"
+    trackNumber: 1
+    duration: "03:27"
+  - title: "Brothers Grimm"
+    trackNumber: 2
+    duration: "03:32"
+  - title: "Ghost Dance"
+    trackNumber: 3
+    duration: "03:58"
+  - title: "Horse Nation"
+    trackNumber: 4
+    duration: "03:25"
+  - title: "Christians"
+    trackNumber: 5
+    duration: "03:48"
+  - title: "A Flower in the Desert"
+    trackNumber: 6
+    duration: "03:14"
+  - title: "Too Young"
+    trackNumber: 7
+    duration: "02:56"
+  - title: "Butterflies"
+    trackNumber: 8
+    duration: "02:47"
+  - title: "With Love"
+    trackNumber: 9
+    duration: "03:25"
+  - title: "Gods Zoo (These Times)"
+    trackNumber: 10
+    duration: "05:08"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/b33a04dc-3032-3fee-a52f-c681c0c07e8d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Ghost Dance is a release by Death Cult released in 1996. It has been featured on 1 Sundown Sessions show. Featured tracks include A Flower In The Desert.
+
+

--- a/src/content/releases/d/death-in-vegas/edgar-card-sampler/index.md
+++ b/src/content/releases/d/death-in-vegas/edgar-card-sampler/index.md
@@ -1,0 +1,41 @@
+﻿---
+title: "Edgar Card Sampler"
+artist: "Death In Vegas"
+releaseDate: "2002-12-18"
+releaseType: "Album"
+labels:
+  - "Arista"
+duration: "0:34:12"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Hands Around My Throat - D.I.V."
+    trackNumber: 1
+    duration: "05:07"
+  - title: "Scorpio Rising"
+    trackNumber: 2
+    duration: "05:37"
+  - title: "Killing Smile"
+    trackNumber: 3
+    duration: "04:49"
+  - title: "So You Say You Lost Your Baby"
+    trackNumber: 4
+    duration: "02:58"
+  - title: "Diving Horses"
+    trackNumber: 5
+    duration: "05:11"
+  - title: "Help Yourself"
+    trackNumber: 6
+    duration: "10:28"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/47c5a998-0638-4a54-a87d-b6a432d309f9"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Edgar Card Sampler is a release by Death In Vegas released in 2002-12-18. It has been featured on 1 Sundown Sessions show. Featured tracks include So You Say You Lost Your Baby.
+
+

--- a/src/content/releases/d/del-shannon/rock-on/index.md
+++ b/src/content/releases/d/del-shannon/rock-on/index.md
@@ -1,0 +1,60 @@
+﻿---
+title: "Rock On!"
+artist: "Del Shannon"
+releaseDate: "1991"
+releaseType: "Album"
+genres:
+  - "rock & roll"
+  - "pop/rock"
+  - "contemporary pop/rock"
+  - "rock and roll"
+  - "rock"
+labels:
+  - "MCA Records"
+  - "Gone Gator Records"
+duration: "0:36:27"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "Walk Away"
+    trackNumber: 1
+    duration: "03:39"
+  - title: "Who Left Who"
+    trackNumber: 2
+    duration: "03:22"
+  - title: "Are You Lovin' Me Too"
+    trackNumber: 3
+    duration: "03:16"
+  - title: "Callin' Out My Name"
+    trackNumber: 4
+    duration: "03:46"
+  - title: "I Go to Pieces"
+    trackNumber: 5
+    duration: "04:01"
+  - title: "Lost in a Memory"
+    trackNumber: 6
+    duration: "03:37"
+  - title: "I Got You (The Birds' Song)"
+    trackNumber: 7
+    duration: "03:43"
+  - title: "What Kind of Fool Do You Think I Am?"
+    trackNumber: 8
+    duration: "03:11"
+  - title: "When I Had You"
+    trackNumber: 9
+    duration: "04:18"
+  - title: "Let's Dance"
+    trackNumber: 10
+    duration: "03:31"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/8cb200dd-7e5d-3f3c-ad82-ffc47148ba1c"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Rock On! is a release by Del Shannon released in 1991. It has been featured on 1 Sundown Sessions show. Featured tracks include Lost In A Memory.
+
+

--- a/src/content/releases/d/del-shannon/runaway-the-very-best-of-del-shannon/index.md
+++ b/src/content/releases/d/del-shannon/runaway-the-very-best-of-del-shannon/index.md
@@ -1,0 +1,113 @@
+﻿---
+title: "Runaway: The Very Best Of Del Shannon"
+artist: "Del Shannon"
+releaseDate: "2002-01-22"
+releaseType: "Album"
+labels:
+  - "Collectables"
+duration: "1:10:23"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+tracks:
+  - title: "Runaway"
+    trackNumber: 1
+    duration: "02:19"
+  - title: "From Me to You"
+    trackNumber: 2
+    duration: "01:56"
+  - title: "Little Town Flirt"
+    trackNumber: 3
+    duration: "02:49"
+  - title: "Jody"
+    trackNumber: 4
+    duration: "02:25"
+  - title: "I Go to Pieces"
+    trackNumber: 5
+    duration: "02:28"
+  - title: "Happiness"
+    trackNumber: 6
+    duration: "02:22"
+  - title: "Do You Wanna Dance?"
+    trackNumber: 7
+    duration: "02:32"
+  - title: "(Marie’s the Name) His Latest Flame"
+    trackNumber: 8
+    duration: "02:22"
+  - title: "Hats Off to Larry"
+    trackNumber: 9
+    duration: "02:02"
+  - title: "Go Away Little Girl"
+    trackNumber: 10
+    duration: "02:19"
+  - title: "Ginny in the Mirror"
+    trackNumber: 11
+    duration: "02:10"
+  - title: "Don’t Gild the Lily, Lily"
+    trackNumber: 12
+    duration: "02:20"
+  - title: "Keep Searchin’ (We’ll Follow the Sun)"
+    trackNumber: 13
+    duration: "02:09"
+  - title: "Kelly"
+    trackNumber: 14
+    duration: "02:37"
+  - title: "Runaround Sue"
+    trackNumber: 15
+    duration: "02:38"
+  - title: "Stranger in Town"
+    trackNumber: 16
+    duration: "02:31"
+  - title: "Running Scared"
+    trackNumber: 17
+    duration: "02:17"
+  - title: "Hey Little Girl"
+    trackNumber: 18
+    duration: "02:31"
+  - title: "The Swiss Maid"
+    trackNumber: 19
+    duration: "02:07"
+  - title: "Handy Man"
+    trackNumber: 20
+    duration: "02:14"
+  - title: "Dream Baby"
+    trackNumber: 21
+    duration: "02:34"
+  - title: "Two Kinds of Teardrops"
+    trackNumber: 22
+    duration: "02:31"
+  - title: "That’s the Way Love Is"
+    trackNumber: 23
+    duration: "02:27"
+  - title: "So Long Baby"
+    trackNumber: 24
+    duration: "02:02"
+  - title: "Two Silhouettes"
+    trackNumber: 25
+    duration: "02:20"
+  - title: "Misery"
+    trackNumber: 26
+    duration: "01:59"
+  - title: "I Won’t Be There"
+    trackNumber: 27
+    duration: "02:04"
+  - title: "Lies"
+    trackNumber: 28
+    duration: "02:39"
+  - title: "Cry Myself to Sleep"
+    trackNumber: 29
+    duration: "02:22"
+  - title: "Runaway (alternate take)"
+    trackNumber: 30
+    duration: "02:17"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e10752dd-248d-3d20-953e-1f108d15d48e"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Runaway: The Very Best Of Del Shannon is a release by Del Shannon released in 2002-01-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Runaway.
+
+

--- a/src/content/releases/d/delays/you-see-colours/index.md
+++ b/src/content/releases/d/delays/you-see-colours/index.md
@@ -1,0 +1,61 @@
+﻿---
+title: "You See Colours"
+artist: "Delays"
+releaseDate: "2006-03-06"
+releaseType: "Album"
+genres:
+  - "indie; alternative; indie rock; indie pop"
+  - "indie; indie rock; indie pop; alternative; power pop"
+  - "rock"
+  - "rock and indie"
+labels:
+  - "Rough Trade"
+duration: "0:40:12"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "You and Me"
+    trackNumber: 1
+    duration: "04:43"
+  - title: "Valentine"
+    trackNumber: 2
+    duration: "04:52"
+  - title: "This Town's Religion"
+    trackNumber: 3
+    duration: "03:08"
+  - title: "Sink Like a Stone"
+    trackNumber: 4
+    duration: "03:05"
+  - title: "Too Much in Your Life"
+    trackNumber: 5
+    duration: "04:38"
+  - title: "Winter's Memory of Summer"
+    trackNumber: 6
+    duration: "03:10"
+  - title: "Given Time"
+    trackNumber: 7
+    duration: "03:00"
+  - title: "Hideaway"
+    trackNumber: 8
+    duration: "03:48"
+  - title: "Lillian"
+    trackNumber: 9
+    duration: "03:01"
+  - title: "Out of Nowhere"
+    trackNumber: 10
+    duration: "02:46"
+  - title: "Waste of Space"
+    trackNumber: 11
+    duration: "03:56"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/bc74fb82-12ac-36fd-854c-56964b8464ef"
+lastmod: "2026-06-25"
+---
+
+## About
+
+You See Colours is a release by Delays released in 2006-03-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Valentine.
+
+

--- a/src/content/releases/d/depeche-mode/speak-and-spell/index.md
+++ b/src/content/releases/d/depeche-mode/speak-and-spell/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "Speak & Spell"
+artist: "Depeche Mode"
+releaseDate: "1981-10-05"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "synthpop"
+  - "electronic"
+  - "synth pop"
+  - "new romantic"
+labels:
+  - "Mute"
+duration: "0:39:40"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "New Life"
+    trackNumber: 1
+    duration: "03:43"
+  - title: "I Sometimes Wish I Was Dead"
+    trackNumber: 2
+    duration: "02:14"
+  - title: "Puppets"
+    trackNumber: 3
+    duration: "03:55"
+  - title: "Boys Say Go!"
+    trackNumber: 4
+    duration: "03:03"
+  - title: "Nodisco"
+    trackNumber: 5
+    duration: "04:11"
+  - title: "What's Your Name?"
+    trackNumber: 6
+    duration: "02:41"
+  - title: "Photographic"
+    trackNumber: 7
+    duration: "04:44"
+  - title: "Tora! Tora! Tora!"
+    trackNumber: 8
+    duration: "04:34"
+  - title: "Big Muff"
+    trackNumber: 9
+    duration: "04:20"
+  - title: "Any Second Now (Voices)"
+    trackNumber: 10
+    duration: "02:35"
+  - title: "Just Can't Get Enough"
+    trackNumber: 11
+    duration: "03:40"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/7a0e0366-91f4-3444-b45a-83b158004165"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Speak & Spell is a release by Depeche Mode released in 1981-10-05. It has been featured on 1 Sundown Sessions show. Featured tracks include New Life.
+
+

--- a/src/content/releases/d/donovan/greatest-hitsa-and-more/index.md
+++ b/src/content/releases/d/donovan/greatest-hitsa-and-more/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Greatest Hitsâ€¦ and More"
+artist: "Donovan"
+releaseDate: "1989"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Greatest Hitsâ€¦ and More is a release by Donovan released in 1989. It has been featured on 1 Sundown Sessions show. Featured tracks include Hurdy Gurdy Man.
+
+## Tracks Featured on Sundown Sessions
+
+- Hurdy Gurdy Man
+
+

--- a/src/content/releases/d/dr-feelgood/the-ua-years/index.md
+++ b/src/content/releases/d/dr-feelgood/the-ua-years/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The UA Years"
+artist: "Dr Feelgood"
+releaseDate: "1989"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The UA Years is a release by Dr Feelgood released in 1989. It has been featured on 1 Sundown Sessions show. Featured tracks include Roxette.
+
+## Tracks Featured on Sundown Sessions
+
+- Roxette
+
+

--- a/src/content/releases/d/dragons/here-are-the-roses/index.md
+++ b/src/content/releases/d/dragons/here-are-the-roses/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Here Are The Roses"
+artist: "Dragons"
+releaseDate: "2007-05-30"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "00s"
+  - "male vocalists"
+  - "new wave"
+  - "rock"
+labels:
+  - "OHM Recordings"
+duration: "0:43:02"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Here Are the Roses"
+    trackNumber: 1
+    duration: "04:30"
+  - title: "Condition"
+    trackNumber: 2
+    duration: "03:37"
+  - title: "Treasure"
+    trackNumber: 3
+    duration: "04:09"
+  - title: "Obedience"
+    trackNumber: 4
+    duration: "04:26"
+  - title: "Trust"
+    trackNumber: 5
+    duration: "04:26"
+  - title: "Epiphany"
+    trackNumber: 6
+    duration: "03:54"
+  - title: "Lonely Tonight"
+    trackNumber: 7
+    duration: "03:48"
+  - title: "Remembrance"
+    trackNumber: 8
+    duration: "04:23"
+  - title: "Where Is the Love?"
+    trackNumber: 9
+    duration: "04:15"
+  - title: "Forever"
+    trackNumber: 10
+    duration: "05:34"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/f7b82e4d-09b8-3eeb-9061-b3b278abedf4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Here Are The Roses is a release by Dragons released in 2007-05-30. It has been featured on 1 Sundown Sessions show. Featured tracks include Condition.
+
+

--- a/src/content/releases/d/duran-duran/duran-duran/index.md
+++ b/src/content/releases/d/duran-duran/duran-duran/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Duran Duran"
+artist: "Duran Duran"
+releaseDate: "1993-02-11"
+releaseType: "Album"
+genres:
+  - "pop"
+  - "pop rock"
+  - "rock"
+  - "synth-pop"
+  - "alternative rock"
+labels:
+  - "Parlophone"
+duration: "1:02:36"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+tracks:
+  - title: "Too Much Information"
+    trackNumber: 1
+    duration: "04:56"
+  - title: "Ordinary World"
+    trackNumber: 2
+    duration: "05:40"
+  - title: "Love Voodoo"
+    trackNumber: 3
+    duration: "04:58"
+  - title: "Drowning Man"
+    trackNumber: 4
+    duration: "05:14"
+  - title: "Shotgun"
+    trackNumber: 5
+    duration: "00:54"
+  - title: "Come Undone"
+    trackNumber: 6
+    duration: "04:38"
+  - title: "Breath After Breath"
+    trackNumber: 7
+    duration: "04:58"
+  - title: "U.M.F."
+    trackNumber: 8
+    duration: "05:34"
+  - title: "Femme Fatale"
+    trackNumber: 9
+    duration: "04:22"
+  - title: "None of the Above"
+    trackNumber: 10
+    duration: "05:18"
+  - title: "Shelter"
+    trackNumber: 11
+    duration: "04:24"
+  - title: "To Whom It May Concern"
+    trackNumber: 12
+    duration: "04:23"
+  - title: "Sin of the City"
+    trackNumber: 13
+    duration: "07:17"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/faedc66c-59ae-36ee-a89d-9dda4a9ea393"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Duran Duran is a release by Duran Duran released in 1993-02-11. It has been featured on 1 Sundown Sessions show. Featured tracks include Planet Earth.
+
+

--- a/src/content/releases/e/electric-light-orchestra/discovery/index.md
+++ b/src/content/releases/e/electric-light-orchestra/discovery/index.md
@@ -1,0 +1,46 @@
+﻿---
+title: "Discovery"
+artist: "Electric Light Orchestra"
+releaseDate: "1979-05-21"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "pop rock"
+  - "disco"
+  - "album rock"
+  - "progressive pop"
+labels:
+  - "Epic"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Brilla Un Pequeño Amor = Shine a Little Love"
+    trackNumber: 1
+  - title: "Confusión"
+    trackNumber: 2
+  - title: "Necesito Su Amor = Need Her Love"
+    trackNumber: 3
+  - title: "El Diario de Horace Wimp = The Diary of Horace Wimp"
+    trackNumber: 4
+  - title: "Último Tren a Londres = Last Train to London"
+    trackNumber: 5
+  - title: "Tristeza de Medianoche = Midnight Blue"
+    trackNumber: 6
+  - title: "Corriendo = On the Run"
+    trackNumber: 7
+  - title: "Deseando = Wishing"
+    trackNumber: 8
+  - title: "No Me Defraudes = Don’t Bring Me Down"
+    trackNumber: 9
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e4f25e55-94d2-3037-a826-b3610490ea2d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Discovery is a release by Electric Light Orchestra released in 1979-05-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Don't Bring Me Down.
+
+

--- a/src/content/releases/e/electric-light-orchestra/electric-light-orchestra/index.md
+++ b/src/content/releases/e/electric-light-orchestra/electric-light-orchestra/index.md
@@ -1,0 +1,40 @@
+﻿---
+title: "Electric Light Orchestra"
+artist: "Electric Light Orchestra"
+releaseDate: "1984"
+releaseType: "EP"
+genres:
+  - "classic rock"
+  - "symphonic rock"
+  - "rock"
+  - "pop"
+labels:
+  - "AMIGA"
+duration: "0:14:34"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Livin’ Thing"
+    trackNumber: 1
+    duration: "03:38"
+  - title: "Ma‐Ma‐Ma Belle"
+    trackNumber: 2
+    duration: "03:33"
+  - title: "Showdown"
+    trackNumber: 3
+    duration: "04:11"
+  - title: "Rockaria"
+    trackNumber: 4
+    duration: "03:12"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/ef8a5104-df8d-4cbc-838f-0a6f615b807d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Electric Light Orchestra is a release by Electric Light Orchestra released in 1984. It has been featured on 1 Sundown Sessions show. Featured tracks include 10538 Overture.
+
+

--- a/src/content/releases/e/electric-light-orchestra/out-of-the-blue/index.md
+++ b/src/content/releases/e/electric-light-orchestra/out-of-the-blue/index.md
@@ -1,0 +1,81 @@
+﻿---
+title: "Out of the Blue"
+artist: "Electric Light Orchestra"
+releaseDate: "1977-10-28"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "symphonic rock"
+  - "art rock"
+  - "pop rock"
+  - "progressive pop"
+labels:
+  - "Jet Records"
+  - "United Artists"
+duration: "1:10:12"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Turn to Stone"
+    trackNumber: 1
+    duration: "03:42"
+  - title: "It’s Over"
+    trackNumber: 2
+    duration: "04:08"
+  - title: "Sweet Talkin’ Woman"
+    trackNumber: 3
+    duration: "03:48"
+  - title: "Across the Border"
+    trackNumber: 4
+    duration: "03:52"
+  - title: "Night in the City"
+    trackNumber: 5
+    duration: "04:02"
+  - title: "Starlight"
+    trackNumber: 6
+    duration: "04:30"
+  - title: "Jungle"
+    trackNumber: 7
+    duration: "03:51"
+  - title: "Believe Me Now"
+    trackNumber: 8
+    duration: "01:21"
+  - title: "Steppin’ Out"
+    trackNumber: 9
+    duration: "04:38"
+  - title: "Standin’ in the Rain"
+    trackNumber: 1
+    duration: "04:20"
+  - title: "Big Wheels"
+    trackNumber: 2
+    duration: "05:10"
+  - title: "Summer and Lightning"
+    trackNumber: 3
+    duration: "04:13"
+  - title: "Mr. Blue Sky"
+    trackNumber: 4
+    duration: "05:05"
+  - title: "Sweet Is the Night"
+    trackNumber: 5
+    duration: "03:26"
+  - title: "The Whale"
+    trackNumber: 6
+    duration: "05:05"
+  - title: "Birmingham Blues"
+    trackNumber: 7
+    duration: "04:21"
+  - title: "Wild West Hero"
+    trackNumber: 8
+    duration: "04:40"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/a720436f-9c8e-439a-a147-18e83441edab"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Out of the Blue is a release by Electric Light Orchestra released in 1977-10-28. It has been featured on 1 Sundown Sessions show. Featured tracks include Mr. Blue Sky.
+
+

--- a/src/content/releases/e/electric-light-orchestra/secret-messages/index.md
+++ b/src/content/releases/e/electric-light-orchestra/secret-messages/index.md
@@ -1,0 +1,29 @@
+﻿---
+title: "Secret Messages"
+artist: "Electric Light Orchestra"
+releaseDate: "1983"
+releaseType: "Single"
+labels:
+  - "Jet Records"
+duration: "0:07:26"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+tracks:
+  - title: "Secret Messages"
+    trackNumber: 1
+    duration: "03:33"
+  - title: "Buildings Have Eyes"
+    trackNumber: 2
+    duration: "03:53"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/359cad21-cf63-48f9-ada7-54a700aab9c8"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Secret Messages is a release by Electric Light Orchestra released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Four Little Diamonds.
+
+

--- a/src/content/releases/e/electric-six/fire/index.md
+++ b/src/content/releases/e/electric-six/fire/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Fire"
+artist: "Electric Six"
+releaseDate: "2003-05-19"
+releaseType: "Album"
+genres:
+  - "funk rock"
+  - "rock pop"
+  - "synth-pop"
+  - "alternative"
+  - "electronic"
+labels:
+  - "XL Recordings"
+duration: "0:38:05"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+tracks:
+  - title: "Dance Commander"
+    trackNumber: 1
+    duration: "02:36"
+  - title: "Electric Demons in Love"
+    trackNumber: 2
+    duration: "03:06"
+  - title: "Naked Pictures (of Your Mother)"
+    trackNumber: 3
+    duration: "02:11"
+  - title: "Danger! High Voltage"
+    trackNumber: 4
+    duration: "03:34"
+  - title: "She's White"
+    trackNumber: 5
+    duration: "03:16"
+  - title: "I Invented the Night"
+    trackNumber: 6
+    duration: "03:17"
+  - title: "Improper Dancing"
+    trackNumber: 7
+    duration: "03:14"
+  - title: "Gay Bar"
+    trackNumber: 8
+    duration: "02:20"
+  - title: "Nuclear War (on the dance Floor)"
+    trackNumber: 9
+    duration: "01:15"
+  - title: "Getting Into the Jam"
+    trackNumber: 10
+    duration: "02:14"
+  - title: "Vengeance and Fashion"
+    trackNumber: 11
+    duration: "02:46"
+  - title: "I'm the Bomb"
+    trackNumber: 12
+    duration: "04:18"
+  - title: "Synthesizer"
+    trackNumber: 13
+    duration: "03:58"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/83a4b2ba-5a6c-3483-b0a0-1c539c6c6c94"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Fire is a release by Electric Six released in 2003-05-19. It has been featured on 1 Sundown Sessions show. Featured tracks include Synthesizer.
+
+

--- a/src/content/releases/e/elvis-costello/my-aim-is-true/index.md
+++ b/src/content/releases/e/elvis-costello/my-aim-is-true/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "My Aim Is True"
+artist: "Elvis Costello"
+releaseDate: "1977-07-22"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "new wave"
+  - "pub rock"
+  - "pop rock"
+  - "rock & roll"
+labels:
+  - "Stiff Records"
+duration: "0:32:53"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Welcome to the Working Week"
+    trackNumber: 1
+    duration: "01:23"
+  - title: "Miracle Man"
+    trackNumber: 2
+    duration: "03:32"
+  - title: "No Dancing"
+    trackNumber: 3
+    duration: "02:42"
+  - title: "Blame It on Cain"
+    trackNumber: 4
+    duration: "02:53"
+  - title: "Alison"
+    trackNumber: 5
+    duration: "03:26"
+  - title: "Sneaky Feelings"
+    trackNumber: 6
+    duration: "02:10"
+  - title: "(The Angels Wanna Wear My) Red Shoes"
+    trackNumber: 7
+    duration: "02:50"
+  - title: "Less Than Zero"
+    trackNumber: 8
+    duration: "03:15"
+  - title: "Mystery Dance"
+    trackNumber: 9
+    duration: "01:38"
+  - title: "Pay It Back"
+    trackNumber: 10
+    duration: "02:35"
+  - title: "I’m Not Angry"
+    trackNumber: 11
+    duration: "03:01"
+  - title: "Waiting for the End of the World"
+    trackNumber: 12
+    duration: "03:22"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/c7a4740f-2729-3895-8498-08c521886a95"
+lastmod: "2026-06-25"
+---
+
+## About
+
+My Aim Is True is a release by Elvis Costello released in 1977-07-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Watching The Detectives.
+
+

--- a/src/content/releases/e/ennio-morricone/the-good-the-bad-and-the-ugly/index.md
+++ b/src/content/releases/e/ennio-morricone/the-good-the-bad-and-the-ugly/index.md
@@ -1,0 +1,23 @@
+﻿---
+title: "The Good, The Bad and The Ugly"
+artist: "Ennio Morricone"
+releaseDate: "1966"
+featuredInShows:
+  - "6"
+  - "10"
+shows:
+  - "6"
+  - "10"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Good, The Bad and The Ugly is a release by Ennio Morricone released in 1966. It has been featured on 2 Sundown Sessions shows. Featured tracks include The Ecstasy Of Gold, The Good, The Bad and The Ugly.
+
+## Tracks Featured on Sundown Sessions
+
+- The Ecstasy Of Gold
+- The Good, The Bad and The Ugly
+
+

--- a/src/content/releases/e/eric-clapton/journeyman/index.md
+++ b/src/content/releases/e/eric-clapton/journeyman/index.md
@@ -1,0 +1,66 @@
+﻿---
+title: "Journeyman"
+artist: "Eric Clapton"
+releaseDate: "1989-10-23"
+releaseType: "Album"
+genres:
+  - "blues rock"
+  - "rock"
+  - "album rock"
+  - "hard rock"
+  - "pop/rock"
+labels:
+  - "Reprise Records"
+  - "Duck Records"
+duration: "0:56:58"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+tracks:
+  - title: "Pretending"
+    trackNumber: 1
+    duration: "04:44"
+  - title: "Anything for Your Love"
+    trackNumber: 2
+    duration: "04:10"
+  - title: "Bad Love"
+    trackNumber: 3
+    duration: "05:14"
+  - title: "Running on Faith"
+    trackNumber: 4
+    duration: "05:33"
+  - title: "Hard Times"
+    trackNumber: 5
+    duration: "03:14"
+  - title: "Hound Dog"
+    trackNumber: 6
+    duration: "02:27"
+  - title: "No Alibis"
+    trackNumber: 7
+    duration: "05:38"
+  - title: "Run So Far"
+    trackNumber: 8
+    duration: "04:07"
+  - title: "Old Love"
+    trackNumber: 9
+    duration: "06:24"
+  - title: "Breaking Point"
+    trackNumber: 10
+    duration: "05:32"
+  - title: "Lead Me On"
+    trackNumber: 11
+    duration: "05:52"
+  - title: "Before You Accuse Me"
+    trackNumber: 12
+    duration: "03:56"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/700072d4-ea59-36fc-bc62-e90b7282aa0c"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Journeyman is a release by Eric Clapton released in 1989-10-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Bad Love.
+
+

--- a/src/content/releases/e/extreme/iii-sides-to-every-story/index.md
+++ b/src/content/releases/e/extreme/iii-sides-to-every-story/index.md
@@ -1,0 +1,73 @@
+﻿---
+title: "III Sides To Every Story"
+artist: "Extreme"
+releaseDate: "1992-08-20"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "rock"
+  - "pop-metal"
+  - "contemporary pop/rock"
+  - "pop/rock"
+labels:
+  - "A&M Records"
+duration: "1:16:09"
+featuredInShows:
+  - "12"
+  - "46"
+shows:
+  - "12"
+  - "46"
+tracks:
+  - title: "Warheads"
+    trackNumber: 1
+    duration: "05:18"
+  - title: "Rest in Peace"
+    trackNumber: 2
+    duration: "06:01"
+  - title: "Politicalamity"
+    trackNumber: 3
+    duration: "05:04"
+  - title: "Color Me Blind"
+    trackNumber: 4
+    duration: "05:00"
+  - title: "Cupid’s Dead"
+    trackNumber: 5
+    duration: "05:56"
+  - title: "Peacemaker Die"
+    trackNumber: 6
+    duration: "06:03"
+  - title: "Seven Sundays"
+    trackNumber: 7
+    duration: "04:18"
+  - title: "Tragic Comic"
+    trackNumber: 8
+    duration: "04:44"
+  - title: "Our Father"
+    trackNumber: 9
+    duration: "04:02"
+  - title: "Stop the World"
+    trackNumber: 10
+    duration: "05:57"
+  - title: "God Isn’t Dead?"
+    trackNumber: 11
+    duration: "02:02"
+  - title: "Everything Under the Sun: I. Rise ’n Shine"
+    trackNumber: 12
+    duration: "06:22"
+  - title: "Everything Under the Sun: II. Am I Ever Gonna Change"
+    trackNumber: 13
+    duration: "06:56"
+  - title: "Everything Under the Sun: III. Who Cares?"
+    trackNumber: 14
+    duration: "08:19"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/2f7495c0-db22-38bd-be93-d7e3d9a00194"
+lastmod: "2026-06-25"
+---
+
+## About
+
+III Sides To Every Story is a release by Extreme released in 1992-08-20. It has been featured on 2 Sundown Sessions shows. Featured tracks include Rest In Peace.
+
+

--- a/src/content/releases/f/fabienne-delsol/on-my-mind/index.md
+++ b/src/content/releases/f/fabienne-delsol/on-my-mind/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "On My Mind"
+artist: "Fabienne DelSol"
+releaseDate: "2010-09-06"
+releaseType: "Album"
+genres:
+  - "garage rock"
+  - "pop rock"
+  - "mod"
+  - "neo-psychedelia"
+  - "garage rock revival"
+labels:
+  - "Damaged Goods"
+duration: "0:32:35"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "To You"
+    trackNumber: 1
+    duration: "01:43"
+  - title: "Your Queen"
+    trackNumber: 2
+    duration: "03:00"
+  - title: "Ragunboneman"
+    trackNumber: 3
+    duration: "02:32"
+  - title: "On My Mind"
+    trackNumber: 4
+    duration: "03:05"
+  - title: "Pas adieu"
+    trackNumber: 5
+    duration: "03:04"
+  - title: "I Feel So Blue"
+    trackNumber: 6
+    duration: "02:37"
+  - title: "And I Have Learnt to Dream"
+    trackNumber: 7
+    duration: "03:07"
+  - title: "Take Your Seat"
+    trackNumber: 8
+    duration: "03:01"
+  - title: "Faraway Spaceman Blues"
+    trackNumber: 9
+    duration: "02:54"
+  - title: "Count Me Out"
+    trackNumber: 10
+    duration: "02:12"
+  - title: "Ce jour là"
+    trackNumber: 11
+    duration: "02:53"
+  - title: "Strange Shadows"
+    trackNumber: 12
+    duration: "02:27"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/5ad75b87-d304-4c7c-b613-072d9bb4956a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+On My Mind is a release by Fabienne DelSol released in 2010-09-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Ragunboneman.
+
+

--- a/src/content/releases/f/fad-gadget/fad-gadget-by-frank-tovey/index.md
+++ b/src/content/releases/f/fad-gadget/fad-gadget-by-frank-tovey/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Fad Gadget By Frank Tovey"
+artist: "Fad Gadget"
+releaseDate: "2006"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Fad Gadget By Frank Tovey is a release by Fad Gadget released in 2006. It has been featured on 1 Sundown Sessions show. Featured tracks include Collapsing New People.
+
+## Tracks Featured on Sundown Sessions
+
+- Collapsing New People
+
+

--- a/src/content/releases/f/fat-white-family/serfs-up/index.md
+++ b/src/content/releases/f/fat-white-family/serfs-up/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Serfs Up!"
+artist: "Fat White Family"
+releaseDate: "2019-04-19"
+releaseType: "Album"
+genres:
+  - "post-punk"
+  - "experimental rock"
+  - "psychedelic"
+  - "art rock"
+  - "hypnagogic pop"
+labels:
+  - "Domino"
+duration: "0:43:47"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "Feet"
+    trackNumber: 1
+    duration: "05:19"
+  - title: "I Believe in Something Better"
+    trackNumber: 2
+    duration: "04:27"
+  - title: "Vagina Dentata"
+    trackNumber: 3
+    duration: "03:00"
+  - title: "Kim's Sunsets"
+    trackNumber: 4
+    duration: "04:20"
+  - title: "Fringe Runner"
+    trackNumber: 5
+    duration: "04:32"
+  - title: "Oh Sebastian"
+    trackNumber: 6
+    duration: "02:44"
+  - title: "Tastes Good With the Money"
+    trackNumber: 7
+    duration: "05:42"
+  - title: "Rock Fishes"
+    trackNumber: 8
+    duration: "04:04"
+  - title: "When I Leave"
+    trackNumber: 9
+    duration: "05:35"
+  - title: "Bobby's Boyfriend"
+    trackNumber: 10
+    duration: "04:01"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d89fe9a1-3b9d-4ab8-911c-476028b7626f"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Serfs Up! is a release by Fat White Family released in 2019-04-19. It has been featured on 1 Sundown Sessions show. Featured tracks include Feet.
+
+

--- a/src/content/releases/f/fews/means/index.md
+++ b/src/content/releases/f/fews/means/index.md
@@ -1,0 +1,57 @@
+﻿---
+title: "MEANS"
+artist: "FEWS"
+releaseDate: "2016-05-20"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "post-punk"
+  - "rock"
+labels:
+  - "Play It Again Sam"
+duration: "0:36:56"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "I.D."
+    trackNumber: 1
+    duration: "02:15"
+  - title: "The Zoo"
+    trackNumber: 2
+    duration: "03:31"
+  - title: "Drinking Games"
+    trackNumber: 3
+    duration: "03:48"
+  - title: "The Queen"
+    trackNumber: 4
+    duration: "02:58"
+  - title: "10 Things"
+    trackNumber: 5
+    duration: "03:50"
+  - title: "100 Goosebumps"
+    trackNumber: 6
+    duration: "02:56"
+  - title: "Keep on Telling Myself"
+    trackNumber: 7
+    duration: "03:59"
+  - title: "If Things Go on Like This"
+    trackNumber: 8
+    duration: "03:03"
+  - title: "Zlatan"
+    trackNumber: 9
+    duration: "02:13"
+  - title: "Ill"
+    trackNumber: 10
+    duration: "08:18"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/44fb53c1-ab01-47b7-9ab1-0a420799b1d7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+MEANS is a release by FEWS released in 2016-05-20. It has been featured on 1 Sundown Sessions show. Featured tracks include The Zoo.
+
+

--- a/src/content/releases/f/fiona-apple/the-idler-wheel/index.md
+++ b/src/content/releases/f/fiona-apple/the-idler-wheel/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The Idler Wheel..."
+artist: "Fiona Apple"
+releaseDate: "2012"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Idler Wheel... is a release by Fiona Apple released in 2012. It has been featured on 1 Sundown Sessions show. Featured tracks include Werewolf.
+
+## Tracks Featured on Sundown Sessions
+
+- Werewolf
+
+

--- a/src/content/releases/f/fleetwood-mac/then-play-on-2013-remaster-expanded-edition/index.md
+++ b/src/content/releases/f/fleetwood-mac/then-play-on-2013-remaster-expanded-edition/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Then Play On (2013 Remaster; Expanded Edition)"
+artist: "Fleetwood Mac"
+releaseDate: "1969"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Then Play On (2013 Remaster; Expanded Edition) is a release by Fleetwood Mac released in 1969. It has been featured on 1 Sundown Sessions show. Featured tracks include The Green Manalishi (With the Two Prong Crown) - 2013 Remaster.
+
+## Tracks Featured on Sundown Sessions
+
+- The Green Manalishi (With the Two Prong Crown) - 2013 Remaster
+
+

--- a/src/content/releases/g/gary-numan/the-pleasure-principle/index.md
+++ b/src/content/releases/g/gary-numan/the-pleasure-principle/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "The Pleasure Principle"
+artist: "Gary Numan"
+releaseDate: "1979-09-07"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "synth-pop"
+  - "new romantic"
+  - "electronic"
+  - "synthpop"
+labels:
+  - "Beggars Banquet"
+duration: "0:41:23"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Airlane"
+    trackNumber: 1
+    duration: "03:19"
+  - title: "Metal"
+    trackNumber: 2
+    duration: "03:34"
+  - title: "Complex"
+    trackNumber: 3
+    duration: "03:12"
+  - title: "Films"
+    trackNumber: 4
+    duration: "04:11"
+  - title: "M.E."
+    trackNumber: 5
+    duration: "05:37"
+  - title: "Tracks"
+    trackNumber: 6
+    duration: "02:52"
+  - title: "Observer"
+    trackNumber: 7
+    duration: "02:54"
+  - title: "Conversation"
+    trackNumber: 8
+    duration: "07:40"
+  - title: "Cars"
+    trackNumber: 9
+    duration: "04:01"
+  - title: "Engineers"
+    trackNumber: 10
+    duration: "04:03"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/2ba66802-18a7-3bf4-958c-db871a6e7f34"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Pleasure Principle is a release by Gary Numan released in 1979-09-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Airlane.
+
+

--- a/src/content/releases/g/gaye-bykers-on-acid/nosedive-karma-ep/index.md
+++ b/src/content/releases/g/gaye-bykers-on-acid/nosedive-karma-ep/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Nosedive Karma EP"
+artist: "Gaye Bykers On Acid"
+releaseDate: "1987"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Nosedive Karma EP is a release by Gaye Bykers On Acid released in 1987. It has been featured on 1 Sundown Sessions show. Featured tracks include Nosedive Karma.
+
+## Tracks Featured on Sundown Sessions
+
+- Nosedive Karma
+
+

--- a/src/content/releases/g/geordie-munro/haste-ye-back/index.md
+++ b/src/content/releases/g/geordie-munro/haste-ye-back/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Haste Ye Back"
+artist: "Geordie Munro"
+releaseDate: "2012"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Haste Ye Back is a release by Geordie Munro released in 2012. It has been featured on 1 Sundown Sessions show. Featured tracks include The Alexander Brothers.
+
+## Tracks Featured on Sundown Sessions
+
+- The Alexander Brothers
+
+

--- a/src/content/releases/g/george-thorogood-and-the-destroyers/the-hard-stuff/index.md
+++ b/src/content/releases/g/george-thorogood-and-the-destroyers/the-hard-stuff/index.md
@@ -1,0 +1,75 @@
+﻿---
+title: "The Hard Stuff"
+artist: "George Thorogood & The Destroyers"
+releaseDate: "2006-05-22"
+releaseType: "Album"
+genres:
+  - "blues"
+  - "blues-rock"
+  - "blues rock"
+  - "rock"
+labels:
+  - "earMUSIC"
+duration: "0:57:13"
+featuredInShows:
+  - "8"
+  - "46"
+shows:
+  - "8"
+  - "46"
+tracks:
+  - title: "The Hard Stuff"
+    trackNumber: 1
+    duration: "03:53"
+  - title: "Hello Josephine"
+    trackNumber: 2
+    duration: "03:07"
+  - title: "Moving"
+    trackNumber: 3
+    duration: "04:15"
+  - title: "I Got My Eyes on You"
+    trackNumber: 4
+    duration: "03:34"
+  - title: "I Didn’t Know"
+    trackNumber: 5
+    duration: "02:58"
+  - title: "Any Town USA"
+    trackNumber: 6
+    duration: "04:18"
+  - title: "Little Rain"
+    trackNumber: 7
+    duration: "04:11"
+  - title: "Cool It"
+    trackNumber: 8
+    duration: "03:03"
+  - title: "Love Doctor"
+    trackNumber: 9
+    duration: "03:41"
+  - title: "Dynaflow Blues"
+    trackNumber: 10
+    duration: "03:47"
+  - title: "Rock Party"
+    trackNumber: 11
+    duration: "04:24"
+  - title: "Drifter’s Escape"
+    trackNumber: 12
+    duration: "03:17"
+  - title: "Give Me Back My Wig"
+    trackNumber: 13
+    duration: "04:27"
+  - title: "Taking Care of Business"
+    trackNumber: 14
+    duration: "04:14"
+  - title: "Huckle Up Baby"
+    trackNumber: 15
+    duration: "03:59"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d1f9d8b3-7f96-3ed9-97c5-c2a4888faf2f"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Hard Stuff is a release by George Thorogood & The Destroyers released in 2006-05-22. It has been featured on 2 Sundown Sessions shows. Featured tracks include Love Doctor.
+
+

--- a/src/content/releases/g/giorgio-moroder/from-here-to-eternity/index.md
+++ b/src/content/releases/g/giorgio-moroder/from-here-to-eternity/index.md
@@ -1,0 +1,52 @@
+﻿---
+title: "From Here to Eternity"
+artist: "Giorgio Moroder"
+releaseDate: "1977-07-22"
+releaseType: "Album"
+genres:
+  - "electronic"
+  - "disco"
+  - "synth-pop"
+  - "electro-disco"
+labels:
+  - "Oasis"
+duration: "0:30:29"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "From Here to Eternity"
+    trackNumber: 1
+    duration: "05:51"
+  - title: "Faster Than the Speed of Love"
+    trackNumber: 2
+    duration: "01:57"
+  - title: "Lost Angeles"
+    trackNumber: 3
+    duration: "02:45"
+  - title: "Utopia - Me Giorgio"
+    trackNumber: 4
+    duration: "03:23"
+  - title: "From Here to Eternity (reprise)"
+    trackNumber: 5
+    duration: "01:35"
+  - title: "First Hand Experience in Second Hand Love"
+    trackNumber: 6
+    duration: "05:01"
+  - title: "I'm Left, You're Right, She's Gone"
+    trackNumber: 7
+    duration: "05:06"
+  - title: "Too Hot to Handle"
+    trackNumber: 8
+    duration: "04:49"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/eea2d61e-2106-32b7-8834-6cf0e50eb9ff"
+lastmod: "2026-06-25"
+---
+
+## About
+
+From Here to Eternity is a release by Giorgio Moroder released in 1977-07-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Utopia - Me Giorgio.
+
+

--- a/src/content/releases/g/goldfrapp/supernature/index.md
+++ b/src/content/releases/g/goldfrapp/supernature/index.md
@@ -1,0 +1,69 @@
+﻿---
+title: "Supernature"
+artist: "Goldfrapp"
+releaseDate: "2005-08-17"
+releaseType: "Album"
+genres:
+  - "electronic"
+  - "pop"
+  - "synth-pop"
+  - "electronica"
+  - "trip hop"
+labels:
+  - "EMI"
+  - "Mute"
+duration: "1:13:57"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Ooh La La"
+    trackNumber: 1
+    duration: "03:24"
+  - title: "Lovely 2 C U"
+    trackNumber: 2
+    duration: "03:25"
+  - title: "Ride a White Horse"
+    trackNumber: 3
+    duration: "04:41"
+  - title: "You Never Know"
+    trackNumber: 4
+    duration: "03:27"
+  - title: "Let It Take You"
+    trackNumber: 5
+    duration: "04:29"
+  - title: "Fly Me Away"
+    trackNumber: 6
+    duration: "04:25"
+  - title: "Slide In"
+    trackNumber: 7
+    duration: "04:17"
+  - title: "Koko"
+    trackNumber: 8
+    duration: "03:23"
+  - title: "Satin Chic"
+    trackNumber: 9
+    duration: "03:28"
+  - title: "Time Out From the World"
+    trackNumber: 10
+    duration: "04:47"
+  - title: "Number 1"
+    trackNumber: 11
+    duration: "05:57"
+  - title: "[data track]"
+    trackNumber: 12
+    duration: "28:09"
+  - title: "[data track]"
+    trackNumber: 13
+    duration: "00:00"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/237b9e12-c7e2-388f-a37e-3be768518b71"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Supernature is a release by Goldfrapp released in 2005-08-17. It has been featured on 1 Sundown Sessions show. Featured tracks include Koko.
+
+

--- a/src/content/releases/g/goodbye-mr-mackenzie/5/index.md
+++ b/src/content/releases/g/goodbye-mr-mackenzie/5/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "5"
+artist: "Goodbye Mr Mackenzie"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+5 is a release by Goodbye Mr Mackenzie. It has been featured on 1 Sundown Sessions show. Featured tracks include Hard, Normal Boy.
+
+## Tracks Featured on Sundown Sessions
+
+- Hard
+- Normal Boy
+
+

--- a/src/content/releases/g/grandaddy/sumday/index.md
+++ b/src/content/releases/g/grandaddy/sumday/index.md
@@ -1,0 +1,63 @@
+﻿---
+title: "Sumday"
+artist: "Grandaddy"
+releaseDate: "2003-06-09"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "rock"
+  - "alternrock"
+labels:
+  - "V2"
+duration: "0:52:27"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Now It's On"
+    trackNumber: 1
+    duration: "04:08"
+  - title: "I'm on Standby"
+    trackNumber: 2
+    duration: "03:12"
+  - title: "The Go in the Go-For-It"
+    trackNumber: 3
+    duration: "03:40"
+  - title: "The Group Who Couldn't Say"
+    trackNumber: 4
+    duration: "04:03"
+  - title: "Lost on Yer Merry Way"
+    trackNumber: 5
+    duration: "06:21"
+  - title: "El Caminos in the West"
+    trackNumber: 6
+    duration: "03:22"
+  - title: "\"Yeah\" Is What We Had"
+    trackNumber: 1
+    duration: "03:45"
+  - title: "Saddest Vacant Lot in All the World"
+    trackNumber: 2
+    duration: "03:52"
+  - title: "Stray Dog and the Chocolate Shake"
+    trackNumber: 3
+    duration: "03:44"
+  - title: "O.K. With My Decay"
+    trackNumber: 4
+    duration: "06:11"
+  - title: "The Warming Sun"
+    trackNumber: 5
+    duration: "05:44"
+  - title: "The Final Push to the Sum"
+    trackNumber: 6
+    duration: "04:23"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/5916a0ad-d791-3d6a-b07b-7570f4ca2b20"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Sumday is a release by Grandaddy released in 2003-06-09. It has been featured on 1 Sundown Sessions show. Featured tracks include I'm On Standby.
+
+

--- a/src/content/releases/h/hawkwind/drive-fast-rock-hard/index.md
+++ b/src/content/releases/h/hawkwind/drive-fast-rock-hard/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Drive Fast, Rock Hard"
+artist: "Hawkwind"
+releaseDate: "2010"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Drive Fast, Rock Hard is a release by Hawkwind released in 2010. It has been featured on 1 Sundown Sessions show. Featured tracks include Silver Machine.
+
+## Tracks Featured on Sundown Sessions
+
+- Silver Machine
+
+

--- a/src/content/releases/h/heaven-17/penthouse-and-pavement/index.md
+++ b/src/content/releases/h/heaven-17/penthouse-and-pavement/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "Penthouse And Pavement"
+artist: "Heaven 17"
+releaseDate: "1981"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "new wave"
+  - "synth and techno pop"
+  - "classic pop and rock"
+  - "electronic"
+labels:
+  - "Virgin"
+duration: "0:37:29"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+tracks:
+  - title: "(We Don’t Need This) Fascist Groove Thang"
+    trackNumber: 1
+    duration: "04:17"
+  - title: "Penthouse and Pavement"
+    trackNumber: 2
+    duration: "06:20"
+  - title: "Play to Win"
+    trackNumber: 3
+    duration: "03:30"
+  - title: "Soul Warfare"
+    trackNumber: 4
+    duration: "04:57"
+  - title: "Geisha Boys and Temple Girls"
+    trackNumber: 5
+    duration: "04:30"
+  - title: "Let’s All Make a Bomb"
+    trackNumber: 6
+    duration: "04:02"
+  - title: "The Height of the Fighting"
+    trackNumber: 7
+    duration: "03:00"
+  - title: "Song With No Name"
+    trackNumber: 8
+    duration: "03:33"
+  - title: "We’re Going to Live for a Very Long Time"
+    trackNumber: 9
+    duration: "03:20"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/1353ea6d-1ec7-3171-9fe0-8a4199d74165"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Penthouse And Pavement is a release by Heaven 17 released in 1981. It has been featured on 1 Sundown Sessions show. Featured tracks include Let's All Make A Bomb.
+
+

--- a/src/content/releases/h/hipsway/hipsway/index.md
+++ b/src/content/releases/h/hipsway/hipsway/index.md
@@ -1,0 +1,57 @@
+﻿---
+title: "Hipsway"
+artist: "Hipsway"
+releaseDate: "1986"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "pop rock"
+  - "synth-pop"
+  - "electronic"
+labels:
+  - "Columbia"
+duration: "0:38:36"
+featuredInShows:
+  - "4"
+  - "13"
+shows:
+  - "4"
+  - "13"
+tracks:
+  - title: "The Honeythief"
+    trackNumber: 1
+    duration: "03:10"
+  - title: "Ask the Lord"
+    trackNumber: 2
+    duration: "04:06"
+  - title: "Bad Thing Longing"
+    trackNumber: 3
+    duration: "04:10"
+  - title: "Upon a Thread"
+    trackNumber: 4
+    duration: "04:07"
+  - title: "Long White Car"
+    trackNumber: 5
+    duration: "04:36"
+  - title: "The Broken Years"
+    trackNumber: 6
+    duration: "03:15"
+  - title: "Tinder"
+    trackNumber: 7
+    duration: "05:15"
+  - title: "Forbidden"
+    trackNumber: 8
+    duration: "04:46"
+  - title: "Set This Day Apart"
+    trackNumber: 9
+    duration: "05:07"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/35970685-7c72-327e-a714-d69f9c99e679"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Hipsway is a release by Hipsway released in 1986. It has been featured on 2 Sundown Sessions shows. Featured tracks include The Honeythief, Tinder.
+
+

--- a/src/content/releases/h/hugh-cornwell/totem-and-taboo/index.md
+++ b/src/content/releases/h/hugh-cornwell/totem-and-taboo/index.md
@@ -1,0 +1,45 @@
+﻿---
+title: "Totem & Taboo"
+artist: "Hugh Cornwell"
+releaseDate: "2012-09-10"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "rock"
+labels:
+  - "Cadiz"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Totem and Taboo"
+    trackNumber: 1
+  - title: "The Face"
+    trackNumber: 2
+  - title: "I Want One of Those"
+    trackNumber: 3
+  - title: "Stuck in Daily Mail Land"
+    trackNumber: 4
+  - title: "Bad Vibrations"
+    trackNumber: 5
+  - title: "God Is a Woman"
+    trackNumber: 6
+  - title: "Love Me Slender"
+    trackNumber: 7
+  - title: "Gods Guns and Gays"
+    trackNumber: 8
+  - title: "A Street Called Carroll"
+    trackNumber: 9
+  - title: "In the Dead of Night"
+    trackNumber: 10
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d5262650-535b-4c90-9bb6-0d0c3478e707"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Totem & Taboo is a release by Hugh Cornwell released in 2012-09-10. It has been featured on 1 Sundown Sessions show. Featured tracks include Totem and Taboo.
+
+

--- a/src/content/releases/h/hussey-regan/curios/index.md
+++ b/src/content/releases/h/hussey-regan/curios/index.md
@@ -1,0 +1,64 @@
+﻿---
+title: "Curios"
+artist: "Hussey-Regan"
+releaseDate: "2011-10-10"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "dark wave"
+  - "electronic"
+  - "pop"
+labels:
+  - "Eyes Wide Shut Recordings"
+duration: "1:03:01"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "Naked & Savage"
+    trackNumber: 1
+    duration: "05:36"
+  - title: "Ordinary World"
+    trackNumber: 2
+    duration: "06:35"
+  - title: "Enjoy the Silence"
+    trackNumber: 3
+    duration: "03:56"
+  - title: "Another Lonely Day"
+    trackNumber: 4
+    duration: "04:40"
+  - title: "Wichita Lineman"
+    trackNumber: 5
+    duration: "03:12"
+  - title: "Ashes to Ashes"
+    trackNumber: 6
+    duration: "05:49"
+  - title: "I Go to Sleep"
+    trackNumber: 7
+    duration: "03:13"
+  - title: "Where the Wild Roses Grow"
+    trackNumber: 8
+    duration: "04:09"
+  - title: "Dangerous Eyes"
+    trackNumber: 9
+    duration: "05:54"
+  - title: "Calling Your Name"
+    trackNumber: 10
+    duration: "06:37"
+  - title: "Unravel"
+    trackNumber: 11
+    duration: "04:29"
+  - title: "A Change in the Weather (Aporia mix)"
+    trackNumber: 12
+    duration: "08:51"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/7cb1f3e4-6b36-4662-8618-58dc50bdcfc7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Curios is a release by Hussey-Regan released in 2011-10-10. It has been featured on 1 Sundown Sessions show. Featured tracks include Naked and Savage.
+
+

--- a/src/content/releases/i/i-got-you-on-tape/spinning-for-the-cause/index.md
+++ b/src/content/releases/i/i-got-you-on-tape/spinning-for-the-cause/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Spinning for the Cause"
+artist: "I Got You On Tape"
+releaseDate: "2009-10-12"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "rock"
+labels:
+  - "V2"
+duration: "0:44:20"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Cabaret"
+    trackNumber: 1
+    duration: "06:00"
+  - title: "Permanent Vacation"
+    trackNumber: 2
+    duration: "03:04"
+  - title: "The Blacksmith"
+    trackNumber: 3
+    duration: "03:12"
+  - title: "Ace in the Hole"
+    trackNumber: 4
+    duration: "03:27"
+  - title: "Polka Dots"
+    trackNumber: 5
+    duration: "04:16"
+  - title: "Spinning for the Cause"
+    trackNumber: 6
+    duration: "04:33"
+  - title: "Waking Up the Brotherhood"
+    trackNumber: 7
+    duration: "04:32"
+  - title: "Beggars and Bangers"
+    trackNumber: 8
+    duration: "03:25"
+  - title: "Talk About the Treadmill"
+    trackNumber: 9
+    duration: "03:21"
+  - title: "Wedding Song"
+    trackNumber: 10
+    duration: "04:09"
+  - title: "Somersault"
+    trackNumber: 11
+    duration: "04:21"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/dff81cc3-3d0f-402e-be7b-dc20d0cb1ff2"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Spinning for the Cause is a release by I Got You On Tape released in 2009-10-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Spinning For The Cause.
+
+

--- a/src/content/releases/i/in-letter-form/fracture-repair-repeat/index.md
+++ b/src/content/releases/i/in-letter-form/fracture-repair-repeat/index.md
@@ -1,0 +1,60 @@
+﻿---
+title: "Fracture. Repair. Repeat."
+artist: "In Letter Form"
+releaseDate: "2016-05-20"
+releaseType: "Album"
+genres:
+  - "dark wave"
+  - "coldwave"
+  - "post-punk"
+  - "rock"
+  - "electronic"
+duration: "0:34:59"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "Face in the Crowd"
+    trackNumber: 1
+    duration: "03:45"
+  - title: "Won't Get the Best for Me"
+    trackNumber: 2
+    duration: "03:47"
+  - title: "Wait Now"
+    trackNumber: 3
+    duration: "03:01"
+  - title: "Audio Drones: Adagio for Terror"
+    trackNumber: 4
+    duration: "00:41"
+  - title: "Terror (Is a State of Mind)"
+    trackNumber: 5
+    duration: "04:26"
+  - title: "High Line"
+    trackNumber: 6
+    duration: "03:36"
+  - title: "Edison's Medicine"
+    trackNumber: 7
+    duration: "05:37"
+  - title: "111"
+    trackNumber: 8
+    duration: "03:27"
+  - title: "Rain Prelude"
+    trackNumber: 9
+    duration: "00:38"
+  - title: "Reflecting the Rain"
+    trackNumber: 10
+    duration: "04:09"
+  - title: "Mal de mer"
+    trackNumber: 11
+    duration: "01:52"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/2f170c17-6e48-4084-8ce6-e7aec91b6d1a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Fracture. Repair. Repeat. is a release by In Letter Form released in 2016-05-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Terror (Is A State Of Mind).
+
+

--- a/src/content/releases/i/inspiral-carpets/revenge-of-the-goldfish/index.md
+++ b/src/content/releases/i/inspiral-carpets/revenge-of-the-goldfish/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "Revenge Of The Goldfish"
+artist: "Inspiral Carpets"
+releaseDate: "1992-10-05"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "rock"
+  - "neo-psychedelia"
+  - "baggy"
+  - "indie"
+labels:
+  - "Elektra"
+duration: "0:46:16"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Generations"
+    trackNumber: 1
+    duration: "02:48"
+  - title: "Saviour"
+    trackNumber: 2
+    duration: "03:59"
+  - title: "Bitches Brew"
+    trackNumber: 3
+    duration: "03:50"
+  - title: "Smoking Her Clothes"
+    trackNumber: 4
+    duration: "04:19"
+  - title: "Fire"
+    trackNumber: 5
+    duration: "03:35"
+  - title: "Here Comes the Flood"
+    trackNumber: 6
+    duration: "04:16"
+  - title: "Dragging Me Down"
+    trackNumber: 7
+    duration: "04:31"
+  - title: "A Little Disappeared"
+    trackNumber: 8
+    duration: "02:59"
+  - title: "Two Worlds Collide"
+    trackNumber: 9
+    duration: "04:38"
+  - title: "Mystery"
+    trackNumber: 10
+    duration: "03:16"
+  - title: "Rain Song"
+    trackNumber: 11
+    duration: "04:41"
+  - title: "Irresistible Force"
+    trackNumber: 12
+    duration: "03:19"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/b9ecc5ef-b2c1-3a48-a8f6-4c1ea1af3c0e"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Revenge Of The Goldfish is a release by Inspiral Carpets released in 1992-10-05. It has been featured on 1 Sundown Sessions show. Featured tracks include Bitches Brew.
+
+

--- a/src/content/releases/i/interpol/antics/index.md
+++ b/src/content/releases/i/interpol/antics/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Antics"
+artist: "Interpol"
+releaseDate: "2004-09-24"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "alternative rock"
+  - "indie"
+  - "post-punk revival"
+  - "rock"
+labels:
+  - "Matador"
+duration: "0:41:39"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+tracks:
+  - title: "Next Exit"
+    trackNumber: 1
+    duration: "03:20"
+  - title: "Evil"
+    trackNumber: 2
+    duration: "03:35"
+  - title: "Narc"
+    trackNumber: 3
+    duration: "04:07"
+  - title: "Take You on a Cruise"
+    trackNumber: 4
+    duration: "04:54"
+  - title: "Slow Hands"
+    trackNumber: 5
+    duration: "03:04"
+  - title: "Not Even Jail"
+    trackNumber: 6
+    duration: "05:46"
+  - title: "Public Pervert"
+    trackNumber: 7
+    duration: "04:40"
+  - title: "C’mere"
+    trackNumber: 8
+    duration: "03:12"
+  - title: "Length of Love"
+    trackNumber: 9
+    duration: "04:06"
+  - title: "A Time to Be So Small"
+    trackNumber: 10
+    duration: "04:50"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/bc7740e1-02c9-3ab7-9869-0e0c79acf941"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Antics is a release by Interpol released in 2004-09-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Slow Hands.
+
+

--- a/src/content/releases/i/isobel-campbell/ballad-of-the-broken-seas/index.md
+++ b/src/content/releases/i/isobel-campbell/ballad-of-the-broken-seas/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "Ballad of the Broken Seas"
+artist: "Isobel Campbell"
+releaseDate: "2006-01-30"
+releaseType: "Album"
+genres:
+  - "country"
+  - "indie pop"
+  - "alternative and punk"
+  - "indie rock"
+  - "rock"
+labels:
+  - "V2"
+duration: "0:42:49"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "Deus Ibi Est"
+    trackNumber: 1
+    duration: "02:51"
+  - title: "Black Mountain"
+    trackNumber: 2
+    duration: "03:10"
+  - title: "The False Husband"
+    trackNumber: 3
+    duration: "03:53"
+  - title: "Ballad of the Broken Seas"
+    trackNumber: 4
+    duration: "02:42"
+  - title: "Revolver"
+    trackNumber: 5
+    duration: "02:40"
+  - title: "Ramblin' Man"
+    trackNumber: 6
+    duration: "03:29"
+  - title: "(Do You Wanna) Come Walk With Me?"
+    trackNumber: 7
+    duration: "03:27"
+  - title: "Saturday's Gone"
+    trackNumber: 8
+    duration: "04:37"
+  - title: "It's Hard to Kill a Bad Thing"
+    trackNumber: 9
+    duration: "02:53"
+  - title: "Honey Child What Can I Do?"
+    trackNumber: 10
+    duration: "03:44"
+  - title: "Dusty Wreath"
+    trackNumber: 11
+    duration: "03:44"
+  - title: "The Circus Is Leaving Town"
+    trackNumber: 12
+    duration: "05:35"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/994cdad1-0365-3439-89ed-6686bd563503"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Ballad of the Broken Seas is a release by Isobel Campbell released in 2006-01-30. It has been featured on 1 Sundown Sessions show. Featured tracks include The False Husband.
+
+

--- a/src/content/releases/i/ist-ist/lost-my-shadow/index.md
+++ b/src/content/releases/i/ist-ist/lost-my-shadow/index.md
@@ -1,0 +1,29 @@
+﻿---
+title: "Lost My Shadow"
+artist: "IST IST"
+releaseDate: "2024-03-08"
+releaseType: "Single"
+genres:
+  - "numbered"
+  - "limited edition"
+labels:
+  - "Kind Violence Records"
+duration: "0:03:07"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "Lost My Shadow"
+    trackNumber: 1
+    duration: "03:07"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d3435c35-6389-4c32-b36f-4d1597f72e7a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Lost My Shadow is a release by IST IST released in 2024-03-08. It has been featured on 1 Sundown Sessions show. Featured tracks include Lost My Shadow.
+
+

--- a/src/content/releases/j/jacco-gardner/cabinet-of-curiosities/index.md
+++ b/src/content/releases/j/jacco-gardner/cabinet-of-curiosities/index.md
@@ -1,0 +1,67 @@
+﻿---
+title: "Cabinet of Curiosities"
+artist: "Jacco Gardner"
+releaseDate: "2013-02-11"
+releaseType: "Album"
+genres:
+  - "psychedelic rock"
+  - "pop"
+  - "rock"
+labels:
+  - "Excelsior Recordings"
+duration: "0:41:39"
+featuredInShows:
+  - "1"
+  - "10"
+  - "13"
+shows:
+  - "1"
+  - "10"
+  - "13"
+tracks:
+  - title: "Clear the Air"
+    trackNumber: 1
+    duration: "03:39"
+  - title: "The One Eyed King"
+    trackNumber: 2
+    duration: "02:24"
+  - title: "Puppets Dangling"
+    trackNumber: 3
+    duration: "03:41"
+  - title: "Where Will You Go"
+    trackNumber: 4
+    duration: "03:23"
+  - title: "Watching the Moon"
+    trackNumber: 5
+    duration: "03:51"
+  - title: "Cabinet of Curiosities"
+    trackNumber: 6
+    duration: "02:46"
+  - title: "The Riddle"
+    trackNumber: 7
+    duration: "04:24"
+  - title: "Lullaby"
+    trackNumber: 8
+    duration: "03:01"
+  - title: "Help Me Out"
+    trackNumber: 9
+    duration: "02:55"
+  - title: "Summer's Game"
+    trackNumber: 10
+    duration: "03:15"
+  - title: "Chameleon"
+    trackNumber: 11
+    duration: "04:09"
+  - title: "The Ballad of Little Jane"
+    trackNumber: 12
+    duration: "04:06"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/43b9e851-bdd7-439c-a02a-aac6a9307a7d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Cabinet of Curiosities is a release by Jacco Gardner released in 2013-02-11. It has been featured on 3 Sundown Sessions shows. Featured tracks include Clear The Air, The Ballad of Little Jane, The One Eyed King.
+
+

--- a/src/content/releases/j/jack-white/as-i-am/index.md
+++ b/src/content/releases/j/jack-white/as-i-am/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "As I Am"
+artist: "Jack White"
+releaseDate: "2007"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+lastmod: "2026-06-25"
+---
+
+## About
+
+As I Am is a release by Jack White released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include Another Way to Die.
+
+## Tracks Featured on Sundown Sessions
+
+- Another Way to Die
+
+

--- a/src/content/releases/j/jackie-lomax/come-and-get-it-the-best-of-apple-records/index.md
+++ b/src/content/releases/j/jackie-lomax/come-and-get-it-the-best-of-apple-records/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Come And Get It - The Best Of Apple Records"
+artist: "Jackie Lomax"
+releaseDate: "2010"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Come And Get It - The Best Of Apple Records is a release by Jackie Lomax released in 2010. It has been featured on 1 Sundown Sessions show. Featured tracks include Sour Milk Sea.
+
+## Tracks Featured on Sundown Sessions
+
+- Sour Milk Sea
+
+

--- a/src/content/releases/j/jarvis-cocker/jarvis/index.md
+++ b/src/content/releases/j/jarvis-cocker/jarvis/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Jarvis"
+artist: "Jarvis Cocker"
+releaseDate: "2006"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Jarvis is a release by Jarvis Cocker released in 2006. It has been featured on 1 Sundown Sessions show. Featured tracks include Fat Children.
+
+## Tracks Featured on Sundown Sessions
+
+- Fat Children
+
+

--- a/src/content/releases/j/jimi-hendrix/are-you-experienced/index.md
+++ b/src/content/releases/j/jimi-hendrix/are-you-experienced/index.md
@@ -1,0 +1,213 @@
+﻿---
+title: "Are You Experienced"
+artist: "Jimi Hendrix"
+releaseDate: "2010-07-10"
+releaseType: "Album"
+duration: "4:10:40"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+tracks:
+  - title: "Foxy Lady"
+    trackNumber: 1
+    duration: "03:16"
+  - title: "Manic Depression"
+    trackNumber: 2
+    duration: "03:34"
+  - title: "Red House"
+    trackNumber: 3
+    duration: "03:51"
+  - title: "Can You See Me"
+    trackNumber: 4
+    duration: "02:34"
+  - title: "Love or Confusion"
+    trackNumber: 5
+    duration: "03:11"
+  - title: "I Don’t Live Today"
+    trackNumber: 6
+    duration: "03:53"
+  - title: "May This Be Love"
+    trackNumber: 7
+    duration: "03:03"
+  - title: "Fire"
+    trackNumber: 8
+    duration: "02:38"
+  - title: "Third Stone From the Sun"
+    trackNumber: 9
+    duration: "06:39"
+  - title: "Remember"
+    trackNumber: 10
+    duration: "02:50"
+  - title: "Are You Experienced"
+    trackNumber: 11
+    duration: "04:17"
+  - title: "Hey Joe"
+    trackNumber: 12
+    duration: "03:28"
+  - title: "Stone Free"
+    trackNumber: 13
+    duration: "03:40"
+  - title: "Purple Haze"
+    trackNumber: 14
+    duration: "02:49"
+  - title: "51st Anniversary"
+    trackNumber: 15
+    duration: "03:19"
+  - title: "The Wind Cries Mary"
+    trackNumber: 16
+    duration: "03:24"
+  - title: "Highway Chile"
+    trackNumber: 17
+    duration: "03:37"
+  - title: "Purple Haze"
+    trackNumber: 1
+    duration: "02:53"
+  - title: "Manic Depression"
+    trackNumber: 2
+    duration: "03:44"
+  - title: "Hey Joe"
+    trackNumber: 3
+    duration: "03:32"
+  - title: "Love or Confusion"
+    trackNumber: 4
+    duration: "03:15"
+  - title: "May This Be Love"
+    trackNumber: 5
+    duration: "03:12"
+  - title: "I Don’t Live Today"
+    trackNumber: 6
+    duration: "03:55"
+  - title: "The Wind Cries Mary"
+    trackNumber: 7
+    duration: "03:22"
+  - title: "Fire"
+    trackNumber: 8
+    duration: "02:45"
+  - title: "Third Stone From the Sun"
+    trackNumber: 9
+    duration: "06:47"
+  - title: "Foxy Lady"
+    trackNumber: 10
+    duration: "03:22"
+  - title: "Are You Experienced"
+    trackNumber: 11
+    duration: "04:26"
+  - title: "Red House"
+    trackNumber: 12
+    duration: "03:57"
+  - title: "Can You See Me"
+    trackNumber: 13
+    duration: "02:37"
+  - title: "Remember"
+    trackNumber: 14
+    duration: "02:53"
+  - title: "Highway Chile (2000 remix)"
+    trackNumber: 15
+    duration: "03:46"
+  - title: "Stone Free (simluated stereo)"
+    trackNumber: 16
+    duration: "03:39"
+  - title: "Hey Joe (alternate take 1)"
+    trackNumber: 1
+    duration: "03:10"
+  - title: "Hey Joe (master version, session takes 1–2)"
+    trackNumber: 2
+    duration: "05:36"
+  - title: "Hey Joe (master version, alternate mono mix)"
+    trackNumber: 3
+    duration: "03:38"
+  - title: "Hey Joe (alternate take 2)"
+    trackNumber: 4
+    duration: "04:01"
+  - title: "Foxy Lady (alternate stereo mix)"
+    trackNumber: 5
+    duration: "03:31"
+  - title: "Can You See Me (session takes 1–3)"
+    trackNumber: 6
+    duration: "06:13"
+  - title: "Can You See Me (master backing track)"
+    trackNumber: 7
+    duration: "02:34"
+  - title: "Can You See Me (alternate stereo mix)"
+    trackNumber: 8
+    duration: "02:36"
+  - title: "Red House (UK version, alternate mono mix)"
+    trackNumber: 9
+    duration: "04:14"
+  - title: "Red House (US version, session takes 1–3)"
+    trackNumber: 10
+    duration: "07:04"
+  - title: "Red House (US version, alternate stereo mix)"
+    trackNumber: 11
+    duration: "03:58"
+  - title: "Remember (session takes 1–7)"
+    trackNumber: 12
+    duration: "14:19"
+  - title: "Remember (alternate mono mix)"
+    trackNumber: 13
+    duration: "02:56"
+  - title: "Purple Haze (alternate stereo mix)"
+    trackNumber: 1
+    duration: "03:29"
+  - title: "Purple Haze (alternate mono mix)"
+    trackNumber: 2
+    duration: "03:02"
+  - title: "51st Anniversary (session takes 1–2)"
+    trackNumber: 3
+    duration: "01:34"
+  - title: "51st Anniversary (master backing track)"
+    trackNumber: 4
+    duration: "03:26"
+  - title: "51st Anniversary (alternate stereo mix)"
+    trackNumber: 5
+    duration: "03:21"
+  - title: "Fire (session takes 1–6)"
+    trackNumber: 6
+    duration: "07:34"
+  - title: "Fire (master backing track)"
+    trackNumber: 7
+    duration: "02:36"
+  - title: "The Wind Cries Mary (master backing track)"
+    trackNumber: 8
+    duration: "03:28"
+  - title: "I Don’t Live Today (session takes 1–3)"
+    trackNumber: 9
+    duration: "07:11"
+  - title: "I Don’t Live Today (master backing track)"
+    trackNumber: 10
+    duration: "04:22"
+  - title: "I Don’t Live Today (alternate stereo mix)"
+    trackNumber: 11
+    duration: "04:06"
+  - title: "Manic Depression (session takes 1–2)"
+    trackNumber: 12
+    duration: "05:31"
+  - title: "Manic Depression (alternate mono mix)"
+    trackNumber: 13
+    duration: "03:44"
+  - title: "La Poupée Qui Fait Non (backing track)"
+    trackNumber: 14
+    duration: "03:38"
+  - title: "Title #3 (backing track)"
+    trackNumber: 15
+    duration: "02:16"
+  - title: "Lover Man (backing track)"
+    trackNumber: 16
+    duration: "03:05"
+  - title: "May This Be Love (alternate mono mix)"
+    trackNumber: 17
+    duration: "03:13"
+  - title: "Third Stone From the Sun (overdub session)"
+    trackNumber: 18
+    duration: "02:36"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/791fdbb8-b19c-4d33-9ba4-d2d2f35abec6"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Are You Experienced is a release by Jimi Hendrix released in 2010-07-10. It has been featured on 1 Sundown Sessions show. Featured tracks include Hey Joe.
+
+

--- a/src/content/releases/j/jimi-hendrix/axis-bold-as-love/index.md
+++ b/src/content/releases/j/jimi-hendrix/axis-bold-as-love/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Axis: Bold As Love"
+artist: "Jimi Hendrix"
+releaseDate: "1967-12-01"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "blues rock"
+  - "acid rock"
+  - "psychedelic rock"
+  - "blues-rock"
+labels:
+  - "Barclay"
+duration: "0:38:46"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "EXP"
+    trackNumber: 1
+    duration: "01:56"
+  - title: "Up From the Skies"
+    trackNumber: 2
+    duration: "02:28"
+  - title: "Spanish Castle Magic"
+    trackNumber: 3
+    duration: "03:04"
+  - title: "Wait Until Tomorrow"
+    trackNumber: 4
+    duration: "03:02"
+  - title: "Ain’t No Telling"
+    trackNumber: 5
+    duration: "01:49"
+  - title: "Little Wing"
+    trackNumber: 6
+    duration: "02:24"
+  - title: "If Six Was Nine"
+    trackNumber: 7
+    duration: "05:36"
+  - title: "You’ve Got Me Floating"
+    trackNumber: 8
+    duration: "02:49"
+  - title: "Castles Made of Sand"
+    trackNumber: 9
+    duration: "02:48"
+  - title: "She’s So Fine"
+    trackNumber: 10
+    duration: "02:39"
+  - title: "One Rainy Wish"
+    trackNumber: 11
+    duration: "03:40"
+  - title: "Little Miss Lover"
+    trackNumber: 12
+    duration: "02:21"
+  - title: "Bold as Love"
+    trackNumber: 13
+    duration: "04:10"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d0b1e21e-cef6-4575-8d92-1afea1894ca3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Axis: Bold As Love is a release by Jimi Hendrix released in 1967-12-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Little Wing.
+
+

--- a/src/content/releases/j/joe-satriani/flying-in-a-blue-dream/index.md
+++ b/src/content/releases/j/joe-satriani/flying-in-a-blue-dream/index.md
@@ -1,0 +1,83 @@
+﻿---
+title: "Flying In A Blue Dream"
+artist: "Joe Satriani"
+releaseDate: "1989-10-30"
+releaseType: "Album"
+genres:
+  - "contemporary pop/rock"
+  - "instrumental rock"
+  - "rock"
+  - "hard rock"
+  - "guitar virtuoso"
+labels:
+  - "Food for Thought"
+duration: "1:04:55"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+tracks:
+  - title: "Flying in a Blue Dream"
+    trackNumber: 1
+    duration: "05:23"
+  - title: "The Mystical Potato Head Groove Thing"
+    trackNumber: 2
+    duration: "05:09"
+  - title: "Can't Slow Down"
+    trackNumber: 3
+    duration: "04:49"
+  - title: "Headless"
+    trackNumber: 4
+    duration: "01:29"
+  - title: "Strange"
+    trackNumber: 5
+    duration: "05:02"
+  - title: "I Believe"
+    trackNumber: 6
+    duration: "05:54"
+  - title: "One Big Rush"
+    trackNumber: 7
+    duration: "03:25"
+  - title: "Big Bad Moon"
+    trackNumber: 8
+    duration: "05:15"
+  - title: "The Feeling"
+    trackNumber: 9
+    duration: "00:50"
+  - title: "The Phone Call"
+    trackNumber: 10
+    duration: "03:01"
+  - title: "Day at the Beach (New Rays From an Ancient Sun)"
+    trackNumber: 11
+    duration: "02:04"
+  - title: "Back to Shalla-Bal"
+    trackNumber: 12
+    duration: "03:14"
+  - title: "Ride"
+    trackNumber: 13
+    duration: "04:56"
+  - title: "The Forgotten, Part 1"
+    trackNumber: 14
+    duration: "01:12"
+  - title: "The Forgotten, Part 2"
+    trackNumber: 15
+    duration: "05:08"
+  - title: "The Bells of Lal, Part 1"
+    trackNumber: 16
+    duration: "01:19"
+  - title: "The Bells of Lal, Part 2"
+    trackNumber: 17
+    duration: "04:07"
+  - title: "Into the Light"
+    trackNumber: 18
+    duration: "02:29"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e19b2146-1ea9-31f3-8a51-65e2c7fbe29b"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Flying In A Blue Dream is a release by Joe Satriani released in 1989-10-30. It has been featured on 1 Sundown Sessions show. Featured tracks include Day at the Beach (New Rays from an Ancient Sun).
+
+

--- a/src/content/releases/j/john-grant/queen-of-denmark/index.md
+++ b/src/content/releases/j/john-grant/queen-of-denmark/index.md
@@ -1,0 +1,76 @@
+﻿---
+title: "Queen of Denmark"
+artist: "John Grant"
+releaseDate: "2010-04-06"
+releaseType: "Album"
+genres:
+  - "soft rock"
+  - "rock"
+labels:
+  - "Bella Union"
+duration: "1:09:58"
+featuredInShows:
+  - "1"
+  - "13"
+shows:
+  - "1"
+  - "13"
+tracks:
+  - title: "TC and Honeybear"
+    trackNumber: 1
+    duration: "05:06"
+  - title: "Marz"
+    trackNumber: 2
+    duration: "03:58"
+  - title: "Where Dreams Go to Die"
+    trackNumber: 3
+    duration: "06:04"
+  - title: "Sigourney Weaver"
+    trackNumber: 4
+    duration: "03:31"
+  - title: "Chicken Bones"
+    trackNumber: 5
+    duration: "03:38"
+  - title: "Silver Platter Club"
+    trackNumber: 6
+    duration: "04:11"
+  - title: "It’s Easier"
+    trackNumber: 7
+    duration: "04:38"
+  - title: "Outer Space"
+    trackNumber: 8
+    duration: "03:15"
+  - title: "Jesus Hates Faggots"
+    trackNumber: 9
+    duration: "03:48"
+  - title: "Caramel"
+    trackNumber: 10
+    duration: "03:35"
+  - title: "Leopard & Lamb"
+    trackNumber: 11
+    duration: "04:41"
+  - title: "Queen of Denmark"
+    trackNumber: 12
+    duration: "04:49"
+  - title: "That’s the Good News"
+    trackNumber: 1
+    duration: "04:14"
+  - title: "Supernatural Defibrillator"
+    trackNumber: 2
+    duration: "02:53"
+  - title: "Fireflies"
+    trackNumber: 3
+    duration: "03:42"
+  - title: "What Time?"
+    trackNumber: 4
+    duration: "07:54"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/35ff2371-1c51-4556-a6a7-4430418f67af"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Queen of Denmark is a release by John Grant released in 2010-04-06. It has been featured on 2 Sundown Sessions shows. Featured tracks include Marz, Where Dreams Go To Die.
+
+

--- a/src/content/releases/j/john-lennon/mind-games/index.md
+++ b/src/content/releases/j/john-lennon/mind-games/index.md
@@ -1,0 +1,35 @@
+﻿---
+title: "Mind Games"
+artist: "John Lennon"
+releaseDate: "1973-10-29"
+releaseType: "Single"
+genres:
+  - "pop rock"
+  - "singer/songwriter"
+  - "chamber pop"
+  - "rock"
+  - "pop"
+labels:
+  - "Apple Records"
+duration: "0:07:00"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Mind Games"
+    trackNumber: 1
+    duration: "04:10"
+  - title: "Meat City"
+    trackNumber: 2
+    duration: "02:50"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/5dc36497-ae8f-4d82-aab9-4a772c9a8885"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Mind Games is a release by John Lennon released in 1973-10-29. It has been featured on 1 Sundown Sessions show. Featured tracks include Out The Blue.
+
+

--- a/src/content/releases/j/john-lennon/plastic-ono-band/index.md
+++ b/src/content/releases/j/john-lennon/plastic-ono-band/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Plastic Ono Band"
+artist: "John Lennon"
+releaseDate: "1970"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Plastic Ono Band is a release by John Lennon released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Love.
+
+## Tracks Featured on Sundown Sessions
+
+- Love
+
+

--- a/src/content/releases/j/john-lennon/sometime-in-new-york-city/index.md
+++ b/src/content/releases/j/john-lennon/sometime-in-new-york-city/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Sometime In New York City"
+artist: "John Lennon"
+releaseDate: "1972"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Sometime In New York City is a release by John Lennon released in 1972. It has been featured on 1 Sundown Sessions show. Featured tracks include New York City.
+
+## Tracks Featured on Sundown Sessions
+
+- New York City
+
+

--- a/src/content/releases/j/juicy-lucy/juicy-lucy/index.md
+++ b/src/content/releases/j/juicy-lucy/juicy-lucy/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Juicy Lucy"
+artist: "Juicy Lucy"
+releaseDate: "1995"
+releaseType: "Album"
+labels:
+  - "Buzz Records"
+duration: "0:56:29"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "She Makes Me Go Down"
+    trackNumber: 1
+    duration: "04:30"
+  - title: "Please Please"
+    trackNumber: 2
+    duration: "05:05"
+  - title: "Mom's Apple Pie"
+    trackNumber: 3
+    duration: "03:52"
+  - title: "Come for Me Lady"
+    trackNumber: 4
+    duration: "05:29"
+  - title: "Noise Noise"
+    trackNumber: 5
+    duration: "05:01"
+  - title: "Revolution"
+    trackNumber: 6
+    duration: "04:36"
+  - title: "She Drives Me Crazy"
+    trackNumber: 7
+    duration: "04:35"
+  - title: "My Inspiration"
+    trackNumber: 8
+    duration: "04:34"
+  - title: "Junky for Your Love"
+    trackNumber: 9
+    duration: "04:53"
+  - title: "Sugar Sweet"
+    trackNumber: 10
+    duration: "04:08"
+  - title: "Slippin' Through the Night"
+    trackNumber: 11
+    duration: "04:28"
+  - title: "Wish You Were Here"
+    trackNumber: 12
+    duration: "05:18"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/faa011fb-3014-4b48-bc18-52c50b5501af"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Juicy Lucy is a release by Juicy Lucy released in 1995. It has been featured on 1 Sundown Sessions show. Featured tracks include Mississippi Woman.
+
+

--- a/src/content/releases/j/juicy-lucy/who-do-you-love/index.md
+++ b/src/content/releases/j/juicy-lucy/who-do-you-love/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Who Do You Love"
+artist: "Juicy Lucy"
+releaseDate: "2002"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Who Do You Love is a release by Juicy Lucy released in 2002. It has been featured on 1 Sundown Sessions show. Featured tracks include Who Do You Love?.
+
+## Tracks Featured on Sundown Sessions
+
+- Who Do You Love?
+
+

--- a/src/content/releases/k/karel-fialka/human-animal/index.md
+++ b/src/content/releases/k/karel-fialka/human-animal/index.md
@@ -1,0 +1,66 @@
+﻿---
+title: "Human Animal"
+artist: "Karel Fialka"
+releaseDate: "1988"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "pop"
+  - "electronic"
+labels:
+  - "I.R.S. Records"
+duration: "0:45:57"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Sun in My Eyes"
+    trackNumber: 1
+    duration: "03:18"
+  - title: "Hey Matthew"
+    trackNumber: 2
+    duration: "03:33"
+  - title: "You Be the Judge"
+    trackNumber: 3
+    duration: "04:29"
+  - title: "Ready for It Now"
+    trackNumber: 4
+    duration: "03:35"
+  - title: "Undercurrents"
+    trackNumber: 5
+    duration: "03:05"
+  - title: "This City"
+    trackNumber: 6
+    duration: "03:48"
+  - title: "The Eyes Have It"
+    trackNumber: 7
+    duration: "03:28"
+  - title: "Eat, Drink, Dance, Relax"
+    trackNumber: 8
+    duration: "03:36"
+  - title: "Human Animal"
+    trackNumber: 9
+    duration: "03:34"
+  - title: "L’Etoile D’or"
+    trackNumber: 10
+    duration: "03:25"
+  - title: "Eat, Drink, Dance, Relax, Too"
+    trackNumber: 11
+    duration: "03:36"
+  - title: "The Eyes Have It II"
+    trackNumber: 12
+    duration: "03:23"
+  - title: "Undercurrents (Liquid mix)"
+    trackNumber: 13
+    duration: "03:02"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/9bf96d14-303c-3bba-bcbd-bb52df1d9f4a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Human Animal is a release by Karel Fialka released in 1988. It has been featured on 1 Sundown Sessions show. Featured tracks include Hey Matthew.
+
+

--- a/src/content/releases/k/killing-joke/night-time/index.md
+++ b/src/content/releases/k/killing-joke/night-time/index.md
@@ -1,0 +1,53 @@
+﻿---
+title: "Night Time"
+artist: "Killing Joke"
+releaseDate: "1985-02"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "british"
+  - "post-punk"
+  - "new wave"
+  - "industrial rock"
+labels:
+  - "E’G"
+duration: "0:39:56"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "Night Time"
+    trackNumber: 1
+    duration: "04:56"
+  - title: "Darkness Before Dawn"
+    trackNumber: 2
+    duration: "05:21"
+  - title: "Love Like Blood"
+    trackNumber: 3
+    duration: "06:51"
+  - title: "Kings and Queens"
+    trackNumber: 4
+    duration: "04:41"
+  - title: "Tabazan"
+    trackNumber: 5
+    duration: "04:37"
+  - title: "Multitudes"
+    trackNumber: 6
+    duration: "04:59"
+  - title: "Europe"
+    trackNumber: 7
+    duration: "04:37"
+  - title: "Eighties"
+    trackNumber: 8
+    duration: "03:50"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/11851270-b38e-3d60-a3ae-972a1e98d326"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Night Time is a release by Killing Joke released in 1985-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Love Like Blood.
+
+

--- a/src/content/releases/k/killing-joke/singles-collection-1979-2012/index.md
+++ b/src/content/releases/k/killing-joke/singles-collection-1979-2012/index.md
@@ -1,0 +1,23 @@
+﻿---
+title: "Singles Collection 1979 - 2012"
+artist: "Killing Joke"
+releaseDate: "2013"
+featuredInShows:
+  - "7"
+  - "13"
+shows:
+  - "7"
+  - "13"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Singles Collection 1979 - 2012 is a release by Killing Joke released in 2013. It has been featured on 2 Sundown Sessions shows. Featured tracks include Eighties, Kings And Queens.
+
+## Tracks Featured on Sundown Sessions
+
+- Eighties
+- Kings And Queens
+
+

--- a/src/content/releases/k/killing-kind/killing-kind/index.md
+++ b/src/content/releases/k/killing-kind/killing-kind/index.md
@@ -1,0 +1,48 @@
+﻿---
+title: "Killing Kind"
+artist: "Killing Kind"
+releaseDate: "2023-01-27"
+releaseType: "Album"
+labels:
+  - "Aenaos Records"
+  - "Viskningar och vrål"
+duration: "0:33:33"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "This Beautiful World"
+    trackNumber: 1
+    duration: "05:04"
+  - title: "When You Die"
+    trackNumber: 2
+    duration: "03:59"
+  - title: "Build Up, Tear Down"
+    trackNumber: 3
+    duration: "04:21"
+  - title: "Killing Kind"
+    trackNumber: 4
+    duration: "04:05"
+  - title: "The Silence"
+    trackNumber: 5
+    duration: "04:12"
+  - title: "The Game Nobody Wins"
+    trackNumber: 6
+    duration: "03:47"
+  - title: "Silver Lining"
+    trackNumber: 7
+    duration: "03:32"
+  - title: "Bound for Hell"
+    trackNumber: 8
+    duration: "04:29"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/c3d3f562-a9fb-48ea-9278-f3e8f80b1e7b"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Killing Kind is a release by Killing Kind released in 2023-01-27. It has been featured on 1 Sundown Sessions show. Featured tracks include This Beautiful World.
+
+

--- a/src/content/releases/k/kirsten-adamson/landing-place/index.md
+++ b/src/content/releases/k/kirsten-adamson/landing-place/index.md
@@ -1,0 +1,43 @@
+﻿---
+title: "Landing Place"
+artist: "Kirsten Adamson"
+releaseDate: "2023-02-03"
+labels:
+  - "Kirsten Adamson Music"
+featuredInShows:
+  - "3"
+shows:
+  - "3"
+tracks:
+  - title: "No Other Mother"
+    trackNumber: 1
+  - title: "My Father's Songs"
+    trackNumber: 2
+  - title: "Stars On The South Coast"
+    trackNumber: 3
+  - title: "Coals And Ashes"
+    trackNumber: 4
+  - title: "I Will Sign"
+    trackNumber: 5
+  - title: "Up And Down"
+    trackNumber: 6
+  - title: "Time With You"
+    trackNumber: 7
+  - title: "They Deserve Better"
+    trackNumber: 8
+  - title: "Useless At Being Alone"
+    trackNumber: 9
+  - title: "What Happens When You Don't Follow Your Heart"
+    trackNumber: 10
+  - title: "Without Warning"
+    trackNumber: 11
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/be7988f8-8e81-41f6-a478-46065cfc8ba3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Landing Place is a release by Kirsten Adamson released in 2023-02-03. It has been featured on 1 Sundown Sessions show. Featured tracks include My Father's Songs.
+
+

--- a/src/content/releases/k/kirsten-adamson/take-me-as-i-am/index.md
+++ b/src/content/releases/k/kirsten-adamson/take-me-as-i-am/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Take Me As I Am"
+artist: "Kirsten Adamson"
+releaseDate: "2023"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Take Me As I Am is a release by Kirsten Adamson released in 2023. It has been featured on 1 Sundown Sessions show. Featured tracks include Take Me As I Am.
+
+## Tracks Featured on Sundown Sessions
+
+- Take Me As I Am
+
+

--- a/src/content/releases/k/kristin-hersh/hips-and-makers/index.md
+++ b/src/content/releases/k/kristin-hersh/hips-and-makers/index.md
@@ -1,0 +1,73 @@
+﻿---
+title: "Hips and Makers"
+artist: "Kristin Hersh"
+releaseDate: "1994-01-24"
+releaseType: "Album"
+genres:
+  - "alt folk"
+  - "rock"
+  - "indie rock"
+  - "acoustic"
+labels:
+  - "Sire Records"
+duration: "0:50:28"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Your Ghost"
+    trackNumber: 1
+    duration: "03:16"
+  - title: "Beestung"
+    trackNumber: 2
+    duration: "03:08"
+  - title: "Teeth"
+    trackNumber: 3
+    duration: "04:10"
+  - title: "Sundrops"
+    trackNumber: 4
+    duration: "04:02"
+  - title: "Sparky"
+    trackNumber: 5
+    duration: "01:29"
+  - title: "Houdini Blues"
+    trackNumber: 6
+    duration: "04:26"
+  - title: "A Loon"
+    trackNumber: 7
+    duration: "04:18"
+  - title: "Velvet Days"
+    trackNumber: 8
+    duration: "03:52"
+  - title: "Close Your Eyes"
+    trackNumber: 9
+    duration: "05:27"
+  - title: "Me and My Charms"
+    trackNumber: 10
+    duration: "04:16"
+  - title: "Tuesday Night"
+    trackNumber: 11
+    duration: "03:03"
+  - title: "The Letter"
+    trackNumber: 12
+    duration: "02:47"
+  - title: "Lurch"
+    trackNumber: 13
+    duration: "00:36"
+  - title: "The Cuckoo"
+    trackNumber: 14
+    duration: "02:12"
+  - title: "Hips and Makers"
+    trackNumber: 15
+    duration: "03:19"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/55e5d5c7-ad75-3c6d-bfff-cb8a65d177d7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Hips and Makers is a release by Kristin Hersh released in 1994-01-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Your Ghost.
+
+

--- a/src/content/releases/k/kubb/mother/index.md
+++ b/src/content/releases/k/kubb/mother/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "Mother"
+artist: "Kubb"
+releaseDate: "2005-11-14"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "indie rock"
+  - "rock and indie"
+  - "pop rock"
+  - "electronic"
+labels:
+  - "Mercury Records"
+duration: "0:47:30"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Remain"
+    trackNumber: 1
+    duration: "03:36"
+  - title: "I Don't Mind"
+    trackNumber: 2
+    duration: "03:49"
+  - title: "Somebody Else"
+    trackNumber: 3
+    duration: "02:54"
+  - title: "Wicked Soul"
+    trackNumber: 4
+    duration: "03:46"
+  - title: "Grow"
+    trackNumber: 5
+    duration: "05:13"
+  - title: "If I Can't Have You"
+    trackNumber: 6
+    duration: "03:26"
+  - title: "Alcatraz"
+    trackNumber: 7
+    duration: "03:18"
+  - title: "Chemical"
+    trackNumber: 8
+    duration: "06:06"
+  - title: "Sun"
+    trackNumber: 9
+    duration: "03:10"
+  - title: "Without You"
+    trackNumber: 10
+    duration: "03:56"
+  - title: "Bitch"
+    trackNumber: 11
+    duration: "03:37"
+  - title: "Burn Again"
+    trackNumber: 12
+    duration: "04:32"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e439f605-2337-3846-a51b-336238a45e8c"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Mother is a release by Kubb released in 2005-11-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Wicked Soul.
+
+

--- a/src/content/releases/l/led-zeppelin/led-zeppelin-iii-remaster/index.md
+++ b/src/content/releases/l/led-zeppelin/led-zeppelin-iii-remaster/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Led Zeppelin III (Remaster)"
+artist: "Led Zeppelin"
+releaseDate: "1970"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Led Zeppelin III (Remaster) is a release by Led Zeppelin released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Since I've Been Loving You - Remaster.
+
+## Tracks Featured on Sundown Sessions
+
+- Since I've Been Loving You - Remaster
+
+

--- a/src/content/releases/l/led-zeppelin/led-zeppelin/index.md
+++ b/src/content/releases/l/led-zeppelin/led-zeppelin/index.md
@@ -1,0 +1,143 @@
+﻿---
+title: "Led Zeppelin"
+artist: "Led Zeppelin"
+releaseDate: "2001"
+releaseType: "Album"
+labels:
+  - "Warner/Chappell Music, Inc."
+duration: "3:37:34"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "Dazed and Confused"
+    trackNumber: 1
+    duration: "06:28"
+  - title: "Good Times Bad Times"
+    trackNumber: 2
+    duration: "02:47"
+  - title: "Communication Breakdown"
+    trackNumber: 3
+    duration: "02:29"
+  - title: "Babe I’m Gonna Leave You"
+    trackNumber: 4
+    duration: "06:43"
+  - title: "Whole Lotta Love"
+    trackNumber: 5
+    duration: "05:35"
+  - title: "Ramble On"
+    trackNumber: 6
+    duration: "04:25"
+  - title: "Heartbreaker"
+    trackNumber: 7
+    duration: "04:16"
+  - title: "What Is and What Should Never Be"
+    trackNumber: 8
+    duration: "04:45"
+  - title: "Thank You"
+    trackNumber: 9
+    duration: "04:51"
+  - title: "Immigrant Song"
+    trackNumber: 10
+    duration: "02:25"
+  - title: "Celebration Day"
+    trackNumber: 11
+    duration: "03:30"
+  - title: "Since I’ve Been Loving You"
+    trackNumber: 12
+    duration: "07:25"
+  - title: "Hey Hey What Can I Do"
+    trackNumber: 13
+    duration: "03:57"
+  - title: "Out on the Tiles"
+    trackNumber: 14
+    duration: "04:07"
+  - title: "Black Dog"
+    trackNumber: 15
+    duration: "04:56"
+  - title: "Rock and Roll"
+    trackNumber: 16
+    duration: "03:40"
+  - title: "Stairway to Heaven"
+    trackNumber: 1
+    duration: "08:01"
+  - title: "The Battle of Evermore"
+    trackNumber: 2
+    duration: "05:53"
+  - title: "When the Levee Breaks"
+    trackNumber: 3
+    duration: "07:10"
+  - title: "Misty Mountain Hop"
+    trackNumber: 4
+    duration: "04:40"
+  - title: "Going to California"
+    trackNumber: 5
+    duration: "03:32"
+  - title: "Over the Hills and Far Away"
+    trackNumber: 6
+    duration: "04:51"
+  - title: "Dancing Days"
+    trackNumber: 7
+    duration: "03:43"
+  - title: "The Rain Song"
+    trackNumber: 8
+    duration: "07:40"
+  - title: "The Ocean"
+    trackNumber: 9
+    duration: "04:32"
+  - title: "Houses of the Holy"
+    trackNumber: 10
+    duration: "04:04"
+  - title: "D’yer Mak’er"
+    trackNumber: 11
+    duration: "04:24"
+  - title: "No Quarter"
+    trackNumber: 12
+    duration: "07:01"
+  - title: "The Song Remains the Same"
+    trackNumber: 13
+    duration: "05:30"
+  - title: "Kashmir"
+    trackNumber: 1
+    duration: "08:29"
+  - title: "Sick Again"
+    trackNumber: 2
+    duration: "04:44"
+  - title: "Trampled Under Foot"
+    trackNumber: 3
+    duration: "05:38"
+  - title: "In the Light"
+    trackNumber: 4
+    duration: "08:47"
+  - title: "The Wanton Song"
+    trackNumber: 5
+    duration: "04:09"
+  - title: "Ten Years Gone"
+    trackNumber: 6
+    duration: "06:34"
+  - title: "Nobody’s Fault but Mine"
+    trackNumber: 7
+    duration: "06:17"
+  - title: "Achilles Last Stand"
+    trackNumber: 8
+    duration: "10:24"
+  - title: "Fool in the Rain"
+    trackNumber: 9
+    duration: "06:14"
+  - title: "All My Love"
+    trackNumber: 10
+    duration: "05:53"
+  - title: "In the Evening"
+    trackNumber: 11
+    duration: "06:46"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/7cfaae49-db15-4c27-a3e2-86cfcb7be3ee"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Led Zeppelin is a release by Led Zeppelin released in 2001. It has been featured on 1 Sundown Sessions show. Featured tracks include I Can't Quit You Baby.
+
+

--- a/src/content/releases/l/lenny-kravitz/are-you-gonna-go-my-way/index.md
+++ b/src/content/releases/l/lenny-kravitz/are-you-gonna-go-my-way/index.md
@@ -1,0 +1,41 @@
+﻿---
+title: "Are You Gonna Go My Way"
+artist: "Lenny Kravitz"
+releaseDate: "1993"
+releaseType: "Single"
+genres:
+  - "pop rock"
+  - "rock"
+  - "hard rock"
+  - "soft rock"
+  - "alternative rock"
+labels:
+  - "Virgin America"
+duration: "0:17:55"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "Are You Gonna Go My Way"
+    trackNumber: 1
+    duration: "03:32"
+  - title: "My Love"
+    trackNumber: 2
+    duration: "03:52"
+  - title: "All My Life"
+    trackNumber: 3
+    duration: "06:16"
+  - title: "Someone Like You"
+    trackNumber: 4
+    duration: "04:14"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/9018165c-4df6-3955-ab16-48658eb7e658"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Are You Gonna Go My Way is a release by Lenny Kravitz released in 1993. It has been featured on 1 Sundown Sessions show. Featured tracks include Are You Gonna Go My Way.
+
+

--- a/src/content/releases/l/live/throwing-copper/index.md
+++ b/src/content/releases/l/live/throwing-copper/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Throwing Copper"
+artist: "Live"
+releaseDate: "1994"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Throwing Copper is a release by Live released in 1994. It has been featured on 1 Sundown Sessions show. Featured tracks include Selling The Drama.
+
+## Tracks Featured on Sundown Sessions
+
+- Selling The Drama
+
+

--- a/src/content/releases/l/lloyd-cole-and-the-commotions/mainstream/index.md
+++ b/src/content/releases/l/lloyd-cole-and-the-commotions/mainstream/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Mainstream"
+artist: "Lloyd Cole and the Commotions"
+releaseDate: "1987-10-26"
+releaseType: "Album"
+genres:
+  - "indie pop"
+  - "pop rock"
+  - "brit rock"
+  - "indie rock"
+  - "rock"
+labels:
+  - "Polydor"
+duration: "0:40:11"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+tracks:
+  - title: "My Bag"
+    trackNumber: 1
+    duration: "03:56"
+  - title: "From the Hip"
+    trackNumber: 2
+    duration: "03:57"
+  - title: "29"
+    trackNumber: 3
+    duration: "05:28"
+  - title: "Mainstream"
+    trackNumber: 4
+    duration: "03:14"
+  - title: "Jennifer She Said"
+    trackNumber: 5
+    duration: "03:02"
+  - title: "Mister Malcontent"
+    trackNumber: 6
+    duration: "04:49"
+  - title: "Sean Penn Blues"
+    trackNumber: 7
+    duration: "03:28"
+  - title: "Big Snake"
+    trackNumber: 8
+    duration: "05:16"
+  - title: "Hey Rusty"
+    trackNumber: 9
+    duration: "04:30"
+  - title: "These Days"
+    trackNumber: 10
+    duration: "02:27"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6e3f99ab-fccf-379a-9631-ad8940967db3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Mainstream is a release by Lloyd Cole and the Commotions released in 1987-10-26. It has been featured on 1 Sundown Sessions show. Featured tracks include My Bag.
+
+

--- a/src/content/releases/l/love-and-rockets/express/index.md
+++ b/src/content/releases/l/love-and-rockets/express/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "Express"
+artist: "Love and Rockets"
+releaseDate: "1986-09-15"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "goth rock"
+  - "alternative rock"
+  - "psychedelic rock"
+labels:
+  - "Big Time Records"
+  - "Beggars Banquet"
+duration: "0:47:31"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "It Could Be Sunshine"
+    trackNumber: 1
+    duration: "04:59"
+  - title: "Kundalini Express"
+    trackNumber: 2
+    duration: "05:48"
+  - title: "All in My Mind"
+    trackNumber: 3
+    duration: "04:44"
+  - title: "Life in Laralay"
+    trackNumber: 4
+    duration: "03:32"
+  - title: "Ball of Confusion"
+    trackNumber: 5
+    duration: "07:22"
+  - title: "Yin and Yang The Flower Pot Man"
+    trackNumber: 6
+    duration: "05:54"
+  - title: "Love Me"
+    trackNumber: 7
+    duration: "03:55"
+  - title: "All in My Mind (acoustic version)"
+    trackNumber: 8
+    duration: "05:07"
+  - title: "An American Dream"
+    trackNumber: 9
+    duration: "06:06"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/76abb523-ddc9-367e-997b-4d88f9f93da0"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Express is a release by Love and Rockets released in 1986-09-15. It has been featured on 1 Sundown Sessions show. Featured tracks include Kundalini Express.
+
+

--- a/src/content/releases/l/love/forever-changes/index.md
+++ b/src/content/releases/l/love/forever-changes/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "Forever Changes"
+artist: "Love"
+releaseDate: "1967-11-01"
+releaseType: "Album"
+genres:
+  - "psychedelic rock"
+  - "folk rock"
+  - "baroque pop"
+  - "rock"
+  - "psychedelic pop"
+labels:
+  - "Elektra"
+duration: "0:42:05"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "Alone Again Or"
+    trackNumber: 1
+    duration: "03:15"
+  - title: "A House Is Not a Motel"
+    trackNumber: 2
+    duration: "03:25"
+  - title: "Andmoreagain"
+    trackNumber: 3
+    duration: "03:15"
+  - title: "The Daily Planet"
+    trackNumber: 4
+    duration: "03:25"
+  - title: "Old Man"
+    trackNumber: 5
+    duration: "02:57"
+  - title: "The Red Telephone"
+    trackNumber: 6
+    duration: "04:45"
+  - title: "Maybe the People Would Be the Times or Between Clark and Hilldale"
+    trackNumber: 7
+    duration: "03:30"
+  - title: "Live and Let Live"
+    trackNumber: 8
+    duration: "05:24"
+  - title: "The Good Humor Man He Sees Everything Like This"
+    trackNumber: 9
+    duration: "03:00"
+  - title: "Bummer in the Summer"
+    trackNumber: 10
+    duration: "02:20"
+  - title: "You Set the Scene"
+    trackNumber: 11
+    duration: "06:49"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/c7035bc6-6101-326f-992c-401d451c1716"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Forever Changes is a release by Love released in 1967-11-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Alone Again Or.
+
+

--- a/src/content/releases/l/love/love/index.md
+++ b/src/content/releases/l/love/love/index.md
@@ -1,0 +1,39 @@
+﻿---
+title: "Love"
+artist: "Love"
+releaseDate: "2017-09-06"
+releaseType: "Single"
+genres:
+  - "j-pop"
+labels:
+  - "SACRA MUSIC"
+duration: "0:16:58"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "=LOVE"
+    trackNumber: 1
+    duration: "04:07"
+  - title: "記憶のどこかで"
+    trackNumber: 2
+    duration: "04:21"
+  - title: "=LOVE (instrumental)"
+    trackNumber: 3
+    duration: "04:07"
+  - title: "記憶のどこかで (instrumental)"
+    trackNumber: 4
+    duration: "04:21"
+  - title: "=LOVE Music Video"
+    trackNumber: 1
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/244e176b-b247-42c0-9363-36989c5ecae0"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Love is a release by Love released in 2017-09-06. It has been featured on 1 Sundown Sessions show. Featured tracks include My Flash On You.
+
+

--- a/src/content/releases/m/marc-bolan/the-t-rex-wax-co-singles-as-and-bs-1972-77/index.md
+++ b/src/content/releases/m/marc-bolan/the-t-rex-wax-co-singles-as-and-bs-1972-77/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The T.Rex Wax Co. Singles A's & B's 1972-77"
+artist: "Marc Bolan"
+releaseDate: "2002"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The T.Rex Wax Co. Singles A's & B's 1972-77 is a release by Marc Bolan released in 2002. It has been featured on 1 Sundown Sessions show. Featured tracks include Children Of The Revolution.
+
+## Tracks Featured on Sundown Sessions
+
+- Children Of The Revolution
+
+

--- a/src/content/releases/m/maria-mckee/you-gotta-sin-to-get-saved/index.md
+++ b/src/content/releases/m/maria-mckee/you-gotta-sin-to-get-saved/index.md
@@ -1,0 +1,57 @@
+﻿---
+title: "You Gotta Sin To Get Saved"
+artist: "Maria McKee"
+releaseDate: "1993-06-22"
+releaseType: "Album"
+genres:
+  - "country rock"
+  - "rock"
+labels:
+  - "Geffen Records"
+  - "MCA Records"
+duration: "0:41:10"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+tracks:
+  - title: "I'm Gonna Soothe You"
+    trackNumber: 1
+    duration: "03:39"
+  - title: "My Lonely Sad Eyes"
+    trackNumber: 2
+    duration: "02:42"
+  - title: "My Girlhood Among the Outlaws"
+    trackNumber: 3
+    duration: "03:45"
+  - title: "Only Once"
+    trackNumber: 4
+    duration: "04:04"
+  - title: "I Forgive You"
+    trackNumber: 5
+    duration: "05:11"
+  - title: "I Can't Make It Alone"
+    trackNumber: 6
+    duration: "03:39"
+  - title: "Precious Time"
+    trackNumber: 7
+    duration: "03:38"
+  - title: "The Way Young Lovers Do"
+    trackNumber: 8
+    duration: "03:30"
+  - title: "Why Wasn't I More Grateful (When Life Was Sweet)"
+    trackNumber: 9
+    duration: "05:05"
+  - title: "You Gotta Sin to Get Saved"
+    trackNumber: 10
+    duration: "05:52"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e201ff03-40c3-3eea-ad27-3b1891f46672"
+lastmod: "2026-06-25"
+---
+
+## About
+
+You Gotta Sin To Get Saved is a release by Maria McKee released in 1993-06-22. It has been featured on 1 Sundown Sessions show. Featured tracks include I Can't Make It Alone.
+
+

--- a/src/content/releases/m/masters-of-reality/pine-cross-dover/index.md
+++ b/src/content/releases/m/masters-of-reality/pine-cross-dover/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "Pine/Cross Dover"
+artist: "Masters Of Reality"
+releaseDate: "2009-08-24"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "stoner metal"
+  - "progressive metal"
+  - "rock"
+  - "heavy metal"
+labels:
+  - "Brownhouse Recordings"
+duration: "0:51:48"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "King Richard TLH"
+    trackNumber: 1
+    duration: "04:20"
+  - title: "Absinthe Jim and Me"
+    trackNumber: 2
+    duration: "03:03"
+  - title: "Worm in the Silk"
+    trackNumber: 3
+    duration: "04:23"
+  - title: "Always"
+    trackNumber: 4
+    duration: "03:24"
+  - title: "Johnny’s Dream"
+    trackNumber: 5
+    duration: "04:38"
+  - title: "Up in It"
+    trackNumber: 6
+    duration: "03:43"
+  - title: "Dreamtime Stomp"
+    trackNumber: 7
+    duration: "03:59"
+  - title: "Rosie’s Presence"
+    trackNumber: 8
+    duration: "03:12"
+  - title: "The Whore of New Orleans"
+    trackNumber: 9
+    duration: "04:43"
+  - title: "Testify to Love"
+    trackNumber: 10
+    duration: "04:16"
+  - title: "Alfalfa"
+    trackNumber: 11
+    duration: "12:07"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/62cacc87-7df9-451f-b6cd-9645817006a1"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Pine/Cross Dover is a release by Masters Of Reality released in 2009-08-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Dreamtime Stomp.
+
+

--- a/src/content/releases/m/may-blitz/may-blitz/index.md
+++ b/src/content/releases/m/may-blitz/may-blitz/index.md
@@ -1,0 +1,42 @@
+﻿---
+title: "May Blitz"
+artist: "May Blitz"
+releaseDate: "1970"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "heavy psych"
+  - "jam band"
+  - "rock"
+  - "progressive rock"
+labels:
+  - "Vertigo"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "Smoking the Day Away"
+    trackNumber: 1
+  - title: "I Don’t Know?"
+    trackNumber: 2
+  - title: "Dreaming"
+    trackNumber: 3
+  - title: "Squeet"
+    trackNumber: 4
+  - title: "Tomorrow May Come"
+    trackNumber: 5
+  - title: "Fire Queen"
+    trackNumber: 6
+  - title: "Virgin Waters"
+    trackNumber: 7
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/400ef392-638e-380e-a89d-a656b045a5de"
+lastmod: "2026-06-25"
+---
+
+## About
+
+May Blitz is a release by May Blitz released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include I Don't Know?.
+
+

--- a/src/content/releases/m/mean-gene-kelton/most-requested/index.md
+++ b/src/content/releases/m/mean-gene-kelton/most-requested/index.md
@@ -1,0 +1,66 @@
+﻿---
+title: "Most Requested"
+artist: "Mean Gene Kelton"
+releaseDate: "1999"
+releaseType: "Album"
+duration: "1:06:41"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Texas Honey"
+    trackNumber: 1
+    duration: "04:17"
+  - title: "Too White to Play the Blues"
+    trackNumber: 2
+    duration: "04:31"
+  - title: "If This Guitar Could Talk"
+    trackNumber: 3
+    duration: "04:47"
+  - title: "Tears on My Guitar"
+    trackNumber: 4
+    duration: "05:38"
+  - title: "Going Back to Memphis"
+    trackNumber: 5
+    duration: "04:12"
+  - title: "Cruisin' Texas Avenue"
+    trackNumber: 6
+    duration: "04:04"
+  - title: "Sinking Deeper (Into the Blues)"
+    trackNumber: 7
+    duration: "04:27"
+  - title: "Big Legged Mama"
+    trackNumber: 8
+    duration: "03:36"
+  - title: "Leaving Paradies (Goodbye Louisiana)"
+    trackNumber: 9
+    duration: "04:47"
+  - title: "The Avon Man"
+    trackNumber: 10
+    duration: "04:53"
+  - title: "Little Black Dress"
+    trackNumber: 11
+    duration: "03:42"
+  - title: "My Blow Up Lover"
+    trackNumber: 12
+    duration: "03:31"
+  - title: "Let Me Pump Your Gas"
+    trackNumber: 13
+    duration: "04:01"
+  - title: "The Texas City Dyke"
+    trackNumber: 14
+    duration: "04:47"
+  - title: "My Baby Don't Wear No Panties"
+    trackNumber: 15
+    duration: "05:28"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/191d26fd-9eff-3cbe-978e-b3c50af8d07e"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Most Requested is a release by Mean Gene Kelton released in 1999. It has been featured on 1 Sundown Sessions show. Featured tracks include My Baby Don't Wear No Panties.
+
+

--- a/src/content/releases/m/melys/chinese-whispers/index.md
+++ b/src/content/releases/m/melys/chinese-whispers/index.md
@@ -1,0 +1,36 @@
+﻿---
+title: "Chinese Whispers"
+artist: "Melys"
+releaseDate: "2001"
+releaseType: "Single"
+genres:
+  - "indie rock"
+  - "rock"
+labels:
+  - "Transformed Dreams"
+  - "Sylem Records"
+duration: "0:13:17"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "Chinese Whispers"
+    trackNumber: 1
+    duration: "04:15"
+  - title: "Watercolour"
+    trackNumber: 2
+    duration: "03:57"
+  - title: "Gwerthpawr"
+    trackNumber: 3
+    duration: "05:05"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e388789a-bac2-3778-b138-f855f691527f"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Chinese Whispers is a release by Melys released in 2001. It has been featured on 1 Sundown Sessions show. Featured tracks include Chinese Whispers.
+
+

--- a/src/content/releases/m/metallica/load/index.md
+++ b/src/content/releases/m/metallica/load/index.md
@@ -1,0 +1,73 @@
+﻿---
+title: "Load"
+artist: "Metallica"
+releaseDate: "1996-05-04"
+releaseType: "Album"
+genres:
+  - "heavy metal"
+  - "hard rock"
+  - "alternative rock"
+  - "rock"
+  - "metal"
+labels:
+  - "Vertigo"
+duration: "1:18:57"
+featuredInShows:
+  - "12"
+  - "46"
+shows:
+  - "12"
+  - "46"
+tracks:
+  - title: "Ain’t My Bitch"
+    trackNumber: 1
+    duration: "05:04"
+  - title: "2 X 4"
+    trackNumber: 2
+    duration: "05:28"
+  - title: "The House Jack Built"
+    trackNumber: 3
+    duration: "06:38"
+  - title: "Until It Sleeps"
+    trackNumber: 4
+    duration: "04:28"
+  - title: "King Nothing"
+    trackNumber: 5
+    duration: "05:29"
+  - title: "Hero of the Day"
+    trackNumber: 6
+    duration: "04:21"
+  - title: "Bleeding Me"
+    trackNumber: 7
+    duration: "08:17"
+  - title: "Cure"
+    trackNumber: 8
+    duration: "04:54"
+  - title: "Poor Twisted Me"
+    trackNumber: 9
+    duration: "04:00"
+  - title: "Wasting My Hate"
+    trackNumber: 10
+    duration: "03:57"
+  - title: "Mama Said"
+    trackNumber: 11
+    duration: "05:19"
+  - title: "Thorn Within"
+    trackNumber: 12
+    duration: "05:51"
+  - title: "Ronnie"
+    trackNumber: 13
+    duration: "05:17"
+  - title: "The Outlaw Torn"
+    trackNumber: 14
+    duration: "09:48"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e389b7df-862d-3d91-a612-acca150f6e71"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Load is a release by Metallica released in 1996-05-04. It has been featured on 2 Sundown Sessions shows. Featured tracks include King Nothing.
+
+

--- a/src/content/releases/n/nadine-shah/filthy-underneath/index.md
+++ b/src/content/releases/n/nadine-shah/filthy-underneath/index.md
@@ -1,0 +1,60 @@
+﻿---
+title: "Filthy Underneath"
+artist: "Nadine Shah"
+releaseDate: "2024-02-23"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "indie pop"
+  - "pop"
+labels:
+  - "EMI North"
+duration: "0:49:39"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Even Light"
+    trackNumber: 1
+    duration: "04:08"
+  - title: "Topless Mother"
+    trackNumber: 2
+    duration: "03:18"
+  - title: "Food for Fuel"
+    trackNumber: 3
+    duration: "05:07"
+  - title: "You Drive, I Shoot"
+    trackNumber: 4
+    duration: "02:54"
+  - title: "Keeping Score"
+    trackNumber: 5
+    duration: "04:28"
+  - title: "Sad Lads Anonymous"
+    trackNumber: 6
+    duration: "05:08"
+  - title: "Greatest Dancer"
+    trackNumber: 7
+    duration: "05:26"
+  - title: "See My Girl"
+    trackNumber: 8
+    duration: "04:40"
+  - title: "Twenty Things"
+    trackNumber: 9
+    duration: "05:26"
+  - title: "Hyperrealism"
+    trackNumber: 10
+    duration: "04:03"
+  - title: "French Exit"
+    trackNumber: 11
+    duration: "05:01"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6cbab3d8-ca06-4f9a-add8-df744144dde3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Filthy Underneath is a release by Nadine Shah released in 2024-02-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Greatest Dancer.
+
+

--- a/src/content/releases/n/nancy-sinatra/nancy-in-london/index.md
+++ b/src/content/releases/n/nancy-sinatra/nancy-in-london/index.md
@@ -1,0 +1,61 @@
+﻿---
+title: "Nancy In London"
+artist: "Nancy Sinatra"
+releaseDate: "1966"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "pop/rock"
+  - "country"
+  - "jazz"
+labels:
+  - "Reprise Records"
+duration: "0:30:00"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "On Broadway"
+    trackNumber: 1
+    duration: "02:47"
+  - title: "The End"
+    trackNumber: 2
+    duration: "02:25"
+  - title: "Step Aside"
+    trackNumber: 3
+    duration: "02:36"
+  - title: "I Can't Grow Peaches on a Cherry Tree"
+    trackNumber: 4
+    duration: "02:41"
+  - title: "Summer Wine"
+    trackNumber: 5
+    duration: "03:44"
+  - title: "Wishin' and Hopin'"
+    trackNumber: 6
+    duration: "02:52"
+  - title: "This Little Bird"
+    trackNumber: 7
+    duration: "02:10"
+  - title: "Shades"
+    trackNumber: 8
+    duration: "02:18"
+  - title: "The More I See You"
+    trackNumber: 9
+    duration: "02:32"
+  - title: "Hutchinson Jail"
+    trackNumber: 10
+    duration: "02:51"
+  - title: "Friday's Child"
+    trackNumber: 11
+    duration: "03:04"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d3e3dcf7-ae64-306b-a4cc-e2e608a1e0e2"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Nancy In London is a release by Nancy Sinatra released in 1966. It has been featured on 1 Sundown Sessions show. Featured tracks include Friday's Child.
+
+

--- a/src/content/releases/n/nazareth/the-anthology/index.md
+++ b/src/content/releases/n/nazareth/the-anthology/index.md
@@ -1,0 +1,142 @@
+﻿---
+title: "The Anthology"
+artist: "Nazareth"
+releaseDate: "2009-01-01"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "classic rock"
+  - "rock"
+  - "heavy metal"
+labels:
+  - "Salvo"
+duration: "2:35:02"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Razamanaz"
+    trackNumber: 1
+    duration: "03:49"
+  - title: "Bad Bad Boy"
+    trackNumber: 2
+    duration: "03:57"
+  - title: "Broken Down Angel"
+    trackNumber: 3
+    duration: "03:44"
+  - title: "Woke Up This Morning"
+    trackNumber: 4
+    duration: "03:53"
+  - title: "Go Down Fighting"
+    trackNumber: 5
+    duration: "03:05"
+  - title: "Turn on Your Receiver"
+    trackNumber: 6
+    duration: "03:19"
+  - title: "Teenage Nervous Breakdown"
+    trackNumber: 7
+    duration: "03:43"
+  - title: "This Flight Tonight"
+    trackNumber: 8
+    duration: "03:23"
+  - title: "Sunshine"
+    trackNumber: 9
+    duration: "04:14"
+  - title: "Shanghai'd in Shanghai"
+    trackNumber: 10
+    duration: "03:43"
+  - title: "Hair of the Dog"
+    trackNumber: 11
+    duration: "04:11"
+  - title: "Love Hurts"
+    trackNumber: 12
+    duration: "03:51"
+  - title: "My White Bicycle"
+    trackNumber: 13
+    duration: "03:26"
+  - title: "Holy Roller"
+    trackNumber: 14
+    duration: "03:24"
+  - title: "Telegram"
+    trackNumber: 15
+    duration: "07:48"
+  - title: "Expect No Mercy"
+    trackNumber: 16
+    duration: "03:27"
+  - title: "Gone Dead Train"
+    trackNumber: 17
+    duration: "03:44"
+  - title: "Place in Your Heart"
+    trackNumber: 18
+    duration: "03:01"
+  - title: "No Mean City"
+    trackNumber: 19
+    duration: "06:30"
+  - title: "Just to Get Into It"
+    trackNumber: 1
+    duration: "04:22"
+  - title: "May the Sunshine"
+    trackNumber: 2
+    duration: "04:54"
+  - title: "Whatever You Want Babe"
+    trackNumber: 3
+    duration: "03:41"
+  - title: "Holiday"
+    trackNumber: 4
+    duration: "03:37"
+  - title: "Heart's Grown Cold"
+    trackNumber: 5
+    duration: "04:13"
+  - title: "Moonlight Eyes"
+    trackNumber: 6
+    duration: "03:36"
+  - title: "Cocaine (live)"
+    trackNumber: 7
+    duration: "04:38"
+  - title: "Little Part of You"
+    trackNumber: 8
+    duration: "03:30"
+  - title: "Dream On"
+    trackNumber: 9
+    duration: "03:26"
+  - title: "Where Are You Now"
+    trackNumber: 10
+    duration: "03:55"
+  - title: "Ruby Tuesday"
+    trackNumber: 11
+    duration: "03:28"
+  - title: "This Month's Messiah"
+    trackNumber: 12
+    duration: "05:17"
+  - title: "Piece of My Heart"
+    trackNumber: 13
+    duration: "04:26"
+  - title: "Winner on the Night"
+    trackNumber: 14
+    duration: "04:11"
+  - title: "Every Time It Rains"
+    trackNumber: 15
+    duration: "04:11"
+  - title: "Thinkin' Man's Nightmare"
+    trackNumber: 16
+    duration: "04:02"
+  - title: "Steamroller"
+    trackNumber: 17
+    duration: "04:29"
+  - title: "When the Lights Come Down"
+    trackNumber: 18
+    duration: "03:29"
+  - title: "Goin' Loco"
+    trackNumber: 19
+    duration: "05:25"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/300ddc6c-677c-42fc-a9df-95a2123d8840"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Anthology is a release by Nazareth released in 2009-01-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Bad, Bad Boy.
+
+

--- a/src/content/releases/n/nazz/nazz/index.md
+++ b/src/content/releases/n/nazz/nazz/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Nazz"
+artist: "Nazz"
+releaseDate: "1968"
+releaseType: "Album"
+genres:
+  - "garage rock"
+  - "psychedelic rock"
+  - "pop rock"
+  - "rock"
+  - "hard rock"
+labels:
+  - "Atlantic"
+duration: "0:37:58"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Open My Eyes"
+    trackNumber: 1
+    duration: "02:48"
+  - title: "Back of Your Mind"
+    trackNumber: 2
+    duration: "03:48"
+  - title: "See What You Can Be"
+    trackNumber: 3
+    duration: "03:00"
+  - title: "Hello It's Me"
+    trackNumber: 4
+    duration: "03:57"
+  - title: "Wildwood Blues"
+    trackNumber: 5
+    duration: "04:39"
+  - title: "If That's the Way You Feel"
+    trackNumber: 6
+    duration: "04:49"
+  - title: "When I Get My Plane"
+    trackNumber: 7
+    duration: "03:08"
+  - title: "Lemming Song"
+    trackNumber: 8
+    duration: "04:26"
+  - title: "Crowded"
+    trackNumber: 9
+    duration: "02:20"
+  - title: "She's Goin' Down"
+    trackNumber: 10
+    duration: "04:59"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/0b35e47d-8970-3fd8-b241-6d24e6ee5aea"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Nazz is a release by Nazz released in 1968. It has been featured on 1 Sundown Sessions show. Featured tracks include Open My Eyes.
+
+

--- a/src/content/releases/n/neil-young/living-with-war/index.md
+++ b/src/content/releases/n/neil-young/living-with-war/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "Living with War"
+artist: "Neil Young"
+releaseDate: "2006-05-02"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "hard rock"
+  - "pop/rock"
+  - "album rock"
+  - "classic pop and rock"
+labels:
+  - "Reprise Records"
+duration: "0:38:56"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "After the Garden"
+    trackNumber: 1
+    duration: "03:23"
+  - title: "Living With War"
+    trackNumber: 2
+    duration: "05:04"
+  - title: "The Restless Consumer"
+    trackNumber: 3
+    duration: "05:47"
+  - title: "Shock and Awe"
+    trackNumber: 4
+    duration: "04:52"
+  - title: "Families"
+    trackNumber: 5
+    duration: "02:25"
+  - title: "Flags of Freedom"
+    trackNumber: 6
+    duration: "03:42"
+  - title: "Let's Impeach the President"
+    trackNumber: 7
+    duration: "05:10"
+  - title: "Lookin' for a Leader"
+    trackNumber: 8
+    duration: "04:03"
+  - title: "Roger and Out"
+    trackNumber: 9
+    duration: "04:25"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/216257f0-a33b-3b29-b7ff-5d133fef3691"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Living with War is a release by Neil Young released in 2006-05-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Heart Of Gold.
+
+

--- a/src/content/releases/n/nick-cave-and-the-bad-seeds/from-her-to-eternity/index.md
+++ b/src/content/releases/n/nick-cave-and-the-bad-seeds/from-her-to-eternity/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "From Her to Eternity"
+artist: "Nick Cave & The Bad Seeds"
+releaseDate: "2009"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+lastmod: "2026-06-25"
+---
+
+## About
+
+From Her to Eternity is a release by Nick Cave & The Bad Seeds released in 2009. It has been featured on 1 Sundown Sessions show. Featured tracks include From Her to Eternity.
+
+## Tracks Featured on Sundown Sessions
+
+- From Her to Eternity
+
+

--- a/src/content/releases/n/nick-lowe/party-of-one/index.md
+++ b/src/content/releases/n/nick-lowe/party-of-one/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "Party Of One"
+artist: "Nick Lowe"
+releaseDate: "1990"
+releaseType: "Album"
+genres:
+  - "country rock"
+  - "rock"
+  - "roots rock"
+  - "rock and roll"
+  - "pop rock"
+labels:
+  - "Reprise Records"
+duration: "0:36:01"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "You Got the Look I Like"
+    trackNumber: 1
+    duration: "03:23"
+  - title: "(I Want to Build a) Jumbo Ark"
+    trackNumber: 2
+    duration: "03:31"
+  - title: "Gai‐Gin Man"
+    trackNumber: 3
+    duration: "02:47"
+  - title: "Who Was That Man?"
+    trackNumber: 4
+    duration: "03:05"
+  - title: "What’s Shakin’ on the Hill"
+    trackNumber: 5
+    duration: "04:02"
+  - title: "Shting‐Shtang"
+    trackNumber: 6
+    duration: "03:22"
+  - title: "All Men Are Liars"
+    trackNumber: 7
+    duration: "03:25"
+  - title: "Rocky Road"
+    trackNumber: 8
+    duration: "03:25"
+  - title: "Refrigerator White"
+    trackNumber: 9
+    duration: "03:07"
+  - title: "I Don’t Know Why You Keep Me On"
+    trackNumber: 10
+    duration: "03:18"
+  - title: "Honey Gun"
+    trackNumber: 11
+    duration: "02:31"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6be32cf4-f46f-35f7-9a4b-8d218137a170"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Party Of One is a release by Nick Lowe released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include You Got The Look I Like.
+
+

--- a/src/content/releases/n/nick-lowe/quiet-please-the-new-best-of-nick-lowe/index.md
+++ b/src/content/releases/n/nick-lowe/quiet-please-the-new-best-of-nick-lowe/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Quiet Please: The New Best of Nick Lowe"
+artist: "Nick Lowe"
+releaseDate: "2009"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Quiet Please: The New Best of Nick Lowe is a release by Nick Lowe released in 2009. It has been featured on 1 Sundown Sessions show. Featured tracks include Half a Boy and Half a Man.
+
+## Tracks Featured on Sundown Sessions
+
+- Half a Boy and Half a Man
+
+

--- a/src/content/releases/n/nirvana/all-of-us/index.md
+++ b/src/content/releases/n/nirvana/all-of-us/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "All Of Us"
+artist: "Nirvana"
+releaseDate: "1968"
+releaseType: "Album"
+genres:
+  - "psychedelic rock"
+  - "rock"
+labels:
+  - "Island"
+duration: "0:35:27"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Rainbow Chaser"
+    trackNumber: 1
+    duration: "02:38"
+  - title: "Tiny Goddess"
+    trackNumber: 2
+    duration: "04:03"
+  - title: "The Touchables (All of Us)"
+    trackNumber: 3
+    duration: "02:59"
+  - title: "Melanie Blue"
+    trackNumber: 4
+    duration: "02:40"
+  - title: "Trapeze"
+    trackNumber: 5
+    duration: "02:49"
+  - title: "The Show Must Go On"
+    trackNumber: 6
+    duration: "02:40"
+  - title: "Girl in the Park"
+    trackNumber: 7
+    duration: "02:41"
+  - title: "Miami Masquerade"
+    trackNumber: 8
+    duration: "02:48"
+  - title: "Frankie the Great"
+    trackNumber: 9
+    duration: "02:29"
+  - title: "You Can Try It"
+    trackNumber: 10
+    duration: "03:18"
+  - title: "Everybody Loves the Clown"
+    trackNumber: 11
+    duration: "02:00"
+  - title: "St. John's Wood Affair"
+    trackNumber: 12
+    duration: "04:18"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e663bd4c-55dc-34de-b785-ed81643b5a7c"
+lastmod: "2026-06-25"
+---
+
+## About
+
+All Of Us is a release by Nirvana released in 1968. It has been featured on 1 Sundown Sessions show. Featured tracks include Rainbow Chaser.
+
+

--- a/src/content/releases/o/orchestral-manoeuvres-in-the-dark/orchestral-manoeuvres-in-the-dark/index.md
+++ b/src/content/releases/o/orchestral-manoeuvres-in-the-dark/orchestral-manoeuvres-in-the-dark/index.md
@@ -1,0 +1,32 @@
+﻿---
+title: "Orchestral Manoeuvres In The Dark"
+artist: "Orchestral Manoeuvres In The Dark"
+releaseDate: "1983"
+releaseType: "EP"
+genres:
+  - "synth-pop"
+  - "pop"
+  - "electronic"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Telegraph"
+    trackNumber: 1
+  - title: "Souvenir"
+    trackNumber: 2
+  - title: "Joan of Arc (Maid of Orleans)"
+    trackNumber: 3
+  - title: "Enola Gay"
+    trackNumber: 4
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/5c992cad-2064-4bdc-aeec-5cd9d27f0f38"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Orchestral Manoeuvres In The Dark is a release by Orchestral Manoeuvres In The Dark released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Messages.
+
+

--- a/src/content/releases/p/patti-smith/gung-ho/index.md
+++ b/src/content/releases/p/patti-smith/gung-ho/index.md
@@ -1,0 +1,67 @@
+﻿---
+title: "Gung Ho"
+artist: "Patti Smith"
+releaseDate: "2000-03-20"
+releaseType: "Album"
+genres:
+  - "pop"
+  - "rock"
+  - "original new wave scene"
+  - "alternative rock"
+labels:
+  - "Arista"
+duration: "1:04:36"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "One Voice"
+    trackNumber: 1
+    duration: "04:04"
+  - title: "Lo and Beholden"
+    trackNumber: 2
+    duration: "04:43"
+  - title: "Boy Cried Wolf"
+    trackNumber: 3
+    duration: "04:51"
+  - title: "Persuasion"
+    trackNumber: 4
+    duration: "04:33"
+  - title: "Gone Pie"
+    trackNumber: 5
+    duration: "04:04"
+  - title: "China Bird"
+    trackNumber: 6
+    duration: "04:07"
+  - title: "Glitter in Their Eyes"
+    trackNumber: 7
+    duration: "03:03"
+  - title: "Strange Messengers"
+    trackNumber: 8
+    duration: "08:02"
+  - title: "Grateful"
+    trackNumber: 9
+    duration: "04:29"
+  - title: "Upright Come"
+    trackNumber: 10
+    duration: "02:58"
+  - title: "New Party"
+    trackNumber: 11
+    duration: "04:30"
+  - title: "Libbie's Song"
+    trackNumber: 12
+    duration: "03:26"
+  - title: "Gung Ho"
+    trackNumber: 13
+    duration: "11:41"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6d5520df-b433-3376-a0c3-3dba9dc5973a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Gung Ho is a release by Patti Smith released in 2000-03-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Glitter In Their Eyes.
+
+

--- a/src/content/releases/p/paul-mccartney/ram/index.md
+++ b/src/content/releases/p/paul-mccartney/ram/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Ram"
+artist: "Paul McCartney"
+releaseDate: "1971"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Ram is a release by Paul McCartney released in 1971. It has been featured on 1 Sundown Sessions show. Featured tracks include Smile Away.
+
+## Tracks Featured on Sundown Sessions
+
+- Smile Away
+
+

--- a/src/content/releases/p/pete-shelley/xla-1/index.md
+++ b/src/content/releases/p/pete-shelley/xla-1/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "XLÂ·1"
+artist: "Pete Shelley"
+releaseDate: "1983"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+lastmod: "2026-06-25"
+---
+
+## About
+
+XLÂ·1 is a release by Pete Shelley released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Telephone Operator.
+
+## Tracks Featured on Sundown Sessions
+
+- Telephone Operator
+
+

--- a/src/content/releases/p/peter-murphy/remixes-from-lion/index.md
+++ b/src/content/releases/p/peter-murphy/remixes-from-lion/index.md
@@ -1,0 +1,58 @@
+﻿---
+title: "Remixes from Lion"
+artist: "Peter Murphy"
+releaseDate: "2015-06"
+releaseType: "Album"
+genres:
+  - "rock"
+labels:
+  - "Nettwerk"
+duration: "1:17:02"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "Hang Up (Youth Remix)"
+    trackNumber: 1
+    duration: "07:16"
+  - title: "Low Tar Stars (Youth Remix)"
+    trackNumber: 2
+    duration: "04:44"
+  - title: "The Ghost of Shokan Lake (Youth Remix)"
+    trackNumber: 3
+    duration: "06:27"
+  - title: "I Am My Own Name (Youth Remix)"
+    trackNumber: 4
+    duration: "07:06"
+  - title: "I'm On Your Side (Youth Remix)"
+    trackNumber: 5
+    duration: "06:02"
+  - title: "The Sound of Water (Youth Remix)"
+    trackNumber: 6
+    duration: "08:32"
+  - title: "Loctaine (Youth Remix)"
+    trackNumber: 7
+    duration: "06:52"
+  - title: "The Sound of Water"
+    trackNumber: 8
+    duration: "08:44"
+  - title: "Gabriel"
+    trackNumber: 9
+    duration: "05:21"
+  - title: "Prayer of Jonas in the Belly of the Whale (White Star Hawk Spirit Dance)"
+    trackNumber: 10
+    duration: "09:29"
+  - title: "Discreet Medley (Richard Thorne Ambient Remix)"
+    trackNumber: 11
+    duration: "06:24"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/ad358529-d72a-4d35-83fb-7a8000a8c59d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Remixes from Lion is a release by Peter Murphy released in 2015-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Hang Up - Youth Remix.
+
+

--- a/src/content/releases/p/phil-lynott/the-philip-lynott-album/index.md
+++ b/src/content/releases/p/phil-lynott/the-philip-lynott-album/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The Philip Lynott Album"
+artist: "Phil Lynott"
+releaseDate: "1982"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Philip Lynott Album is a release by Phil Lynott released in 1982. It has been featured on 1 Sundown Sessions show. Featured tracks include Yellow Pearl.
+
+## Tracks Featured on Sundown Sessions
+
+- Yellow Pearl
+
+

--- a/src/content/releases/p/pigs-pigs-pigs-pigs-pigs-pigs-pigs/hot-stuff/index.md
+++ b/src/content/releases/p/pigs-pigs-pigs-pigs-pigs-pigs-pigs/hot-stuff/index.md
@@ -1,0 +1,32 @@
+﻿---
+title: "Hot Stuff"
+artist: "Pigs Pigs Pigs Pigs Pigs Pigs Pigs"
+releaseDate: "2021-10-20"
+releaseType: "Single"
+genres:
+  - "doom metal"
+  - "sludge metal"
+  - "stoner rock"
+  - "rock"
+  - "krautrock"
+labels:
+  - "Rocket Recordings"
+duration: "0:04:58"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "Hot Stuff"
+    trackNumber: 1
+    duration: "04:58"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/4e024395-26b8-4081-ba1c-de61d7ee9314"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Hot Stuff is a release by Pigs Pigs Pigs Pigs Pigs Pigs Pigs released in 2021-10-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Hot Stuff.
+
+

--- a/src/content/releases/p/pink-floyd/the-early-years-1967-72-cre-ation/index.md
+++ b/src/content/releases/p/pink-floyd/the-early-years-1967-72-cre-ation/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The Early Years 1967-72 Cre/ation"
+artist: "Pink Floyd"
+releaseDate: "2016"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Early Years 1967-72 Cre/ation is a release by Pink Floyd released in 2016. It has been featured on 1 Sundown Sessions show. Featured tracks include See Emily Play.
+
+## Tracks Featured on Sundown Sessions
+
+- See Emily Play
+
+

--- a/src/content/releases/p/pink-floyd/the-piper-at-the-gates-of-dawn/index.md
+++ b/src/content/releases/p/pink-floyd/the-piper-at-the-gates-of-dawn/index.md
@@ -1,0 +1,50 @@
+﻿---
+title: "The Piper At The Gates Of Dawn"
+artist: "Pink Floyd"
+releaseDate: "1967-07-07"
+releaseType: "Album"
+genres:
+  - "psychedelic rock"
+  - "rock"
+  - "space rock"
+  - "experimental rock"
+  - "classic rock"
+labels:
+  - "Columbia Records"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+tracks:
+  - title: "Astronomy Domine"
+    trackNumber: 1
+  - title: "Lucifer Sam"
+    trackNumber: 2
+  - title: "Matilda Mother"
+    trackNumber: 3
+  - title: "Flaming"
+    trackNumber: 4
+  - title: "Pow R. Toc H."
+    trackNumber: 5
+  - title: "Bike"
+    trackNumber: 6
+  - title: "Interstellar Overdrive"
+    trackNumber: 7
+  - title: "The Gnome"
+    trackNumber: 8
+  - title: "Chapter 24"
+    trackNumber: 9
+  - title: "The Scarecrow"
+    trackNumber: 10
+  - title: "Take Up Thy Stethoscope and Walk"
+    trackNumber: 11
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6792b6d1-4e65-3c3c-9d20-d08aa1dcfc60"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Piper At The Gates Of Dawn is a release by Pink Floyd released in 1967-07-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Astronomy Domine.
+
+

--- a/src/content/releases/p/pixies/surfer-rosa/index.md
+++ b/src/content/releases/p/pixies/surfer-rosa/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Surfer Rosa"
+artist: "Pixies"
+releaseDate: "1988-03-21"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "rock"
+  - "alternative"
+  - "indie rock"
+  - "college rock"
+labels:
+  - "Grabaciones Accidentales"
+duration: "0:33:26"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Bone Machine"
+    trackNumber: 1
+    duration: "03:03"
+  - title: "Break My Body"
+    trackNumber: 2
+    duration: "02:05"
+  - title: "Something Against You"
+    trackNumber: 3
+    duration: "01:47"
+  - title: "Broken Face"
+    trackNumber: 4
+    duration: "01:30"
+  - title: "Gigantic"
+    trackNumber: 5
+    duration: "03:54"
+  - title: "River Euphrates"
+    trackNumber: 6
+    duration: "02:31"
+  - title: "Where Is My Mind?"
+    trackNumber: 7
+    duration: "03:53"
+  - title: "Cactus"
+    trackNumber: 8
+    duration: "02:16"
+  - title: "Tony’s Theme"
+    trackNumber: 9
+    duration: "01:52"
+  - title: "Oh My Golly! / [untitled]"
+    trackNumber: 10
+    duration: "02:32"
+  - title: "Vamos"
+    trackNumber: 11
+    duration: "04:20"
+  - title: "I’m Amazed"
+    trackNumber: 12
+    duration: "01:42"
+  - title: "Brick Is Red"
+    trackNumber: 13
+    duration: "02:00"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/74e36cbc-a747-3ebf-a60e-51e656c87741"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Surfer Rosa is a release by Pixies released in 1988-03-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Where Is My Mind?.
+
+

--- a/src/content/releases/p/plastic-bertrand/plastic-bertrand/index.md
+++ b/src/content/releases/p/plastic-bertrand/plastic-bertrand/index.md
@@ -1,0 +1,83 @@
+﻿---
+title: "Plastic Bertrand"
+artist: "Plastic Bertrand"
+releaseDate: "1998"
+releaseType: "Album"
+genres:
+  - "punk"
+  - "pop rock"
+  - "pop"
+  - "rock"
+  - "electronic"
+labels:
+  - "Universal"
+duration: "0:55:20"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "Ça plane pour moi"
+    trackNumber: 1
+    duration: "03:02"
+  - title: "Tout petit la planète"
+    trackNumber: 2
+    duration: "04:11"
+  - title: "Sentimentale‐moi"
+    trackNumber: 3
+    duration: "03:57"
+  - title: "Le Petit Tortillard"
+    trackNumber: 4
+    duration: "02:11"
+  - title: "Bambino"
+    trackNumber: 5
+    duration: "02:06"
+  - title: "Super Cool"
+    trackNumber: 6
+    duration: "03:09"
+  - title: "Le monde est merveilleux"
+    trackNumber: 7
+    duration: "03:09"
+  - title: "Stop ou encore"
+    trackNumber: 8
+    duration: "03:24"
+  - title: "Sans amour"
+    trackNumber: 9
+    duration: "02:58"
+  - title: "Hula Hoop"
+    trackNumber: 10
+    duration: "03:04"
+  - title: "Baby Doll"
+    trackNumber: 11
+    duration: "03:02"
+  - title: "Fou des 50’s"
+    trackNumber: 12
+    duration: "02:17"
+  - title: "Cœur d’acier"
+    trackNumber: 13
+    duration: "02:20"
+  - title: "Le Pantin"
+    trackNumber: 14
+    duration: "03:34"
+  - title: "Paradis"
+    trackNumber: 15
+    duration: "03:23"
+  - title: "Jacques Cousteau"
+    trackNumber: 16
+    duration: "02:43"
+  - title: "Major Tom"
+    trackNumber: 17
+    duration: "03:17"
+  - title: "Gueule d’amour"
+    trackNumber: 18
+    duration: "03:25"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/0e63b6a1-41ec-3dee-8f8d-740613fe05d7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Plastic Bertrand is a release by Plastic Bertrand released in 1998. It has been featured on 1 Sundown Sessions show. Featured tracks include Ca Plane Pour Moi.
+
+

--- a/src/content/releases/p/prince/nothing-compares-2-u/index.md
+++ b/src/content/releases/p/prince/nothing-compares-2-u/index.md
@@ -1,0 +1,31 @@
+﻿---
+title: "Nothing Compares 2 U"
+artist: "Prince"
+releaseDate: "2018-04-19"
+releaseType: "Single"
+genres:
+  - "ballad"
+  - "contemporary r&b"
+  - "rock"
+  - "pop"
+labels:
+  - "Warner Bros. Records"
+duration: "0:04:40"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Nothing Compares 2 U"
+    trackNumber: 1
+    duration: "04:40"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/3534cf47-26df-40ce-81fd-52a0c1279fdf"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Nothing Compares 2 U is a release by Prince released in 2018-04-19. It has been featured on 1 Sundown Sessions show. Featured tracks include Nothing Compares 2 U.
+
+

--- a/src/content/releases/q/queens-of-the-stone-age/like-clockwork/index.md
+++ b/src/content/releases/q/queens-of-the-stone-age/like-clockwork/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "...Like Clockwork"
+artist: "Queens of the Stone Age"
+releaseDate: "2013"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+lastmod: "2026-06-25"
+---
+
+## About
+
+...Like Clockwork is a release by Queens of the Stone Age released in 2013. It has been featured on 1 Sundown Sessions show. Featured tracks include I Sat By The Ocean.
+
+## Tracks Featured on Sundown Sessions
+
+- I Sat By The Ocean
+
+

--- a/src/content/releases/r/r-e-m/green/index.md
+++ b/src/content/releases/r/r-e-m/green/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "Green"
+artist: "R.E.M."
+releaseDate: "1988-11-07"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "rock"
+  - "pop"
+  - "alternative"
+  - "modern rock"
+labels:
+  - "Warner Bros. Records"
+duration: "0:41:00"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Pop Song 89"
+    trackNumber: 1
+    duration: "03:04"
+  - title: "Get Up"
+    trackNumber: 2
+    duration: "02:41"
+  - title: "You Are the Everything"
+    trackNumber: 3
+    duration: "03:44"
+  - title: "Stand"
+    trackNumber: 4
+    duration: "03:12"
+  - title: "World Leader Pretend"
+    trackNumber: 5
+    duration: "04:19"
+  - title: "The Wrong Child"
+    trackNumber: 6
+    duration: "03:38"
+  - title: "Orange Crush"
+    trackNumber: 7
+    duration: "03:51"
+  - title: "Turn You Inside‐Out"
+    trackNumber: 8
+    duration: "04:17"
+  - title: "Hairshirt"
+    trackNumber: 9
+    duration: "03:55"
+  - title: "I Remember California"
+    trackNumber: 10
+    duration: "05:03"
+  - title: "[untitled]"
+    trackNumber: 11
+    duration: "03:09"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/16a9cef3-b470-3ae1-bf10-cc04232d3e21"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Green is a release by R.E.M. released in 1988-11-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Pop Song 89.
+
+

--- a/src/content/releases/r/r-e-m/lifes-rich-pageant/index.md
+++ b/src/content/releases/r/r-e-m/lifes-rich-pageant/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "Lifes Rich Pageant"
+artist: "R.E.M."
+releaseDate: "1986-07-28"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "rock"
+  - "jangle pop"
+  - "alternative pop/rock"
+  - "alternative/indie rock"
+labels:
+  - "I.R.S. Records"
+duration: "0:38:30"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Begin the Begin"
+    trackNumber: 1
+    duration: "03:28"
+  - title: "These Days"
+    trackNumber: 2
+    duration: "03:24"
+  - title: "Fall on Me"
+    trackNumber: 3
+    duration: "02:50"
+  - title: "Cuyahoga"
+    trackNumber: 4
+    duration: "04:21"
+  - title: "Hyena"
+    trackNumber: 5
+    duration: "02:51"
+  - title: "Underneath the Bunker"
+    trackNumber: 6
+    duration: "01:27"
+  - title: "The Flowers of Guatemala"
+    trackNumber: 7
+    duration: "03:57"
+  - title: "I Believe"
+    trackNumber: 8
+    duration: "03:50"
+  - title: "What If We Give It Away?"
+    trackNumber: 9
+    duration: "03:34"
+  - title: "Just a Touch"
+    trackNumber: 10
+    duration: "03:00"
+  - title: "Swan Swan H"
+    trackNumber: 11
+    duration: "02:50"
+  - title: "Superman"
+    trackNumber: 12
+    duration: "02:53"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/8b6b2628-7bd4-3fed-9d65-cf4e5dc45939"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Lifes Rich Pageant is a release by R.E.M. released in 1986-07-28. It has been featured on 1 Sundown Sessions show. Featured tracks include Fall On Me.
+
+

--- a/src/content/releases/r/r-e-m/new-adventures-in-hi-fi/index.md
+++ b/src/content/releases/r/r-e-m/new-adventures-in-hi-fi/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "New Adventures In Hi-Fi"
+artist: "R.E.M."
+releaseDate: "1996"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+lastmod: "2026-06-25"
+---
+
+## About
+
+New Adventures In Hi-Fi is a release by R.E.M. released in 1996. It has been featured on 1 Sundown Sessions show. Featured tracks include E-Bow The Letter.
+
+## Tracks Featured on Sundown Sessions
+
+- E-Bow The Letter
+
+

--- a/src/content/releases/r/radio-stars/songs-for-swinging-lovers/index.md
+++ b/src/content/releases/r/radio-stars/songs-for-swinging-lovers/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "Songs for Swinging Lovers"
+artist: "Radio Stars"
+releaseDate: "1977"
+releaseType: "Album"
+genres:
+  - "power pop"
+  - "pop rock"
+  - "punk"
+  - "rock"
+  - "pop"
+labels:
+  - "Ariola"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Dirty Pictures"
+    trackNumber: 1
+  - title: "Good Personality"
+    trackNumber: 2
+  - title: "Is It Really Necessary"
+    trackNumber: 3
+  - title: "The Beast of Barnsley"
+    trackNumber: 4
+  - title: "Nervous Wreck"
+    trackNumber: 5
+  - title: "Nothing Happened Today"
+    trackNumber: 6
+  - title: "Eric"
+    trackNumber: 7
+  - title: "Don't Waste My Time"
+    trackNumber: 8
+  - title: "Arthur Is Dead (Let's Rot)"
+    trackNumber: 9
+  - title: "Macaroni and Mice"
+    trackNumber: 10
+  - title: "Nice Girls"
+    trackNumber: 11
+  - title: "Talking 'Bout You"
+    trackNumber: 12
+  - title: "No Russians in Russia"
+    trackNumber: 13
+  - title: "Buy Chiswick Records"
+    trackNumber: 14
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/171e8194-50f3-4087-be52-9a46642ca3e2"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Songs for Swinging Lovers is a release by Radio Stars released in 1977. It has been featured on 1 Sundown Sessions show. Featured tracks include Nervous Wreck.
+
+

--- a/src/content/releases/r/rainbow/down-to-earth/index.md
+++ b/src/content/releases/r/rainbow/down-to-earth/index.md
@@ -1,0 +1,51 @@
+﻿---
+title: "Down To Earth"
+artist: "Rainbow"
+releaseDate: "1979"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "rock"
+  - "rainbow on cover"
+labels:
+  - "Polydor"
+duration: "0:36:36"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "All Night Long"
+    trackNumber: 1
+    duration: "03:52"
+  - title: "Eyes of the World"
+    trackNumber: 2
+    duration: "06:42"
+  - title: "No Time to Lose"
+    trackNumber: 3
+    duration: "03:44"
+  - title: "Makin’ Love"
+    trackNumber: 4
+    duration: "04:40"
+  - title: "Since You Been Gone"
+    trackNumber: 5
+    duration: "03:20"
+  - title: "Love’s No Friend"
+    trackNumber: 6
+    duration: "04:54"
+  - title: "Danger Zone"
+    trackNumber: 7
+    duration: "04:31"
+  - title: "Lost in Hollywood"
+    trackNumber: 8
+    duration: "04:50"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/255eb3e1-3ee6-3b42-b030-c2e7a9984478"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Down To Earth is a release by Rainbow released in 1979. It has been featured on 1 Sundown Sessions show. Featured tracks include All Night Long.
+
+

--- a/src/content/releases/r/ramones/end-of-the-century/index.md
+++ b/src/content/releases/r/ramones/end-of-the-century/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "End of the Century"
+artist: "Ramones"
+releaseDate: "1980-02-04"
+releaseType: "Album"
+genres:
+  - "american punk"
+  - "punk"
+  - "alternative/indie rock"
+  - "pop/rock"
+  - "new york punk"
+labels:
+  - "Sire Records"
+duration: "0:34:12"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "Do You Remember Rock 'n' Roll Radio?"
+    trackNumber: 1
+    duration: "03:52"
+  - title: "I'm Affected"
+    trackNumber: 2
+    duration: "02:53"
+  - title: "Danny Says"
+    trackNumber: 3
+    duration: "03:09"
+  - title: "Chinese Rock"
+    trackNumber: 4
+    duration: "02:31"
+  - title: "The Return of Jackie and Judy"
+    trackNumber: 5
+    duration: "03:14"
+  - title: "Let's Go"
+    trackNumber: 6
+    duration: "02:34"
+  - title: "Baby, I Love You"
+    trackNumber: 7
+    duration: "03:49"
+  - title: "I Can't Make It on Time"
+    trackNumber: 8
+    duration: "02:33"
+  - title: "This Ain't Havana"
+    trackNumber: 9
+    duration: "02:18"
+  - title: "Rock 'n' Roll High School"
+    trackNumber: 10
+    duration: "02:41"
+  - title: "All the Way"
+    trackNumber: 11
+    duration: "02:30"
+  - title: "High Risk Insurance"
+    trackNumber: 12
+    duration: "02:08"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/b46e3fa3-f066-311b-a096-8c8b9353dab8"
+lastmod: "2026-06-25"
+---
+
+## About
+
+End of the Century is a release by Ramones released in 1980-02-04. It has been featured on 1 Sundown Sessions show. Featured tracks include Rock 'n' Roll Radio.
+
+

--- a/src/content/releases/r/red-lorry-yellow-lorry/talk-about-the-weather/index.md
+++ b/src/content/releases/r/red-lorry-yellow-lorry/talk-about-the-weather/index.md
@@ -1,0 +1,52 @@
+﻿---
+title: "Talk About The Weather"
+artist: "Red Lorry Yellow Lorry"
+releaseDate: "1985"
+releaseType: "Album"
+genres:
+  - "gothic rock"
+  - "rock"
+  - "post-punk"
+  - "new wave"
+labels:
+  - "Red Rhino Records"
+duration: "0:27:22"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Talk About the Weather"
+    trackNumber: 1
+    duration: "04:06"
+  - title: "Hand on Heart"
+    trackNumber: 2
+    duration: "03:48"
+  - title: "Feel a Piece"
+    trackNumber: 3
+    duration: "02:43"
+  - title: "Hollow Eyes"
+    trackNumber: 4
+    duration: "03:39"
+  - title: "This Today"
+    trackNumber: 5
+    duration: "03:23"
+  - title: "Sometimes"
+    trackNumber: 6
+    duration: "03:03"
+  - title: "Strange Dream"
+    trackNumber: 7
+    duration: "03:16"
+  - title: "Happy"
+    trackNumber: 8
+    duration: "03:24"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d2adea9e-fa8c-3a4a-90bd-2f2f5b696e28"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Talk About The Weather is a release by Red Lorry Yellow Lorry released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include Talk About The Weather.
+
+

--- a/src/content/releases/r/ringo-starr/ringo/index.md
+++ b/src/content/releases/r/ringo-starr/ringo/index.md
@@ -1,0 +1,47 @@
+﻿---
+title: "Ringo"
+artist: "Ringo Starr"
+releaseDate: "1973-11-23"
+releaseType: "Album"
+genres:
+  - "pop rock"
+  - "rock"
+  - "rock pop"
+  - "pop"
+labels:
+  - "Apple Records"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "I'm the Greatest"
+    trackNumber: 1
+  - title: "Have You Seen My Baby (Hold On)"
+    trackNumber: 2
+  - title: "Photograph"
+    trackNumber: 3
+  - title: "Sunshine Life for Me (Sail Away Raymond)"
+    trackNumber: 4
+  - title: "You're Sixteen (You're Beautiful and You're Mine)"
+    trackNumber: 5
+  - title: "Oh My My"
+    trackNumber: 6
+  - title: "Step Lightly"
+    trackNumber: 7
+  - title: "Six O'Clock"
+    trackNumber: 8
+  - title: "Devil Woman"
+    trackNumber: 9
+  - title: "You and Me (Babe)"
+    trackNumber: 10
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/92e9a813-265a-3ddb-a5ad-5daac76af8b1"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Ringo is a release by Ringo Starr released in 1973-11-23. It has been featured on 1 Sundown Sessions show. Featured tracks include It Don't Come Easy.
+
+

--- a/src/content/releases/r/roachford/roachford/index.md
+++ b/src/content/releases/r/roachford/roachford/index.md
@@ -1,0 +1,58 @@
+﻿---
+title: "Roachford"
+artist: "Roachford"
+releaseDate: "1988-07-11"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "pop rock"
+  - "rock"
+  - "electronic"
+labels:
+  - "Epic"
+duration: "0:40:18"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+tracks:
+  - title: "Give It Up"
+    trackNumber: 1
+    duration: "03:38"
+  - title: "Family Man"
+    trackNumber: 2
+    duration: "03:48"
+  - title: "Cuddly Toy (Feel for Me)"
+    trackNumber: 3
+    duration: "03:47"
+  - title: "Find Me Another Love"
+    trackNumber: 4
+    duration: "04:19"
+  - title: "No Way"
+    trackNumber: 5
+    duration: "04:03"
+  - title: "Kathleen"
+    trackNumber: 6
+    duration: "05:51"
+  - title: "Shotgun (Crazy World We Live In)"
+    trackNumber: 7
+    duration: "03:34"
+  - title: "Lying Again"
+    trackNumber: 8
+    duration: "03:31"
+  - title: "Since"
+    trackNumber: 9
+    duration: "03:22"
+  - title: "Nobody but You"
+    trackNumber: 10
+    duration: "04:25"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e4ca0aa9-feb0-3c83-a41c-203ef9bb791a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Roachford is a release by Roachford released in 1988-07-11. It has been featured on 1 Sundown Sessions show. Featured tracks include Cuddly Toy.
+
+

--- a/src/content/releases/r/robert-hazard-and-the-heroes/out-of-the-blue/index.md
+++ b/src/content/releases/r/robert-hazard-and-the-heroes/out-of-the-blue/index.md
@@ -1,0 +1,69 @@
+﻿---
+title: "Out Of The Blue"
+artist: "Robert Hazard & The Heroes"
+releaseDate: "2018"
+releaseType: "Album"
+duration: "1:08:49"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "Escalator of Life"
+    trackNumber: 1
+    duration: "04:37"
+  - title: "Change Reaction"
+    trackNumber: 2
+    duration: "04:03"
+  - title: "Hang Around With You"
+    trackNumber: 3
+    duration: "03:04"
+  - title: "Out of the Blue"
+    trackNumber: 4
+    duration: "03:45"
+  - title: "Blowin' in the Wind"
+    trackNumber: 5
+    duration: "04:25"
+  - title: "Fire on Fire"
+    trackNumber: 6
+    duration: "04:43"
+  - title: "Interplanetary Private Eye"
+    trackNumber: 7
+    duration: "05:20"
+  - title: "The Cool Life"
+    trackNumber: 8
+    duration: "04:14"
+  - title: "Undercover Lover"
+    trackNumber: 9
+    duration: "04:14"
+  - title: "She's Hot"
+    trackNumber: 10
+    duration: "04:05"
+  - title: "Miami Beach"
+    trackNumber: 11
+    duration: "04:29"
+  - title: "Darling"
+    trackNumber: 12
+    duration: "03:39"
+  - title: "Hip Pocket"
+    trackNumber: 13
+    duration: "04:03"
+  - title: "Be My Girl"
+    trackNumber: 14
+    duration: "03:18"
+  - title: "Hard Hearted"
+    trackNumber: 15
+    duration: "03:07"
+  - title: "Say Yo! (live)"
+    trackNumber: 16
+    duration: "07:35"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/17be65e9-a58f-3e7b-b759-a5bc43b49d7d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Out Of The Blue is a release by Robert Hazard & The Heroes released in 2018. It has been featured on 1 Sundown Sessions show. Featured tracks include Escalator Of Life.
+
+

--- a/src/content/releases/r/robert-palmer/secrets/index.md
+++ b/src/content/releases/r/robert-palmer/secrets/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "Secrets"
+artist: "Robert Palmer"
+releaseDate: "1979-06-28"
+releaseType: "Album"
+genres:
+  - "pop"
+  - "pop rock"
+  - "r&b"
+  - "dance-rock"
+  - "blue-eyed soul"
+labels:
+  - "Island"
+duration: "0:37:14"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Bad Case of Lovin’ You (Doctor, Doctor)"
+    trackNumber: 1
+    duration: "03:14"
+  - title: "Too Good to Be True"
+    trackNumber: 2
+    duration: "03:01"
+  - title: "Can We Still Be Friends"
+    trackNumber: 3
+    duration: "03:41"
+  - title: "In Walks Love Again"
+    trackNumber: 4
+    duration: "02:49"
+  - title: "Mean Ol’ World"
+    trackNumber: 5
+    duration: "03:38"
+  - title: "Love Stop"
+    trackNumber: 6
+    duration: "03:01"
+  - title: "Jealous"
+    trackNumber: 7
+    duration: "03:18"
+  - title: "Under Suspicion"
+    trackNumber: 8
+    duration: "03:26"
+  - title: "Woman You’re Wonderful"
+    trackNumber: 9
+    duration: "04:02"
+  - title: "What’s It Take?"
+    trackNumber: 10
+    duration: "03:30"
+  - title: "Remember to Remember"
+    trackNumber: 11
+    duration: "03:30"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/91dfed93-aa99-3016-9593-b9291de159f3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Secrets is a release by Robert Palmer released in 1979-06-28. It has been featured on 1 Sundown Sessions show. Featured tracks include Bad Case Of Loving You (Doctor, Doctor).
+
+

--- a/src/content/releases/r/roddy-frame/the-north-star/index.md
+++ b/src/content/releases/r/roddy-frame/the-north-star/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "The North Star"
+artist: "Roddy Frame"
+releaseDate: "1998-09-21"
+releaseType: "Album"
+genres:
+  - "folk rock"
+  - "rock"
+labels:
+  - "Independiente"
+duration: "0:37:35"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "Back to the One"
+    trackNumber: 1
+    duration: "04:01"
+  - title: "The North Star"
+    trackNumber: 2
+    duration: "04:04"
+  - title: "Here Comes the Ocean"
+    trackNumber: 3
+    duration: "03:23"
+  - title: "River of Brightness"
+    trackNumber: 4
+    duration: "04:22"
+  - title: "Strings"
+    trackNumber: 5
+    duration: "04:10"
+  - title: "Bigger Brighter Better"
+    trackNumber: 6
+    duration: "03:27"
+  - title: "Autumn Flower"
+    trackNumber: 7
+    duration: "04:17"
+  - title: "Reason for Living"
+    trackNumber: 8
+    duration: "03:16"
+  - title: "Sister Shadow"
+    trackNumber: 9
+    duration: "03:38"
+  - title: "Hymn to Grace"
+    trackNumber: 10
+    duration: "02:54"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/909ff44f-97cd-3f0d-93f4-4b352032dff1"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The North Star is a release by Roddy Frame released in 1998-09-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Reason For Living.
+
+

--- a/src/content/releases/r/roxy-music/roxy-music/index.md
+++ b/src/content/releases/r/roxy-music/roxy-music/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Roxy Music"
+artist: "Roxy Music"
+releaseDate: "1972-06-16"
+releaseType: "Album"
+genres:
+  - "art rock"
+  - "glam rock"
+  - "rock"
+  - "glam"
+  - "rock/pop"
+labels:
+  - "Reprise Records"
+duration: "0:45:05"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Re‐Make/Re‐Model"
+    trackNumber: 1
+    duration: "05:10"
+  - title: "Ladytron"
+    trackNumber: 2
+    duration: "04:21"
+  - title: "If There Is Something"
+    trackNumber: 3
+    duration: "06:33"
+  - title: "Virginia Plain"
+    trackNumber: 4
+    duration: "02:50"
+  - title: "2 H.B."
+    trackNumber: 5
+    duration: "04:34"
+  - title: "The Bob (Medley)"
+    trackNumber: 6
+    duration: "05:48"
+  - title: "Chance Meeting"
+    trackNumber: 7
+    duration: "03:00"
+  - title: "Would You Believe?"
+    trackNumber: 8
+    duration: "03:47"
+  - title: "Sea Breezes"
+    trackNumber: 9
+    duration: "07:00"
+  - title: "Bitters End"
+    trackNumber: 10
+    duration: "02:02"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/3ff6284f-88b0-3285-895a-61c733e6d4ca"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Roxy Music is a release by Roxy Music released in 1972-06-16. It has been featured on 1 Sundown Sessions show. Featured tracks include Virginia Plain.
+
+

--- a/src/content/releases/r/royal-blood/back-to-the-water-below/index.md
+++ b/src/content/releases/r/royal-blood/back-to-the-water-below/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Back To The Water Below"
+artist: "Royal Blood"
+releaseDate: "2023-09-01"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "rock"
+  - "plattentests.de"
+  - "offizielle charts"
+  - "ph_3_stars"
+labels:
+  - "Warner Records"
+duration: "0:31:22"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "Mountains at Midnight"
+    trackNumber: 1
+    duration: "03:06"
+  - title: "Shiner in the Dark"
+    trackNumber: 2
+    duration: "03:27"
+  - title: "Pull Me Through"
+    trackNumber: 3
+    duration: "03:08"
+  - title: "The Firing Line"
+    trackNumber: 4
+    duration: "03:22"
+  - title: "Tell Me When It’s Too Late"
+    trackNumber: 5
+    duration: "02:44"
+  - title: "Triggers"
+    trackNumber: 6
+    duration: "02:55"
+  - title: "How Many More Times"
+    trackNumber: 7
+    duration: "03:11"
+  - title: "High Waters"
+    trackNumber: 8
+    duration: "02:45"
+  - title: "There Goes My Cool"
+    trackNumber: 9
+    duration: "02:56"
+  - title: "Waves"
+    trackNumber: 10
+    duration: "03:48"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/10676a3a-980f-4226-a3bd-207a473aa600"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Back To The Water Below is a release by Royal Blood released in 2023-09-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Supermodel Avalanches.
+
+

--- a/src/content/releases/r/rush/permanent-waves/index.md
+++ b/src/content/releases/r/rush/permanent-waves/index.md
@@ -1,0 +1,47 @@
+﻿---
+title: "Permanent Waves"
+artist: "Rush"
+releaseDate: "1980-01-01"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "progressive rock"
+  - "hard rock"
+  - "album rock"
+  - "prog rock"
+labels:
+  - "Mercury Records"
+duration: "0:35:41"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "The Spirit of Radio"
+    trackNumber: 1
+    duration: "04:59"
+  - title: "Freewill"
+    trackNumber: 2
+    duration: "05:24"
+  - title: "Jacob’s Ladder"
+    trackNumber: 3
+    duration: "07:31"
+  - title: "Entre nous"
+    trackNumber: 4
+    duration: "04:38"
+  - title: "Different Strings"
+    trackNumber: 5
+    duration: "03:52"
+  - title: "Natural Science"
+    trackNumber: 6
+    duration: "09:16"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/664ffb4c-8178-3f99-b0d3-0bab3a51f793"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Permanent Waves is a release by Rush released in 1980-01-01. It has been featured on 1 Sundown Sessions show. Featured tracks include The Spirit Of Radio.
+
+

--- a/src/content/releases/s/sananda-maitreya/introducing-the-hardline-according-to-sananda-maitreya/index.md
+++ b/src/content/releases/s/sananda-maitreya/introducing-the-hardline-according-to-sananda-maitreya/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Introducing The Hardline According To Sananda Maitreya"
+artist: "Sananda Maitreya"
+releaseDate: "1987"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Introducing The Hardline According To Sananda Maitreya is a release by Sananda Maitreya released in 1987. It has been featured on 1 Sundown Sessions show. Featured tracks include Who's Loving You.
+
+## Tracks Featured on Sundown Sessions
+
+- Who's Loving You
+
+

--- a/src/content/releases/s/santana/ultimate-santana/index.md
+++ b/src/content/releases/s/santana/ultimate-santana/index.md
@@ -1,0 +1,85 @@
+﻿---
+title: "Ultimate Santana"
+artist: "Santana"
+releaseDate: "2007-10-16"
+releaseType: "Album"
+genres:
+  - "jazz"
+  - "latin rock"
+  - "rock"
+  - "pop rock"
+  - "house"
+labels:
+  - "Arista"
+  - "Columbia"
+  - "Legacy"
+duration: "1:17:41"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Into the Night"
+    trackNumber: 1
+    duration: "03:42"
+  - title: "Smooth"
+    trackNumber: 2
+    duration: "04:55"
+  - title: "Maria Maria"
+    trackNumber: 3
+    duration: "04:21"
+  - title: "This Boy’s Fire"
+    trackNumber: 4
+    duration: "03:30"
+  - title: "She’s Not There"
+    trackNumber: 5
+    duration: "04:09"
+  - title: "Black Magic Woman"
+    trackNumber: 6
+    duration: "03:15"
+  - title: "The Game of Love"
+    trackNumber: 7
+    duration: "04:14"
+  - title: "Samba pa ti"
+    trackNumber: 8
+    duration: "04:45"
+  - title: "Evil Ways"
+    trackNumber: 9
+    duration: "03:55"
+  - title: "Put Your Lights On"
+    trackNumber: 10
+    duration: "04:45"
+  - title: "Corazón espinado"
+    trackNumber: 11
+    duration: "04:35"
+  - title: "Why Don’t You & I"
+    trackNumber: 12
+    duration: "03:51"
+  - title: "Just Feel Better"
+    trackNumber: 13
+    duration: "04:12"
+  - title: "Europa (Earth’s Cry Heaven’s Smile)"
+    trackNumber: 14
+    duration: "05:05"
+  - title: "No One to Depend On"
+    trackNumber: 15
+    duration: "05:34"
+  - title: "Oye como va"
+    trackNumber: 16
+    duration: "04:18"
+  - title: "Interplanetary Party"
+    trackNumber: 17
+    duration: "04:06"
+  - title: "The Game of Love"
+    trackNumber: 18
+    duration: "04:20"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e5417609-11fe-34e0-afb6-c91696b3939c"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Ultimate Santana is a release by Santana released in 2007-10-16. It has been featured on 1 Sundown Sessions show. Featured tracks include Europa.
+
+

--- a/src/content/releases/s/scorpions/crazy-world/index.md
+++ b/src/content/releases/s/scorpions/crazy-world/index.md
@@ -1,0 +1,36 @@
+﻿---
+title: "Crazy World"
+artist: "Scorpions"
+releaseDate: "1990"
+releaseType: "Single"
+labels:
+  - "Phonogram"
+  - "Vertigo"
+duration: "0:19:35"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+tracks:
+  - title: "Tease Me Please Me"
+    trackNumber: 1
+    duration: "04:44"
+  - title: "Hit Between the Eyes"
+    trackNumber: 2
+    duration: "04:33"
+  - title: "Crazy World"
+    trackNumber: 3
+    duration: "05:08"
+  - title: "Wind of Change"
+    trackNumber: 4
+    duration: "05:10"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/99251e8c-7365-4f53-a6d1-9ae0d0f0e35f"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Crazy World is a release by Scorpions released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include Wind Of Change.
+
+

--- a/src/content/releases/s/sex-gang-children/song-and-legend/index.md
+++ b/src/content/releases/s/sex-gang-children/song-and-legend/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Song and Legend"
+artist: "Sex Gang Children"
+releaseDate: "1983"
+releaseType: "Album"
+genres:
+  - "gothic rock"
+  - "deathrock"
+  - "rock"
+  - "goth"
+  - "punk"
+labels:
+  - "Illuminated Records"
+duration: "0:36:38"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+tracks:
+  - title: "The Crack Up"
+    trackNumber: 1
+    duration: "03:39"
+  - title: "German Nun"
+    trackNumber: 2
+    duration: "03:02"
+  - title: "Chant"
+    trackNumber: 3
+    duration: "00:16"
+  - title: "State of Mind"
+    trackNumber: 4
+    duration: "03:11"
+  - title: "Sebastiane"
+    trackNumber: 5
+    duration: "03:11"
+  - title: "Draconian Dream"
+    trackNumber: 6
+    duration: "03:57"
+  - title: "Shout and Scream"
+    trackNumber: 7
+    duration: "03:24"
+  - title: "Killer 'K'"
+    trackNumber: 8
+    duration: "03:09"
+  - title: "Cannibal Queen"
+    trackNumber: 9
+    duration: "01:58"
+  - title: "Abyss"
+    trackNumber: 10
+    duration: "02:19"
+  - title: "Kill Machine"
+    trackNumber: 11
+    duration: "01:58"
+  - title: "Song and Legend"
+    trackNumber: 12
+    duration: "03:37"
+  - title: "Dream Reprise"
+    trackNumber: 13
+    duration: "02:57"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/3d877d2b-992f-374d-a6f1-26d733a64b13"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Song and Legend is a release by Sex Gang Children released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Sebastiane.
+
+

--- a/src/content/releases/s/simple-minds/empires-and-dance/index.md
+++ b/src/content/releases/s/simple-minds/empires-and-dance/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Empires And Dance"
+artist: "Simple Minds"
+releaseDate: "1980-09-01"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "synth-pop"
+  - "rock"
+  - "electronic"
+  - "pop"
+labels:
+  - "Arista"
+duration: "0:45:49"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "I Travel"
+    trackNumber: 1
+    duration: "04:02"
+  - title: "Today I Died Again"
+    trackNumber: 2
+    duration: "04:38"
+  - title: "Celebrate"
+    trackNumber: 3
+    duration: "05:09"
+  - title: "This Fear of Gods"
+    trackNumber: 4
+    duration: "07:05"
+  - title: "Capital City"
+    trackNumber: 5
+    duration: "06:15"
+  - title: "Constantinople Line"
+    trackNumber: 6
+    duration: "04:40"
+  - title: "Twist/Run/Repulsion"
+    trackNumber: 7
+    duration: "04:32"
+  - title: "Thirty Frames a Second"
+    trackNumber: 8
+    duration: "05:03"
+  - title: "Kant-Kino"
+    trackNumber: 9
+    duration: "01:53"
+  - title: "Room"
+    trackNumber: 10
+    duration: "02:28"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/18a9bbd4-e9cd-3ece-aa3a-c3aa61af571b"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Empires And Dance is a release by Simple Minds released in 1980-09-01. It has been featured on 1 Sundown Sessions show. Featured tracks include I Travel.
+
+

--- a/src/content/releases/s/simple-minds/new-gold-dream-81-82-83-84/index.md
+++ b/src/content/releases/s/simple-minds/new-gold-dream-81-82-83-84/index.md
@@ -1,0 +1,29 @@
+﻿---
+title: "New Gold Dream (81/82/83/84)"
+artist: "Simple Minds"
+releaseDate: "1983-03-01"
+releaseType: "Single"
+labels:
+  - "Virgin"
+duration: "0:11:52"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "New Gold Dream (81/82/83/84 (german remix)"
+    trackNumber: 1
+    duration: "06:52"
+  - title: "Somebody Up There Likes You"
+    trackNumber: 2
+    duration: "05:00"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/7bbf7ab0-9833-4a94-941b-55e6138338a0"
+lastmod: "2026-06-25"
+---
+
+## About
+
+New Gold Dream (81/82/83/84) is a release by Simple Minds released in 1983-03-01. It has been featured on 1 Sundown Sessions show. Featured tracks include New Gold Dream (81/82/83/84).
+
+

--- a/src/content/releases/s/simple-minds/reel-to-real-cacophony/index.md
+++ b/src/content/releases/s/simple-minds/reel-to-real-cacophony/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Reel To Real Cacophony"
+artist: "Simple Minds"
+releaseDate: "1979"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Reel To Real Cacophony is a release by Simple Minds released in 1979. It has been featured on 1 Sundown Sessions show. Featured tracks include Changeling.
+
+## Tracks Featured on Sundown Sessions
+
+- Changeling
+
+

--- a/src/content/releases/s/siobhan-wilson/there-are-no-saints/index.md
+++ b/src/content/releases/s/siobhan-wilson/there-are-no-saints/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "There Are No Saints"
+artist: "Siobhan Wilson"
+releaseDate: "2017-07-14"
+releaseType: "Album"
+labels:
+  - "[no label]"
+duration: "0:44:30"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+tracks:
+  - title: "There Are No Saints"
+    trackNumber: 1
+    duration: "01:30"
+  - title: "Whatever Helps"
+    trackNumber: 2
+    duration: "02:58"
+  - title: "Dear God"
+    trackNumber: 3
+    duration: "05:07"
+  - title: "Paris est blanche"
+    trackNumber: 4
+    duration: "03:22"
+  - title: "Disaster and Grace"
+    trackNumber: 5
+    duration: "05:55"
+  - title: "J’Attendrai"
+    trackNumber: 6
+    duration: "03:14"
+  - title: "Incarnation"
+    trackNumber: 7
+    duration: "04:39"
+  - title: "Make You Mine"
+    trackNumber: 8
+    duration: "06:01"
+  - title: "Dark Matter"
+    trackNumber: 9
+    duration: "02:48"
+  - title: "Dystopian Bach"
+    trackNumber: 10
+    duration: "05:02"
+  - title: "It Must Have Been the Moon"
+    trackNumber: 11
+    duration: "03:49"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/a054a4fd-a4e2-4d46-89f5-4333a21361e7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+There Are No Saints is a release by Siobhan Wilson released in 2017-07-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Make You Mine.
+
+

--- a/src/content/releases/s/siouxsie/mantaray/index.md
+++ b/src/content/releases/s/siouxsie/mantaray/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Mantaray"
+artist: "Siouxsie"
+releaseDate: "2007-09-03"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "classic pop and rock"
+  - "rock"
+  - "pop"
+labels:
+  - "UMC"
+  - "W14 Music"
+duration: "0:40:57"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "Into a Swan"
+    trackNumber: 1
+    duration: "04:12"
+  - title: "About to Happen"
+    trackNumber: 2
+    duration: "02:50"
+  - title: "Here Comes That Day"
+    trackNumber: 3
+    duration: "04:03"
+  - title: "Loveless"
+    trackNumber: 4
+    duration: "04:24"
+  - title: "If It Doesn't Kill You"
+    trackNumber: 5
+    duration: "04:32"
+  - title: "One Mile Below"
+    trackNumber: 6
+    duration: "03:00"
+  - title: "Drone Zone"
+    trackNumber: 7
+    duration: "03:22"
+  - title: "Sea of Tranquility"
+    trackNumber: 8
+    duration: "05:13"
+  - title: "They Follow You"
+    trackNumber: 9
+    duration: "05:02"
+  - title: "Heaven and Alchemy"
+    trackNumber: 10
+    duration: "04:19"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/3841833c-1285-362e-8b4e-dfa389bac378"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Mantaray is a release by Siouxsie released in 2007-09-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Into a Swan.
+
+

--- a/src/content/releases/s/sisters-of-mercy/first-and-last-and-always-collection/index.md
+++ b/src/content/releases/s/sisters-of-mercy/first-and-last-and-always-collection/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "First and Last and Always Collection"
+artist: "Sisters of Mercy"
+releaseDate: "1985"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+lastmod: "2026-06-25"
+---
+
+## About
+
+First and Last and Always Collection is a release by Sisters of Mercy released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include Marian.
+
+## Tracks Featured on Sundown Sessions
+
+- Marian
+
+

--- a/src/content/releases/s/sisters-of-mercy/some-girls-wander-by-mistake/index.md
+++ b/src/content/releases/s/sisters-of-mercy/some-girls-wander-by-mistake/index.md
@@ -1,0 +1,86 @@
+﻿---
+title: "Some Girls Wander by Mistake"
+artist: "Sisters of Mercy"
+releaseDate: "1992-04-27"
+releaseType: "Album"
+genres:
+  - "gothic rock"
+  - "post-punk"
+  - "alternative"
+  - "dance-rock"
+  - "electronic"
+labels:
+  - "Elektra"
+duration: "1:19:28"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Alice"
+    trackNumber: 1
+    duration: "03:34"
+  - title: "Floorshow"
+    trackNumber: 2
+    duration: "03:40"
+  - title: "Phantom"
+    trackNumber: 3
+    duration: "07:10"
+  - title: "1969"
+    trackNumber: 4
+    duration: "02:45"
+  - title: "Kiss the Carpet"
+    trackNumber: 5
+    duration: "05:55"
+  - title: "Lights"
+    trackNumber: 6
+    duration: "05:51"
+  - title: "Valentine"
+    trackNumber: 7
+    duration: "04:44"
+  - title: "Fix"
+    trackNumber: 8
+    duration: "03:41"
+  - title: "Burn"
+    trackNumber: 9
+    duration: "04:49"
+  - title: "Kiss the Carpet (reprise)"
+    trackNumber: 10
+    duration: "00:36"
+  - title: "Temple of Love (extended version)"
+    trackNumber: 11
+    duration: "07:42"
+  - title: "Heartland"
+    trackNumber: 12
+    duration: "04:47"
+  - title: "Gimme Shelter"
+    trackNumber: 13
+    duration: "05:57"
+  - title: "The Damage Done"
+    trackNumber: 14
+    duration: "03:03"
+  - title: "Watch"
+    trackNumber: 15
+    duration: "03:11"
+  - title: "Home of the Hit-Men"
+    trackNumber: 16
+    duration: "00:34"
+  - title: "Body Electric"
+    trackNumber: 17
+    duration: "04:18"
+  - title: "Adrenochrome"
+    trackNumber: 18
+    duration: "02:57"
+  - title: "Anaconda"
+    trackNumber: 19
+    duration: "04:06"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/abb1621a-c039-3386-b961-271fbf59e5ce"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Some Girls Wander by Mistake is a release by Sisters of Mercy released in 1992-04-27. It has been featured on 1 Sundown Sessions show. Featured tracks include Alice.
+
+

--- a/src/content/releases/s/skids/days-in-europa/index.md
+++ b/src/content/releases/s/skids/days-in-europa/index.md
@@ -1,0 +1,48 @@
+﻿---
+title: "Days In Europa"
+artist: "Skids"
+releaseDate: "1979-10-12"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "leftfield"
+  - "new wave"
+  - "rock"
+  - "electronic"
+labels:
+  - "Virgin"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "Animation"
+    trackNumber: 1
+  - title: "Charade"
+    trackNumber: 2
+  - title: "Dulce et Decorum Est (Pro Patria Mori)"
+    trackNumber: 3
+  - title: "Pros and Cons"
+    trackNumber: 4
+  - title: "Home of the Saved"
+    trackNumber: 5
+  - title: "Working for the Yankee Dollar"
+    trackNumber: 6
+  - title: "The Olympian"
+    trackNumber: 7
+  - title: "Thanatos"
+    trackNumber: 8
+  - title: "A Day in Europa"
+    trackNumber: 9
+  - title: "Peaceful Times"
+    trackNumber: 10
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/4417730b-534d-3fa3-93f5-4d9c3d7cce79"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Days In Europa is a release by Skids released in 1979-10-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Charade.
+
+

--- a/src/content/releases/s/snowy-white/bird-of-paradise-an-anthology/index.md
+++ b/src/content/releases/s/snowy-white/bird-of-paradise-an-anthology/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Bird of Paradise - An Anthology"
+artist: "Snowy White"
+releaseDate: "2003"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Bird of Paradise - An Anthology is a release by Snowy White released in 2003. It has been featured on 1 Sundown Sessions show. Featured tracks include Bird of Paradise.
+
+## Tracks Featured on Sundown Sessions
+
+- Bird of Paradise
+
+

--- a/src/content/releases/s/soft-cell/non-stop-ecstatic-dancing/index.md
+++ b/src/content/releases/s/soft-cell/non-stop-ecstatic-dancing/index.md
@@ -1,0 +1,47 @@
+﻿---
+title: "Non Stop Ecstatic Dancing"
+artist: "Soft Cell"
+releaseDate: "1982-06-21"
+releaseType: "Album"
+genres:
+  - "pop"
+  - "synth pop"
+  - "new romantic"
+  - "punk/new wave"
+  - "pop/rock"
+labels:
+  - "Sire Records"
+duration: "0:31:02"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Memorabilia"
+    trackNumber: 1
+    duration: "05:22"
+  - title: "Where Did Our Love Go"
+    trackNumber: 2
+    duration: "04:24"
+  - title: "What"
+    trackNumber: 3
+    duration: "04:33"
+  - title: "A Man Could Get Lost"
+    trackNumber: 4
+    duration: "03:58"
+  - title: "Insecure… Me?"
+    trackNumber: 5
+    duration: "07:30"
+  - title: "Sex Dwarf"
+    trackNumber: 6
+    duration: "05:15"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/555e158d-383f-3317-9c23-29e3c592fe6e"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Non Stop Ecstatic Dancing is a release by Soft Cell released in 1982-06-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Tainted Love / Where Did Our Love Go?.
+
+

--- a/src/content/releases/s/something-happens/stuck-together-with-gods-glue/index.md
+++ b/src/content/releases/s/something-happens/stuck-together-with-gods-glue/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Stuck Together With God's Glue"
+artist: "Something Happens"
+releaseDate: "1990"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Stuck Together With God's Glue is a release by Something Happens released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include Hello, Hello, Hello, Hello, Hello (Petrol).
+
+## Tracks Featured on Sundown Sessions
+
+- Hello, Hello, Hello, Hello, Hello (Petrol)
+
+

--- a/src/content/releases/s/space/the-best-of/index.md
+++ b/src/content/releases/s/space/the-best-of/index.md
@@ -1,0 +1,69 @@
+﻿---
+title: "The Best Of"
+artist: "Space"
+releaseDate: "2009-11-09"
+releaseType: "Album"
+genres:
+  - "disco"
+  - "dance"
+  - "electronic"
+labels:
+  - "Nang Records"
+duration: "1:10:53"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Magic Fly"
+    trackNumber: 1
+    duration: "04:24"
+  - title: "Running in the City"
+    trackNumber: 2
+    duration: "04:16"
+  - title: "Just Blue"
+    trackNumber: 3
+    duration: "04:34"
+  - title: "Carry on Turn Me On"
+    trackNumber: 4
+    duration: "07:16"
+  - title: "Tango in Space"
+    trackNumber: 5
+    duration: "04:32"
+  - title: "Air Force"
+    trackNumber: 6
+    duration: "04:17"
+  - title: "Prison"
+    trackNumber: 7
+    duration: "06:20"
+  - title: "Flying Nightmare"
+    trackNumber: 8
+    duration: "03:27"
+  - title: "Deliverance"
+    trackNumber: 9
+    duration: "06:39"
+  - title: "Fasten Seat Belt"
+    trackNumber: 10
+    duration: "06:03"
+  - title: "Symphony"
+    trackNumber: 11
+    duration: "05:01"
+  - title: "Robbots"
+    trackNumber: 12
+    duration: "03:40"
+  - title: "Inner Voices"
+    trackNumber: 13
+    duration: "03:33"
+  - title: "Save Your Love for Me"
+    trackNumber: 14
+    duration: "06:44"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/f4764000-f1d4-439f-a927-426a181c5630"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Best Of is a release by Space released in 2009-11-09. It has been featured on 1 Sundown Sessions show. Featured tracks include Magic Fly.
+
+

--- a/src/content/releases/s/sparks/kimono-my-house/index.md
+++ b/src/content/releases/s/sparks/kimono-my-house/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Kimono My House"
+artist: "Sparks"
+releaseDate: "1974-05"
+releaseType: "Album"
+genres:
+  - "glam rock"
+  - "art rock"
+  - "art pop"
+  - "pop rock"
+  - "anthemic"
+labels:
+  - "Island"
+duration: "0:34:24"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+tracks:
+  - title: "This Town Ain't Big Enough For Both Of Us"
+    trackNumber: 1
+    duration: "03:00"
+  - title: "Amateur Hour"
+    trackNumber: 2
+    duration: "03:24"
+  - title: "Falling In Love With Myself Again"
+    trackNumber: 3
+    duration: "02:59"
+  - title: "Here In Heaven"
+    trackNumber: 4
+    duration: "02:40"
+  - title: "Thank God It's Not Christmas"
+    trackNumber: 5
+    duration: "05:00"
+  - title: "Hasta Mañana, Monsieur"
+    trackNumber: 6
+    duration: "03:33"
+  - title: "Talent Is An Asset"
+    trackNumber: 7
+    duration: "03:14"
+  - title: "Complaints"
+    trackNumber: 8
+    duration: "02:45"
+  - title: "In My Family"
+    trackNumber: 9
+    duration: "03:11"
+  - title: "Equator"
+    trackNumber: 10
+    duration: "04:38"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/0539b843-2228-36f5-965d-f370d05f66c3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Kimono My House is a release by Sparks released in 1974-05. It has been featured on 1 Sundown Sessions show. Featured tracks include Amateur Hour.
+
+

--- a/src/content/releases/s/spoon/tv-set/index.md
+++ b/src/content/releases/s/spoon/tv-set/index.md
@@ -1,0 +1,28 @@
+﻿---
+title: "TV Set"
+artist: "Spoon"
+releaseDate: "2015-05-19"
+releaseType: "Single"
+genres:
+  - "rock"
+labels:
+  - "Loma Vista Recordings"
+duration: "0:03:13"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "TV Set"
+    trackNumber: 1
+    duration: "03:13"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6624370f-3743-431e-9ab1-cf109ad08fcd"
+lastmod: "2026-06-25"
+---
+
+## About
+
+TV Set is a release by Spoon released in 2015-05-19. It has been featured on 1 Sundown Sessions show. Featured tracks include TV Set.
+
+

--- a/src/content/releases/s/squeeze/some-fantastic-place/index.md
+++ b/src/content/releases/s/squeeze/some-fantastic-place/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Some Fantastic Place"
+artist: "Squeeze"
+releaseDate: "1993-09-14"
+releaseType: "Album"
+genres:
+  - "pop rock"
+  - "rock"
+labels:
+  - "A&M Records"
+duration: "0:48:21"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Everything in the World"
+    trackNumber: 1
+    duration: "04:30"
+  - title: "Some Fantastic Place"
+    trackNumber: 2
+    duration: "04:31"
+  - title: "Third Rail"
+    trackNumber: 3
+    duration: "03:38"
+  - title: "Loving You Tonight"
+    trackNumber: 4
+    duration: "04:48"
+  - title: "It’s Over"
+    trackNumber: 5
+    duration: "03:45"
+  - title: "Cold Shoulder"
+    trackNumber: 6
+    duration: "05:48"
+  - title: "Talk to Him"
+    trackNumber: 7
+    duration: "03:45"
+  - title: "Jolly Comes Home"
+    trackNumber: 8
+    duration: "05:00"
+  - title: "Images of Loving"
+    trackNumber: 9
+    duration: "04:10"
+  - title: "True Colours (The Storm)"
+    trackNumber: 10
+    duration: "03:39"
+  - title: "Pinocchio"
+    trackNumber: 11
+    duration: "04:42"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/656090ba-0653-39c0-9a54-6ac87a2763c3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Some Fantastic Place is a release by Squeeze released in 1993-09-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Third Rail.
+
+

--- a/src/content/releases/s/stevie-ray-vaughan/texas-flood-legacy-edition/index.md
+++ b/src/content/releases/s/stevie-ray-vaughan/texas-flood-legacy-edition/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Texas Flood (Legacy Edition)"
+artist: "Stevie Ray Vaughan"
+releaseDate: "1983"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Texas Flood (Legacy Edition) is a release by Stevie Ray Vaughan released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Tell Me.
+
+## Tracks Featured on Sundown Sessions
+
+- Tell Me
+
+

--- a/src/content/releases/t/t-rex/tanx/index.md
+++ b/src/content/releases/t/t-rex/tanx/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Tanx"
+artist: "T. Rex"
+releaseDate: "1973-01-28"
+releaseType: "Album"
+genres:
+  - "glam rock"
+  - "glam"
+  - "rock"
+  - "rock & roll"
+  - "proto-punk"
+labels:
+  - "Reprise Records"
+duration: "0:34:16"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Tenement Lady"
+    trackNumber: 1
+    duration: "02:54"
+  - title: "Rapids"
+    trackNumber: 2
+    duration: "02:45"
+  - title: "Mister Mister"
+    trackNumber: 3
+    duration: "03:27"
+  - title: "Broken Hearted Blues"
+    trackNumber: 4
+    duration: "02:00"
+  - title: "Shock Rock"
+    trackNumber: 5
+    duration: "01:40"
+  - title: "Country Honey"
+    trackNumber: 6
+    duration: "01:45"
+  - title: "Electric Slim & The Factory Hen"
+    trackNumber: 7
+    duration: "03:02"
+  - title: "Mad Donna"
+    trackNumber: 8
+    duration: "02:13"
+  - title: "Born to Boogie"
+    trackNumber: 9
+    duration: "02:03"
+  - title: "Life Is Strange"
+    trackNumber: 10
+    duration: "02:27"
+  - title: "The Street & Babe Shadow"
+    trackNumber: 11
+    duration: "02:15"
+  - title: "Highway Knees"
+    trackNumber: 12
+    duration: "02:32"
+  - title: "Left Hand Luke"
+    trackNumber: 13
+    duration: "05:13"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/150be579-06f0-3ddf-8b6e-f725dda83e6b"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Tanx is a release by T. Rex released in 1973-01-28. It has been featured on 1 Sundown Sessions show. Featured tracks include 20th Century Boy.
+
+

--- a/src/content/releases/t/talk-talk/the-colour-of-spring/index.md
+++ b/src/content/releases/t/talk-talk/the-colour-of-spring/index.md
@@ -1,0 +1,53 @@
+﻿---
+title: "The Colour of Spring"
+artist: "Talk Talk"
+releaseDate: "1986-03"
+releaseType: "Album"
+genres:
+  - "art pop"
+  - "rock"
+  - "pop"
+  - "alternative/indie rock"
+  - "baroque pop"
+labels:
+  - "EMI"
+duration: "0:45:37"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Happiness Is Easy"
+    trackNumber: 1
+    duration: "06:31"
+  - title: "I Don’t Believe in You"
+    trackNumber: 2
+    duration: "05:02"
+  - title: "Life’s What You Make It"
+    trackNumber: 3
+    duration: "04:29"
+  - title: "April 5th"
+    trackNumber: 4
+    duration: "05:50"
+  - title: "Living in Another World"
+    trackNumber: 5
+    duration: "06:55"
+  - title: "Give It Up"
+    trackNumber: 6
+    duration: "05:17"
+  - title: "Chameleon Day"
+    trackNumber: 7
+    duration: "03:20"
+  - title: "Time It’s Time"
+    trackNumber: 8
+    duration: "08:10"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/072ec17c-aa60-3070-99ab-fce9e9009d97"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Colour of Spring is a release by Talk Talk released in 1986-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Life's What You Make It.
+
+

--- a/src/content/releases/t/talk-talk/the-partys-over/index.md
+++ b/src/content/releases/t/talk-talk/the-partys-over/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The Party's Over"
+artist: "Talk Talk"
+releaseDate: "1982"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Party's Over is a release by Talk Talk released in 1982. It has been featured on 1 Sundown Sessions show. Featured tracks include Talk Talk.
+
+## Tracks Featured on Sundown Sessions
+
+- Talk Talk
+
+

--- a/src/content/releases/t/talking-heads/burning-down-the-house/index.md
+++ b/src/content/releases/t/talking-heads/burning-down-the-house/index.md
@@ -1,0 +1,38 @@
+﻿---
+title: "Burning Down the House"
+artist: "Talking Heads"
+releaseDate: "1983"
+releaseType: "Single"
+genres:
+  - "new wave"
+  - "synth-pop"
+  - "pop rock"
+  - "alternative rock"
+  - "rock"
+labels:
+  - "Sire Records"
+duration: "0:13:18"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Burning Down the House"
+    trackNumber: 1
+    duration: "04:02"
+  - title: "I Get Wild/Wild Gravity"
+    trackNumber: 2
+    duration: "04:11"
+  - title: "Moon Rocks"
+    trackNumber: 3
+    duration: "05:04"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/52f81d27-4ad4-4085-a5d7-0e6cad9af74a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Burning Down the House is a release by Talking Heads released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Burning Down the House.
+
+

--- a/src/content/releases/t/tears-for-fears/the-tipping-point/index.md
+++ b/src/content/releases/t/tears-for-fears/the-tipping-point/index.md
@@ -1,0 +1,26 @@
+﻿---
+title: "The Tipping Point"
+artist: "Tears For Fears"
+releaseDate: "2021-10-07"
+releaseType: "Single"
+labels:
+  - "Concord Records"
+duration: "0:04:13"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "The Tipping Point"
+    trackNumber: 1
+    duration: "04:13"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/20e90e34-ab28-4032-ae0a-4dfc9e23f1e8"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Tipping Point is a release by Tears For Fears released in 2021-10-07. It has been featured on 1 Sundown Sessions show. Featured tracks include My Demons.
+
+

--- a/src/content/releases/t/teenage-fanclub/four-thousand-seven-hundred-and-seventy-seconds-a-shortcut-to-teenage-fanclub/index.md
+++ b/src/content/releases/t/teenage-fanclub/four-thousand-seven-hundred-and-seventy-seconds-a-shortcut-to-teenage-fanclub/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Four Thousand, Seven Hundred and Seventy seconds; A Shortcut to Teenage Fanclub"
+artist: "Teenage Fanclub"
+releaseDate: "2003"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Four Thousand, Seven Hundred and Seventy seconds; A Shortcut to Teenage Fanclub is a release by Teenage Fanclub released in 2003. It has been featured on 1 Sundown Sessions show. Featured tracks include Ain't That Enough.
+
+## Tracks Featured on Sundown Sessions
+
+- Ain't That Enough
+
+

--- a/src/content/releases/t/the-adventures/the-sea-of-love/index.md
+++ b/src/content/releases/t/the-adventures/the-sea-of-love/index.md
@@ -1,0 +1,54 @@
+﻿---
+title: "The Sea Of Love"
+artist: "The Adventures"
+releaseDate: "1988"
+releaseType: "Album"
+genres:
+  - "pop/rock"
+  - "pop rock"
+  - "rock"
+labels:
+  - "Elektra"
+duration: "0:40:56"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "Drowning in the Sea of Love"
+    trackNumber: 1
+    duration: "04:37"
+  - title: "Broken Land"
+    trackNumber: 2
+    duration: "05:06"
+  - title: "You Don't Have to Cry Anymore"
+    trackNumber: 3
+    duration: "04:11"
+  - title: "The Trip to Bountiful (When the Rain Comes Down)"
+    trackNumber: 4
+    duration: "05:08"
+  - title: "Heaven Knows Which Way"
+    trackNumber: 5
+    duration: "04:35"
+  - title: "Hold Me Now"
+    trackNumber: 6
+    duration: "04:05"
+  - title: "The Sound of Summer"
+    trackNumber: 7
+    duration: "04:50"
+  - title: "When Your Heart Was Young"
+    trackNumber: 8
+    duration: "03:51"
+  - title: "One Step From Heaven"
+    trackNumber: 9
+    duration: "04:33"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/66a60245-808e-3873-987b-ac1ea8a860b3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Sea Of Love is a release by The Adventures released in 1988. It has been featured on 1 Sundown Sessions show. Featured tracks include Broken Land.
+
+

--- a/src/content/releases/t/the-airborne-toxic-event/digital-ep/index.md
+++ b/src/content/releases/t/the-airborne-toxic-event/digital-ep/index.md
@@ -1,0 +1,19 @@
+﻿---
+title: "Digital EP"
+artist: "The Airborne Toxic Event"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Digital EP is a release by The Airborne Toxic Event. It has been featured on 1 Sundown Sessions show. Featured tracks include This Is Nowhere.
+
+## Tracks Featured on Sundown Sessions
+
+- This Is Nowhere
+
+

--- a/src/content/releases/t/the-alarm/declaration/index.md
+++ b/src/content/releases/t/the-alarm/declaration/index.md
@@ -1,0 +1,61 @@
+﻿---
+title: "Declaration"
+artist: "The Alarm"
+releaseDate: "1984-02"
+releaseType: "Album"
+genres:
+  - "rock"
+labels:
+  - "I.R.S. Records"
+duration: "0:46:08"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Declaration"
+    trackNumber: 1
+    duration: "00:42"
+  - title: "Marching On"
+    trackNumber: 2
+    duration: "03:35"
+  - title: "Where Were You Hiding When the Storm Broke?"
+    trackNumber: 3
+    duration: "02:56"
+  - title: "Third Light"
+    trackNumber: 4
+    duration: "03:19"
+  - title: "Sixty Eight Guns"
+    trackNumber: 5
+    duration: "05:46"
+  - title: "We Are the Light"
+    trackNumber: 6
+    duration: "03:18"
+  - title: "Shout to the Devil"
+    trackNumber: 7
+    duration: "04:23"
+  - title: "Blaze of Glory"
+    trackNumber: 8
+    duration: "06:03"
+  - title: "Tell Me"
+    trackNumber: 9
+    duration: "03:10"
+  - title: "The Deceiver"
+    trackNumber: 10
+    duration: "04:50"
+  - title: "The Stand (Prophecy)"
+    trackNumber: 11
+    duration: "01:17"
+  - title: "Howling Wind"
+    trackNumber: 12
+    duration: "06:46"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/5e56a993-6750-38ca-8725-d9c2ef926b61"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Declaration is a release by The Alarm released in 1984-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Sixty Eight Guns.
+
+

--- a/src/content/releases/t/the-associates/the-very-best-of-the-associates/index.md
+++ b/src/content/releases/t/the-associates/the-very-best-of-the-associates/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The Very Best of The Associates"
+artist: "The Associates"
+releaseDate: "2016"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Very Best of The Associates is a release by The Associates released in 2016. It has been featured on 1 Sundown Sessions show. Featured tracks include White Car in Germany.
+
+## Tracks Featured on Sundown Sessions
+
+- White Car in Germany
+
+

--- a/src/content/releases/t/the-beatles/the-beatles-1967-1970-remastered/index.md
+++ b/src/content/releases/t/the-beatles/the-beatles-1967-1970-remastered/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The Beatles 1967 - 1970 (Remastered)"
+artist: "The Beatles"
+releaseDate: "1973"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Beatles 1967 - 1970 (Remastered) is a release by The Beatles released in 1973. It has been featured on 1 Sundown Sessions show. Featured tracks include Revolution - Remastered 2009.
+
+## Tracks Featured on Sundown Sessions
+
+- Revolution - Remastered 2009
+
+

--- a/src/content/releases/t/the-beatles/the-beatles/index.md
+++ b/src/content/releases/t/the-beatles/the-beatles/index.md
@@ -1,0 +1,83 @@
+﻿---
+title: "The Beatles"
+artist: "The Beatles"
+releaseDate: "1968"
+releaseType: "Album"
+duration: "0:59:32"
+featuredInShows:
+  - "9"
+  - "15"
+shows:
+  - "9"
+  - "15"
+tracks:
+  - title: "Eleanor Rigby"
+    trackNumber: 1
+    duration: "02:11"
+  - title: "Let It Be"
+    trackNumber: 2
+    duration: "03:57"
+  - title: "Michelle"
+    trackNumber: 3
+    duration: "02:45"
+  - title: "Yesterday"
+    trackNumber: 4
+    duration: "02:09"
+  - title: "Getting Better All the Time"
+    trackNumber: 5
+    duration: "02:48"
+  - title: "The Fool on the Hill"
+    trackNumber: 6
+    duration: "03:04"
+  - title: "Norwegian Wood (This Bird Has Flown)"
+    trackNumber: 7
+    duration: "02:06"
+  - title: "Hey Jude"
+    trackNumber: 8
+    duration: "04:09"
+  - title: "Strawberry Fields Forever"
+    trackNumber: 9
+    duration: "03:31"
+  - title: "Penny Lane"
+    trackNumber: 10
+    duration: "03:01"
+  - title: "Eleanor Rigby"
+    trackNumber: 11
+    duration: "02:11"
+  - title: "Let It Be"
+    trackNumber: 12
+    duration: "03:57"
+  - title: "Michelle"
+    trackNumber: 13
+    duration: "02:45"
+  - title: "Yesterday"
+    trackNumber: 14
+    duration: "02:09"
+  - title: "Getting Better All the Time"
+    trackNumber: 15
+    duration: "02:55"
+  - title: "The Fool on the Hill"
+    trackNumber: 16
+    duration: "03:04"
+  - title: "Norwegian Wood"
+    trackNumber: 17
+    duration: "02:06"
+  - title: "Hey Jude"
+    trackNumber: 18
+    duration: "04:08"
+  - title: "Strawberry Fields Forever"
+    trackNumber: 19
+    duration: "03:31"
+  - title: "Penny Lane"
+    trackNumber: 20
+    duration: "02:56"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/db1d1fa5-c328-3514-a30c-fa6a4321ffe4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Beatles is a release by The Beatles released in 1968. It has been featured on 2 Sundown Sessions shows. Featured tracks include Everybody's Got Something To Hide Except Me And My Monkey, Glass Onion, Good Night.
+
+

--- a/src/content/releases/t/the-cars/the-cars/index.md
+++ b/src/content/releases/t/the-cars/the-cars/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "The Cars"
+artist: "The Cars"
+releaseDate: "1978-06-06"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "pop rock"
+  - "rock"
+  - "power pop"
+  - "bittersweet"
+labels:
+  - "Elektra"
+duration: "0:35:11"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "Good Times Roll"
+    trackNumber: 1
+    duration: "03:45"
+  - title: "My Best Friend’s Girl"
+    trackNumber: 2
+    duration: "03:43"
+  - title: "Just What I Needed"
+    trackNumber: 3
+    duration: "03:43"
+  - title: "I’m in Touch With Your World"
+    trackNumber: 4
+    duration: "03:31"
+  - title: "Don’t Cha Stop"
+    trackNumber: 5
+    duration: "03:02"
+  - title: "You’re All I’ve Got Tonight"
+    trackNumber: 6
+    duration: "04:13"
+  - title: "Bye Bye Love"
+    trackNumber: 7
+    duration: "04:13"
+  - title: "Moving in Stereo"
+    trackNumber: 8
+    duration: "04:41"
+  - title: "All Mixed Up"
+    trackNumber: 9
+    duration: "04:17"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/36172f3d-9b55-37f1-9fd4-0cbd2f3af0ce"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Cars is a release by The Cars released in 1978-06-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Just What I Needed.
+
+

--- a/src/content/releases/t/the-civil-wars/the-civil-wars/index.md
+++ b/src/content/releases/t/the-civil-wars/the-civil-wars/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "The Civil Wars"
+artist: "The Civil Wars"
+releaseDate: "2013-07-30"
+releaseType: "Album"
+genres:
+  - "pop"
+  - "folk"
+  - "pop rock"
+  - "indie rock"
+  - "rock"
+labels:
+  - "sensibility"
+duration: "0:43:02"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "The One That Got Away"
+    trackNumber: 1
+    duration: "03:32"
+  - title: "I Had Me a Girl"
+    trackNumber: 2
+    duration: "03:45"
+  - title: "Same Old Same Old"
+    trackNumber: 3
+    duration: "03:48"
+  - title: "Dust to Dust"
+    trackNumber: 4
+    duration: "03:49"
+  - title: "Eavesdrop"
+    trackNumber: 5
+    duration: "03:35"
+  - title: "Devil’s Backbone"
+    trackNumber: 6
+    duration: "02:29"
+  - title: "From This Valley"
+    trackNumber: 7
+    duration: "03:33"
+  - title: "Tell Mama"
+    trackNumber: 8
+    duration: "03:48"
+  - title: "Oh Henry"
+    trackNumber: 9
+    duration: "03:32"
+  - title: "Disarm"
+    trackNumber: 10
+    duration: "04:42"
+  - title: "Sacred Heart"
+    trackNumber: 11
+    duration: "03:19"
+  - title: "D’Arline"
+    trackNumber: 12
+    duration: "03:06"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/1d18f97c-adc8-4929-a789-f427c2ca8ffc"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Civil Wars is a release by The Civil Wars released in 2013-07-30. It has been featured on 1 Sundown Sessions show. Featured tracks include The One That Got Away.
+
+

--- a/src/content/releases/t/the-countess-of-fife/star-of-the-sea/index.md
+++ b/src/content/releases/t/the-countess-of-fife/star-of-the-sea/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Star Of The Sea"
+artist: "The Countess Of Fife"
+releaseDate: "2022"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Star Of The Sea is a release by The Countess Of Fife released in 2022. It has been featured on 1 Sundown Sessions show. Featured tracks include Trapped.
+
+## Tracks Featured on Sundown Sessions
+
+- Trapped
+
+

--- a/src/content/releases/t/the-cult/born-into-this/index.md
+++ b/src/content/releases/t/the-cult/born-into-this/index.md
@@ -1,0 +1,72 @@
+﻿---
+title: "Born Into This"
+artist: "The Cult"
+releaseDate: "2007-08-14"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "rock"
+  - "alternative rock"
+labels:
+  - "Roadrunner Records"
+duration: "1:04:07"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Born Into This"
+    trackNumber: 1
+    duration: "04:04"
+  - title: "Citizens"
+    trackNumber: 2
+    duration: "04:32"
+  - title: "Diamonds"
+    trackNumber: 3
+    duration: "04:06"
+  - title: "Dirty Little Rockstar"
+    trackNumber: 4
+    duration: "03:40"
+  - title: "Holy Mountain"
+    trackNumber: 5
+    duration: "03:42"
+  - title: "I Assassin"
+    trackNumber: 6
+    duration: "04:13"
+  - title: "Illuminated"
+    trackNumber: 7
+    duration: "04:07"
+  - title: "Tiger in the Sun"
+    trackNumber: 8
+    duration: "05:07"
+  - title: "Savages"
+    trackNumber: 9
+    duration: "03:54"
+  - title: "Sound of Destruction"
+    trackNumber: 10
+    duration: "03:30"
+  - title: "Stand Alone"
+    trackNumber: 1
+    duration: "05:13"
+  - title: "War Pony Destroyer"
+    trackNumber: 2
+    duration: "04:21"
+  - title: "I Assassin (demo)"
+    trackNumber: 3
+    duration: "04:37"
+  - title: "Sound of Destruction (demo)"
+    trackNumber: 4
+    duration: "04:25"
+  - title: "Savages (full length version)"
+    trackNumber: 5
+    duration: "04:32"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/5ad91de2-ea74-305f-98c0-34b940d183c0"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Born Into This is a release by The Cult released in 2007-08-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Dirty Little Rockstar.
+
+

--- a/src/content/releases/t/the-cult/dreamtime-2024-remaster/index.md
+++ b/src/content/releases/t/the-cult/dreamtime-2024-remaster/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Dreamtime (2024 Remaster)"
+artist: "The Cult"
+releaseDate: "2024"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Dreamtime (2024 Remaster) is a release by The Cult released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include 83rd Dream - 2024 Remaster.
+
+## Tracks Featured on Sundown Sessions
+
+- 83rd Dream - 2024 Remaster
+
+

--- a/src/content/releases/t/the-cult/dreamtime-live-at-the-lyceum/index.md
+++ b/src/content/releases/t/the-cult/dreamtime-live-at-the-lyceum/index.md
@@ -1,0 +1,48 @@
+﻿---
+title: "Dreamtime (Live at The Lyceum)"
+artist: "The Cult"
+releaseDate: "1985-09-21"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "gothic rock"
+  - "rock"
+  - "hard rock"
+  - "post-punk"
+labels:
+  - "NEXUS"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "83rd Dream"
+    trackNumber: 1
+  - title: "God's Zoo"
+    trackNumber: 2
+  - title: "Bad Medicine"
+    trackNumber: 3
+  - title: "A Flower In The Desert"
+    trackNumber: 4
+  - title: "Dreamtime"
+    trackNumber: 5
+  - title: "Christians"
+    trackNumber: 6
+  - title: "Horse Nation"
+    trackNumber: 7
+  - title: "Bone Bag"
+    trackNumber: 8
+  - title: "Ghost Dance"
+    trackNumber: 9
+  - title: "Moya"
+    trackNumber: 10
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/ffdae58b-49ee-3b14-8e24-b433d2759506"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Dreamtime (Live at The Lyceum) is a release by The Cult released in 1985-09-21. It has been featured on 1 Sundown Sessions show. Featured tracks include 83rd Dream.
+
+

--- a/src/content/releases/t/the-cult/electric/index.md
+++ b/src/content/releases/t/the-cult/electric/index.md
@@ -1,0 +1,64 @@
+﻿---
+title: "Electric"
+artist: "The Cult"
+releaseDate: "1987-05-21"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "rock"
+  - "glam metal"
+  - "metal"
+  - "alternative rock"
+labels:
+  - "BMG Music International"
+duration: "0:38:47"
+featuredInShows:
+  - "12"
+  - "46"
+shows:
+  - "12"
+  - "46"
+tracks:
+  - title: "Wild Flower"
+    trackNumber: 1
+    duration: "03:38"
+  - title: "Peace Dog"
+    trackNumber: 2
+    duration: "03:35"
+  - title: "Lil' Devil"
+    trackNumber: 3
+    duration: "02:44"
+  - title: "Aphrodisiac Jacket"
+    trackNumber: 4
+    duration: "04:11"
+  - title: "Electric Ocean"
+    trackNumber: 5
+    duration: "02:49"
+  - title: "Bad Fun"
+    trackNumber: 6
+    duration: "03:35"
+  - title: "King Contrary Man"
+    trackNumber: 7
+    duration: "03:12"
+  - title: "Love Removal Machine"
+    trackNumber: 8
+    duration: "04:17"
+  - title: "Born to Be Wild"
+    trackNumber: 9
+    duration: "03:55"
+  - title: "Outlaw"
+    trackNumber: 10
+    duration: "02:52"
+  - title: "Memphis Hip Shake"
+    trackNumber: 11
+    duration: "03:59"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e9e740ec-a09f-3f29-802f-43af41b7e440"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Electric is a release by The Cult released in 1987-05-21. It has been featured on 2 Sundown Sessions shows. Featured tracks include Born To Be Wild, Electric Ocean.
+
+

--- a/src/content/releases/t/the-cult/love/index.md
+++ b/src/content/releases/t/the-cult/love/index.md
@@ -1,0 +1,61 @@
+﻿---
+title: "Love"
+artist: "The Cult"
+releaseDate: "1985-08"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "rock"
+  - "hard rock"
+  - "gothic rock"
+  - "neo-psychedelia"
+labels:
+  - "Beggars Banquet"
+duration: "0:52:01"
+featuredInShows:
+  - "4"
+  - "7"
+shows:
+  - "4"
+  - "7"
+tracks:
+  - title: "Nirvana"
+    trackNumber: 1
+    duration: "05:28"
+  - title: "Big Neon Glitter"
+    trackNumber: 2
+    duration: "04:56"
+  - title: "Love"
+    trackNumber: 3
+    duration: "05:33"
+  - title: "Brother Wolf, Sister Moon"
+    trackNumber: 4
+    duration: "06:49"
+  - title: "Rain"
+    trackNumber: 5
+    duration: "03:58"
+  - title: "Phoenix"
+    trackNumber: 6
+    duration: "05:08"
+  - title: "Hollow Man"
+    trackNumber: 7
+    duration: "04:47"
+  - title: "Revolution"
+    trackNumber: 8
+    duration: "05:29"
+  - title: "She Sells Sanctuary"
+    trackNumber: 9
+    duration: "04:24"
+  - title: "Black Angel"
+    trackNumber: 10
+    duration: "05:25"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e7d22464-a11e-3ff1-8d97-4af3f0c1aeb2"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Love is a release by The Cult released in 1985-08. It has been featured on 2 Sundown Sessions shows. Featured tracks include Big Neon Glitter, Nirvana.
+
+

--- a/src/content/releases/t/the-damned/new-rose/index.md
+++ b/src/content/releases/t/the-damned/new-rose/index.md
@@ -1,0 +1,33 @@
+﻿---
+title: "New Rose"
+artist: "The Damned"
+releaseDate: "1976-10-22"
+releaseType: "Single"
+genres:
+  - "punk"
+  - "punk rock"
+  - "rock"
+labels:
+  - "Stiff Records"
+duration: "0:04:29"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+tracks:
+  - title: "New Rose"
+    trackNumber: 1
+    duration: "02:45"
+  - title: "Help"
+    trackNumber: 2
+    duration: "01:44"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d5edc24a-a657-3701-8a59-1ed512dcec25"
+lastmod: "2026-06-25"
+---
+
+## About
+
+New Rose is a release by The Damned released in 1976-10-22. It has been featured on 1 Sundown Sessions show. Featured tracks include New Rose.
+
+

--- a/src/content/releases/t/the-darkness/permission-to-land/index.md
+++ b/src/content/releases/t/the-darkness/permission-to-land/index.md
@@ -1,0 +1,60 @@
+﻿---
+title: "Permission to Land"
+artist: "The Darkness"
+releaseDate: "2003-07-07"
+releaseType: "Album"
+genres:
+  - "hard rock"
+  - "glam rock"
+  - "rock"
+  - "rock and indie"
+  - "general"
+labels:
+  - "Atlantic"
+  - "Must…Destroy!!"
+duration: "0:38:19"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+tracks:
+  - title: "Black Shuck"
+    trackNumber: 1
+    duration: "03:22"
+  - title: "Get Your Hands Off My Woman"
+    trackNumber: 2
+    duration: "02:46"
+  - title: "Growing on Me"
+    trackNumber: 3
+    duration: "03:31"
+  - title: "I Believe in a Thing Called Love"
+    trackNumber: 4
+    duration: "03:36"
+  - title: "Love Is Only a Feeling"
+    trackNumber: 5
+    duration: "04:20"
+  - title: "Givin’ Up"
+    trackNumber: 6
+    duration: "03:34"
+  - title: "Stuck in a Rut"
+    trackNumber: 7
+    duration: "03:18"
+  - title: "Friday Night"
+    trackNumber: 8
+    duration: "02:55"
+  - title: "Love on the Rocks With No Ice"
+    trackNumber: 9
+    duration: "05:56"
+  - title: "Holding My Own"
+    trackNumber: 10
+    duration: "04:57"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/00edead2-61f0-3122-9f23-7c741c1f39cf"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Permission to Land is a release by The Darkness released in 2003-07-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Growing on Me.
+
+

--- a/src/content/releases/t/the-detroit-cobras/life-love-and-leaving/index.md
+++ b/src/content/releases/t/the-detroit-cobras/life-love-and-leaving/index.md
@@ -1,0 +1,71 @@
+﻿---
+title: "Life, Love And Leaving"
+artist: "The Detroit Cobras"
+releaseDate: "2001-04"
+releaseType: "Album"
+genres:
+  - "garage rock"
+  - "soul"
+  - "rock"
+labels:
+  - "Sympathy for the Record Industry"
+duration: "0:29:47"
+featuredInShows:
+  - "1"
+  - "4"
+shows:
+  - "1"
+  - "4"
+tracks:
+  - title: "Hey Sailor"
+    trackNumber: 1
+    duration: "02:26"
+  - title: "He Did It"
+    trackNumber: 2
+    duration: "02:22"
+  - title: "Find Me a Home"
+    trackNumber: 3
+    duration: "01:31"
+  - title: "Oh My Lover"
+    trackNumber: 4
+    duration: "01:34"
+  - title: "Cry On"
+    trackNumber: 5
+    duration: "02:15"
+  - title: "Stupidity"
+    trackNumber: 6
+    duration: "01:56"
+  - title: "Bye Bye Baby"
+    trackNumber: 7
+    duration: "02:31"
+  - title: "Boss Lady"
+    trackNumber: 8
+    duration: "02:09"
+  - title: "Laughing at You"
+    trackNumber: 9
+    duration: "01:35"
+  - title: "Can’t Miss Nothing"
+    trackNumber: 10
+    duration: "01:54"
+  - title: "Right Around the Corner"
+    trackNumber: 11
+    duration: "02:27"
+  - title: "Won’t You Dance With Me"
+    trackNumber: 12
+    duration: "02:14"
+  - title: "Let’s Forget About the Past"
+    trackNumber: 13
+    duration: "02:46"
+  - title: "Shout Bama Lama"
+    trackNumber: 14
+    duration: "02:01"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/25c00fdf-ddad-3cdd-bd76-11a04813dc9f"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Life, Love And Leaving is a release by The Detroit Cobras released in 2001-04. It has been featured on 2 Sundown Sessions shows. Featured tracks include Cry On, Shout Bamalama.
+
+

--- a/src/content/releases/t/the-doors/absolutely-live/index.md
+++ b/src/content/releases/t/the-doors/absolutely-live/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "Absolutely Live"
+artist: "The Doors"
+releaseDate: "1970-07"
+releaseType: "Album"
+genres:
+  - "psychedelic rock"
+  - "blues rock"
+  - "acid rock and british blues"
+  - "acid rock"
+  - "sexual"
+labels:
+  - "Elektra"
+duration: "1:17:43"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+tracks:
+  - title: "Who Do You Love"
+    trackNumber: 1
+    duration: "08:41"
+  - title: "Medley: Alabama Song / Back Door Man / Love Hides / Five to One"
+    trackNumber: 2
+    duration: "10:39"
+  - title: "Build Me a Woman"
+    trackNumber: 3
+    duration: "03:42"
+  - title: "When the Music’s Over"
+    trackNumber: 4
+    duration: "14:54"
+  - title: "Close to You"
+    trackNumber: 1
+    duration: "05:28"
+  - title: "Universal Mind"
+    trackNumber: 2
+    duration: "05:00"
+  - title: "Break On Thru, #2"
+    trackNumber: 3
+    duration: "07:30"
+  - title: "The Celebration of the Lizard"
+    trackNumber: 4
+    duration: "14:33"
+  - title: "Soul Kitchen"
+    trackNumber: 5
+    duration: "07:16"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/f02e01d9-a8a7-3530-bd4f-bc5b60f3b777"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Absolutely Live is a release by The Doors released in 1970-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Who Do You Love.
+
+

--- a/src/content/releases/t/the-doors/strange-days/index.md
+++ b/src/content/releases/t/the-doors/strange-days/index.md
@@ -1,0 +1,61 @@
+﻿---
+title: "Strange Days"
+artist: "The Doors"
+releaseDate: "1967-09-27"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "psychedelic rock"
+  - "acid rock"
+  - "acid rock and british blues"
+  - "blues rock"
+labels:
+  - "Elektra"
+duration: "0:34:49"
+featuredInShows:
+  - "11"
+  - "46"
+shows:
+  - "11"
+  - "46"
+tracks:
+  - title: "Strange Days"
+    trackNumber: 1
+    duration: "03:05"
+  - title: "You’re Lost Little Girl"
+    trackNumber: 2
+    duration: "03:01"
+  - title: "Love Me Two Times"
+    trackNumber: 3
+    duration: "03:23"
+  - title: "Unhappy Girl"
+    trackNumber: 4
+    duration: "02:00"
+  - title: "Horse Latitudes"
+    trackNumber: 5
+    duration: "01:30"
+  - title: "Moonlight Drive"
+    trackNumber: 6
+    duration: "03:00"
+  - title: "People Are Strange"
+    trackNumber: 7
+    duration: "02:10"
+  - title: "My Eyes Have Seen You"
+    trackNumber: 8
+    duration: "02:22"
+  - title: "I Can’t See Your Face in My Mind"
+    trackNumber: 9
+    duration: "03:18"
+  - title: "When the Music's Over"
+    trackNumber: 10
+    duration: "11:00"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/9b1acd78-3d19-37bb-8ca0-5816d44da439"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Strange Days is a release by The Doors released in 1967-09-27. It has been featured on 2 Sundown Sessions shows. Featured tracks include Strange Days, When the Music's Over.
+
+

--- a/src/content/releases/t/the-easybeats/easy/index.md
+++ b/src/content/releases/t/the-easybeats/easy/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Easy"
+artist: "The Easybeats"
+releaseDate: "1965-09-23"
+releaseType: "Album"
+genres:
+  - "rock and roll"
+  - "rock"
+labels:
+  - "Parlophone"
+duration: "0:32:29"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "It’s So Easy"
+    trackNumber: 1
+    duration: "02:15"
+  - title: "I’m a Madman"
+    trackNumber: 2
+    duration: "02:54"
+  - title: "I Wonder"
+    trackNumber: 3
+    duration: "01:53"
+  - title: "She Said Alright"
+    trackNumber: 4
+    duration: "02:17"
+  - title: "I’m Gonna Tell Everybody"
+    trackNumber: 5
+    duration: "02:08"
+  - title: "Hey Girl"
+    trackNumber: 6
+    duration: "02:13"
+  - title: "She’s So Fine"
+    trackNumber: 7
+    duration: "02:10"
+  - title: "You Got It Off Me"
+    trackNumber: 8
+    duration: "02:34"
+  - title: "Cry, Cry, Cry"
+    trackNumber: 9
+    duration: "02:02"
+  - title: "A Letter"
+    trackNumber: 10
+    duration: "01:45"
+  - title: "Easy Beat"
+    trackNumber: 11
+    duration: "02:42"
+  - title: "You’ll Come Back Again"
+    trackNumber: 12
+    duration: "01:59"
+  - title: "Girl on My Mind"
+    trackNumber: 13
+    duration: "03:05"
+  - title: "Ya Can’t Do That"
+    trackNumber: 14
+    duration: "02:27"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/bf17005b-d504-3056-86bd-e3d6ae0b7c8f"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Easy is a release by The Easybeats released in 1965-09-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Friday On My Mind.
+
+

--- a/src/content/releases/t/the-essence/purity/index.md
+++ b/src/content/releases/t/the-essence/purity/index.md
@@ -1,0 +1,67 @@
+﻿---
+title: "Purity"
+artist: "The Essence"
+releaseDate: "1985"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "synth-pop"
+  - "rock"
+  - "electronic"
+labels:
+  - "Midnight Music"
+duration: "0:46:12"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "The Last Preach"
+    trackNumber: 1
+    duration: "06:08"
+  - title: "A Reflected Dream"
+    trackNumber: 2
+    duration: "02:56"
+  - title: "The Cat"
+    trackNumber: 3
+    duration: "03:44"
+  - title: "The Blind"
+    trackNumber: 4
+    duration: "02:19"
+  - title: "Never Mine"
+    trackNumber: 5
+    duration: "03:18"
+  - title: "Endless Lakes"
+    trackNumber: 6
+    duration: "03:27"
+  - title: "Forever in Death"
+    trackNumber: 7
+    duration: "02:54"
+  - title: "Salvation"
+    trackNumber: 8
+    duration: "02:46"
+  - title: "The Waving Girl"
+    trackNumber: 9
+    duration: "03:52"
+  - title: "Purity"
+    trackNumber: 10
+    duration: "04:26"
+  - title: "Confusion"
+    trackNumber: 11
+    duration: "04:07"
+  - title: "From My Mouth"
+    trackNumber: 12
+    duration: "01:46"
+  - title: "The Swaying Wind"
+    trackNumber: 13
+    duration: "04:24"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/8bb49a78-87ff-307f-9b84-bf707bfcb464"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Purity is a release by The Essence released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include The Cat.
+
+

--- a/src/content/releases/t/the-exploding-boy/exploding-boy/index.md
+++ b/src/content/releases/t/the-exploding-boy/exploding-boy/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Exploding Boy"
+artist: "The Exploding Boy"
+releaseDate: "2007"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Exploding Boy is a release by The Exploding Boy released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include Better Than Fine.
+
+## Tracks Featured on Sundown Sessions
+
+- Better Than Fine
+
+

--- a/src/content/releases/t/the-filthy-tongues/jacobs-ladder/index.md
+++ b/src/content/releases/t/the-filthy-tongues/jacobs-ladder/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Jacob's Ladder"
+artist: "The Filthy Tongues"
+releaseDate: "2016"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Jacob's Ladder is a release by The Filthy Tongues released in 2016. It has been featured on 1 Sundown Sessions show. Featured tracks include Children of the Filthy.
+
+## Tracks Featured on Sundown Sessions
+
+- Children of the Filthy
+
+

--- a/src/content/releases/t/the-groundhogs/blues-obituary/index.md
+++ b/src/content/releases/t/the-groundhogs/blues-obituary/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Blues Obituary"
+artist: "The Groundhogs"
+releaseDate: "1969"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Blues Obituary is a release by The Groundhogs released in 1969. It has been featured on 1 Sundown Sessions show. Featured tracks include Natchez Burning.
+
+## Tracks Featured on Sundown Sessions
+
+- Natchez Burning
+
+

--- a/src/content/releases/t/the-hollies/distant-light/index.md
+++ b/src/content/releases/t/the-hollies/distant-light/index.md
@@ -1,0 +1,62 @@
+﻿---
+title: "Distant Light"
+artist: "The Hollies"
+releaseDate: "1971-12"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "pop"
+  - "swamp rock"
+  - "pop rock"
+  - "country rock"
+labels:
+  - "Epic"
+duration: "0:44:45"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "Life I’ve Led"
+    trackNumber: 1
+    duration: "03:59"
+  - title: "Look What We’ve Got"
+    trackNumber: 2
+    duration: "04:10"
+  - title: "Hold On"
+    trackNumber: 3
+    duration: "04:09"
+  - title: "Pull Down the Blind"
+    trackNumber: 4
+    duration: "03:32"
+  - title: "To Do With Love"
+    trackNumber: 5
+    duration: "03:29"
+  - title: "Promised Land"
+    trackNumber: 6
+    duration: "04:22"
+  - title: "Long Cool Woman in a Black Dress"
+    trackNumber: 7
+    duration: "03:19"
+  - title: "You Know the Score"
+    trackNumber: 8
+    duration: "05:40"
+  - title: "Cable Car"
+    trackNumber: 9
+    duration: "04:24"
+  - title: "Little Thing Like Love"
+    trackNumber: 10
+    duration: "03:22"
+  - title: "Long Dark Road"
+    trackNumber: 11
+    duration: "04:15"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/a2a6e2dd-77cd-3b0b-8331-99f53113e9cf"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Distant Light is a release by The Hollies released in 1971-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Long Cool Woman (In a Black Dress).
+
+

--- a/src/content/releases/t/the-house-of-love/the-house-of-love-2012-deluxe-version/index.md
+++ b/src/content/releases/t/the-house-of-love/the-house-of-love-2012-deluxe-version/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "The House Of Love (2012 Deluxe Version)"
+artist: "The House of Love"
+releaseDate: "2012"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The House Of Love (2012 Deluxe Version) is a release by The House of Love released in 2012. It has been featured on 1 Sundown Sessions show. Featured tracks include Christine - 2018 Remaster.
+
+## Tracks Featured on Sundown Sessions
+
+- Christine - 2018 Remaster
+
+

--- a/src/content/releases/t/the-human-league/reproduction/index.md
+++ b/src/content/releases/t/the-human-league/reproduction/index.md
@@ -1,0 +1,56 @@
+﻿---
+title: "Reproduction"
+artist: "The Human League"
+releaseDate: "1979-10-01"
+releaseType: "Album"
+genres:
+  - "electronic"
+  - "new wave"
+  - "synth-pop"
+  - "post-punk"
+  - "alternative/indie rock"
+labels:
+  - "Virgin"
+duration: "0:42:23"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+tracks:
+  - title: "Almost Medieval"
+    trackNumber: 1
+    duration: "04:34"
+  - title: "Circus of Death"
+    trackNumber: 2
+    duration: "03:51"
+  - title: "The Path of Least Resistance"
+    trackNumber: 3
+    duration: "03:27"
+  - title: "Blind Youth"
+    trackNumber: 4
+    duration: "03:16"
+  - title: "The Word Before Last"
+    trackNumber: 5
+    duration: "03:56"
+  - title: "Empire State Human"
+    trackNumber: 6
+    duration: "03:10"
+  - title: "Morale… / You’ve Lost That Loving Feeling"
+    trackNumber: 7
+    duration: "09:30"
+  - title: "Austerity / Girl One (medley)"
+    trackNumber: 8
+    duration: "06:38"
+  - title: "Zero as a Limit"
+    trackNumber: 9
+    duration: "04:01"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/1d41c0ad-ceb4-39bc-9885-4bb3c9cc27af"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Reproduction is a release by The Human League released in 1979-10-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Empire State Human.
+
+

--- a/src/content/releases/t/the-human-league/travelogue/index.md
+++ b/src/content/releases/t/the-human-league/travelogue/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Travelogue"
+artist: "The Human League"
+releaseDate: "1980-05-23"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "experimental"
+  - "electro"
+  - "electronic"
+  - "new wave"
+labels:
+  - "Virgin"
+duration: "0:39:58"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "The Black Hit of Space"
+    trackNumber: 1
+    duration: "04:14"
+  - title: "Only After Dark"
+    trackNumber: 2
+    duration: "03:53"
+  - title: "Life Kills"
+    trackNumber: 3
+    duration: "03:10"
+  - title: "Dreams of Leaving"
+    trackNumber: 4
+    duration: "05:55"
+  - title: "Toyota City"
+    trackNumber: 5
+    duration: "03:24"
+  - title: "Crow and a Baby"
+    trackNumber: 6
+    duration: "03:46"
+  - title: "The Touchables"
+    trackNumber: 7
+    duration: "03:24"
+  - title: "Gordon’s Gin"
+    trackNumber: 8
+    duration: "03:01"
+  - title: "Being Boiled"
+    trackNumber: 9
+    duration: "04:25"
+  - title: "WXJL Tonight"
+    trackNumber: 10
+    duration: "04:46"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/e30d6387-674f-3489-8b57-138735f5f9cf"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Travelogue is a release by The Human League released in 1980-05-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Rock 'n' Roll / Night Clubbing.
+
+

--- a/src/content/releases/t/the-lathums/stellar-cast/index.md
+++ b/src/content/releases/t/the-lathums/stellar-cast/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Stellar Cast"
+artist: "The Lathums"
+releaseDate: "2024"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Stellar Cast is a release by The Lathums released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Stellar Cast.
+
+## Tracks Featured on Sundown Sessions
+
+- Stellar Cast
+
+

--- a/src/content/releases/t/the-mission/aura/index.md
+++ b/src/content/releases/t/the-mission/aura/index.md
@@ -1,0 +1,73 @@
+﻿---
+title: "Aura"
+artist: "The Mission"
+releaseDate: "2001-12-03"
+releaseType: "Album"
+genres:
+  - "gothic rock"
+  - "rock"
+  - "alternative rock"
+  - "pop"
+labels:
+  - "Oblivion"
+duration: "1:17:04"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Evangeline"
+    trackNumber: 1
+    duration: "03:56"
+  - title: "Shine Like the Stars"
+    trackNumber: 2
+    duration: "04:34"
+  - title: "(Slave to) Lust"
+    trackNumber: 3
+    duration: "05:41"
+  - title: "Mesmerised"
+    trackNumber: 4
+    duration: "05:14"
+  - title: "Lay Your Hands on Me"
+    trackNumber: 5
+    duration: "05:35"
+  - title: "Dragonfly"
+    trackNumber: 6
+    duration: "05:41"
+  - title: "Happy"
+    trackNumber: 7
+    duration: "03:07"
+  - title: "To Die by Your Hand"
+    trackNumber: 8
+    duration: "01:18"
+  - title: "Trophy / It Never Rains..."
+    trackNumber: 9
+    duration: "05:42"
+  - title: "The Light That Pours From You"
+    trackNumber: 10
+    duration: "05:25"
+  - title: "Burlesque"
+    trackNumber: 11
+    duration: "04:56"
+  - title: "Cocoon"
+    trackNumber: 12
+    duration: "07:33"
+  - title: "In Denial"
+    trackNumber: 13
+    duration: "09:07"
+  - title: "Evangeline (video clip)"
+    trackNumber: 1
+    duration: "04:11"
+  - title: "Deliverance (live performance Sep. 25th, 2001, Oberhausen Arena/Germany)"
+    trackNumber: 2
+    duration: "04:57"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/c20fbfce-30d6-3ce4-bb30-516e0e941684"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Aura is a release by The Mission released in 2001-12-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Dragonfly.
+
+

--- a/src/content/releases/t/the-mission/carved-in-sand/index.md
+++ b/src/content/releases/t/the-mission/carved-in-sand/index.md
@@ -1,0 +1,46 @@
+﻿---
+title: "Carved In Sand"
+artist: "The Mission"
+releaseDate: "1990-02"
+releaseType: "Album"
+genres:
+  - "gothic rock"
+  - "goth rock"
+  - "rock"
+labels:
+  - "Mercury Records"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Amelia"
+    trackNumber: 1
+  - title: "Into the Blue"
+    trackNumber: 2
+  - title: "Butterfly on a Wheel"
+    trackNumber: 3
+  - title: "Sea of Love"
+    trackNumber: 4
+  - title: "Deliverance"
+    trackNumber: 5
+  - title: "Grapes of Wrath"
+    trackNumber: 6
+  - title: "Belief"
+    trackNumber: 7
+  - title: "Paradise (Will Shine Like the Moon)"
+    trackNumber: 8
+  - title: "Hungry as the Hunter"
+    trackNumber: 9
+  - title: "Lovely"
+    trackNumber: 10
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/ae7c651a-0997-32a3-8491-5646e7b6ff17"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Carved In Sand is a release by The Mission released in 1990-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Deliverance.
+
+

--- a/src/content/releases/t/the-mission/the-first-chapter/index.md
+++ b/src/content/releases/t/the-mission/the-first-chapter/index.md
@@ -1,0 +1,53 @@
+﻿---
+title: "The First Chapter"
+artist: "The Mission"
+releaseDate: "1987-06"
+releaseType: "Album"
+genres:
+  - "gothic rock"
+  - "rock"
+labels:
+  - "Mercury Records"
+duration: "0:46:00"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+tracks:
+  - title: "Like a Hurricane"
+    trackNumber: 1
+    duration: "05:00"
+  - title: "Over the Hills and Far Away"
+    trackNumber: 2
+    duration: "03:59"
+  - title: "Naked and Savage"
+    trackNumber: 3
+    duration: "04:45"
+  - title: "Serpents Kiss"
+    trackNumber: 4
+    duration: "04:13"
+  - title: "Dancing Barefoot"
+    trackNumber: 5
+    duration: "03:08"
+  - title: "The Crystal Ocean (extended)"
+    trackNumber: 6
+    duration: "07:37"
+  - title: "Garden of Delight (extended)"
+    trackNumber: 7
+    duration: "05:03"
+  - title: "Wake (RSV)"
+    trackNumber: 8
+    duration: "05:04"
+  - title: "Like a Hurricane (extended)"
+    trackNumber: 9
+    duration: "07:07"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/a69bfa81-2f38-3729-8b10-cf4c4477b26d"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The First Chapter is a release by The Mission released in 1987-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Naked And Savage.
+
+

--- a/src/content/releases/t/the-motors/airport-the-motors-greatest-hits/index.md
+++ b/src/content/releases/t/the-motors/airport-the-motors-greatest-hits/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Airport - The Motors Greatest Hits"
+artist: "The Motors"
+releaseDate: "1995"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Airport - The Motors Greatest Hits is a release by The Motors released in 1995. It has been featured on 1 Sundown Sessions show. Featured tracks include Dancing The Night Away.
+
+## Tracks Featured on Sundown Sessions
+
+- Dancing The Night Away
+
+

--- a/src/content/releases/t/the-move/hitsnflips/index.md
+++ b/src/content/releases/t/the-move/hitsnflips/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Hits'n'Flips"
+artist: "The Move"
+releaseDate: "2013"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Hits'n'Flips is a release by The Move released in 2013. It has been featured on 1 Sundown Sessions show. Featured tracks include Blackberry Way.
+
+## Tracks Featured on Sundown Sessions
+
+- Blackberry Way
+
+

--- a/src/content/releases/t/the-move/move/index.md
+++ b/src/content/releases/t/the-move/move/index.md
@@ -1,0 +1,66 @@
+﻿---
+title: "Move"
+artist: "The Move"
+releaseDate: "1968-04"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "psychedelic rock"
+  - "pop"
+labels:
+  - "Regal Zonophone"
+duration: "0:35:42"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Yellow Rainbow"
+    trackNumber: 1
+    duration: "02:38"
+  - title: "Kilroy Was Here"
+    trackNumber: 2
+    duration: "02:46"
+  - title: "(Here We Go Round) The Lemon Tree"
+    trackNumber: 3
+    duration: "03:10"
+  - title: "Weekend"
+    trackNumber: 4
+    duration: "01:48"
+  - title: "Walk Upon the Water"
+    trackNumber: 5
+    duration: "03:19"
+  - title: "Flowers in the Rain"
+    trackNumber: 6
+    duration: "02:30"
+  - title: "Hey Grandma"
+    trackNumber: 7
+    duration: "03:14"
+  - title: "Useless Information"
+    trackNumber: 8
+    duration: "03:00"
+  - title: "Zing Went the Strings of My Heart"
+    trackNumber: 9
+    duration: "02:50"
+  - title: "The Girl Outside"
+    trackNumber: 10
+    duration: "02:55"
+  - title: "Fire Brigade"
+    trackNumber: 11
+    duration: "02:24"
+  - title: "Mist on a Monday Morning"
+    trackNumber: 12
+    duration: "02:32"
+  - title: "Cherry Blossom Clinic"
+    trackNumber: 13
+    duration: "02:32"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/096f6b37-68c9-3bee-a60d-68a27febe8f6"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Move is a release by The Move released in 1968-04. It has been featured on 1 Sundown Sessions show. Featured tracks include Fire Brigade.
+
+

--- a/src/content/releases/t/the-move/shazam-2007-remaster/index.md
+++ b/src/content/releases/t/the-move/shazam-2007-remaster/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Shazam (2007 Remaster)"
+artist: "The Move"
+releaseDate: "1970"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Shazam (2007 Remaster) is a release by The Move released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Hello Susie - 2007 Remaster.
+
+## Tracks Featured on Sundown Sessions
+
+- Hello Susie - 2007 Remaster
+
+

--- a/src/content/releases/t/the-move/shazam/index.md
+++ b/src/content/releases/t/the-move/shazam/index.md
@@ -1,0 +1,40 @@
+﻿---
+title: "Shazam"
+artist: "The Move"
+releaseDate: "1970"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "pop rock"
+  - "psychedelic rock"
+labels:
+  - "Regal Zonophone"
+featuredInShows:
+  - "1"
+  - "14"
+shows:
+  - "1"
+  - "14"
+tracks:
+  - title: "Hello Suzie"
+    trackNumber: 1
+  - title: "Beautiful Daughter"
+    trackNumber: 2
+  - title: "Cherry Blossom Clinic Revisited"
+    trackNumber: 3
+  - title: "Fields of People"
+    trackNumber: 4
+  - title: "Don’t Make My Baby Blue"
+    trackNumber: 5
+  - title: "The Last Thing on My Mind"
+    trackNumber: 6
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/dd5298d4-ee21-32f7-8d6d-3acc6f7ed122"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Shazam is a release by The Move released in 1970. It has been featured on 2 Sundown Sessions shows. Featured tracks include Cherry Blossom Clinic Revisited, Hello Susie.
+
+

--- a/src/content/releases/t/the-music-machine/turn-on-the-music-machine/index.md
+++ b/src/content/releases/t/the-music-machine/turn-on-the-music-machine/index.md
@@ -1,0 +1,63 @@
+﻿---
+title: "(Turn On) The Music Machine"
+artist: "The Music Machine"
+releaseDate: "1966"
+releaseType: "Album"
+genres:
+  - "garage rock"
+  - "rock"
+  - "psychedelic rock"
+labels:
+  - "Original Sound"
+duration: "0:32:03"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Talk Talk"
+    trackNumber: 1
+    duration: "01:58"
+  - title: "Trouble"
+    trackNumber: 2
+    duration: "02:14"
+  - title: "Cherry Cherry"
+    trackNumber: 3
+    duration: "03:11"
+  - title: "Taxman"
+    trackNumber: 4
+    duration: "02:34"
+  - title: "Some Other Drum"
+    trackNumber: 5
+    duration: "02:34"
+  - title: "Masculine Intuition"
+    trackNumber: 6
+    duration: "02:09"
+  - title: "The People in Me"
+    trackNumber: 7
+    duration: "02:58"
+  - title: "See See Rider"
+    trackNumber: 8
+    duration: "02:33"
+  - title: "Wrong"
+    trackNumber: 9
+    duration: "02:19"
+  - title: "96 Tears"
+    trackNumber: 10
+    duration: "02:20"
+  - title: "Come on In"
+    trackNumber: 11
+    duration: "02:55"
+  - title: "Hey Joe"
+    trackNumber: 12
+    duration: "04:11"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/88991a31-90ab-3943-93a3-b72daebebdd3"
+lastmod: "2026-06-25"
+---
+
+## About
+
+(Turn On) The Music Machine is a release by The Music Machine released in 1966. It has been featured on 1 Sundown Sessions show. Featured tracks include The People In Me.
+
+

--- a/src/content/releases/t/the-organ/grab-that-gun/index.md
+++ b/src/content/releases/t/the-organ/grab-that-gun/index.md
@@ -1,0 +1,60 @@
+﻿---
+title: "Grab That Gun"
+artist: "The Organ"
+releaseDate: "2004-05-24"
+releaseType: "Album"
+genres:
+  - "indie rock"
+  - "rock"
+  - "pop rock"
+labels:
+  - "Mint Records"
+duration: "0:30:00"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "Brother"
+    trackNumber: 1
+    duration: "04:01"
+  - title: "Steven Smith"
+    trackNumber: 2
+    duration: "02:06"
+  - title: "Love, Love, Love"
+    trackNumber: 3
+    duration: "03:31"
+  - title: "Basement Band Song"
+    trackNumber: 4
+    duration: "04:12"
+  - title: "Sinking Hearts"
+    trackNumber: 5
+    duration: "02:09"
+  - title: "A Sudden Death"
+    trackNumber: 6
+    duration: "02:54"
+  - title: "There Is Nothing I Can Do"
+    trackNumber: 7
+    duration: "02:35"
+  - title: "I Am Not Surprised"
+    trackNumber: 8
+    duration: "02:44"
+  - title: "No One Has Ever Looked So Dead"
+    trackNumber: 9
+    duration: "01:57"
+  - title: "Memorize the City"
+    trackNumber: 10
+    duration: "03:10"
+  - title: "[untitled]"
+    trackNumber: 11
+    duration: "00:37"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/7cf30478-3b74-38c1-97fe-8840a3bd653b"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Grab That Gun is a release by The Organ released in 2004-05-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Brother.
+
+

--- a/src/content/releases/t/the-revillos/rev-up/index.md
+++ b/src/content/releases/t/the-revillos/rev-up/index.md
@@ -1,0 +1,68 @@
+﻿---
+title: "Rev Up"
+artist: "The Revillos"
+releaseDate: "1980"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "rock"
+  - "punk"
+  - "pop"
+labels:
+  - "Dindisc"
+  - "Snatzo Recordi"
+duration: "0:28:43"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Secret of the Shadow"
+    trackNumber: 1
+    duration: "01:25"
+  - title: "Rev Up!"
+    trackNumber: 2
+    duration: "02:20"
+  - title: "Rock-A-Boom"
+    trackNumber: 3
+    duration: "02:25"
+  - title: "Voodoo"
+    trackNumber: 4
+    duration: "02:44"
+  - title: "Bobby Come Back to Me"
+    trackNumber: 5
+    duration: "02:27"
+  - title: "Scuba Boy Bop"
+    trackNumber: 6
+    duration: "01:44"
+  - title: "Yeah Yeah"
+    trackNumber: 7
+    duration: "02:14"
+  - title: "Hungry for Love"
+    trackNumber: 8
+    duration: "01:48"
+  - title: "Juke Box Sound"
+    trackNumber: 9
+    duration: "01:57"
+  - title: "On the Beach"
+    trackNumber: 10
+    duration: "03:33"
+  - title: "Cool Jerk"
+    trackNumber: 11
+    duration: "02:11"
+  - title: "Hippy Hippy Sheik"
+    trackNumber: 12
+    duration: "01:30"
+  - title: "Motorbike Beat"
+    trackNumber: 13
+    duration: "02:25"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/a845a6d9-5c76-3e46-83e7-e661f7e319c1"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Rev Up is a release by The Revillos released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include Motorbike Beat.
+
+

--- a/src/content/releases/t/the-ruts/youve-gotta-get-out-of-it/index.md
+++ b/src/content/releases/t/the-ruts/youve-gotta-get-out-of-it/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "You've Gotta Get Out Of It"
+artist: "The Ruts"
+releaseDate: "1980"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+lastmod: "2026-06-25"
+---
+
+## About
+
+You've Gotta Get Out Of It is a release by The Ruts released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include Staring At The Rude Boys.
+
+## Tracks Featured on Sundown Sessions
+
+- Staring At The Rude Boys
+
+

--- a/src/content/releases/t/the-selecter/too-much-pressure/index.md
+++ b/src/content/releases/t/the-selecter/too-much-pressure/index.md
@@ -1,0 +1,74 @@
+﻿---
+title: "Too Much Pressure"
+artist: "The Selecter"
+releaseDate: "1999"
+releaseType: "Album"
+genres:
+  - "ska"
+  - "rock"
+labels:
+  - "The Harry May Record Company"
+duration: "0:53:43"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Three Minute Hero"
+    trackNumber: 1
+    duration: "02:56"
+  - title: "Too Much Pressure"
+    trackNumber: 2
+    duration: "03:32"
+  - title: "On My Radio ’91"
+    trackNumber: 3
+    duration: "03:27"
+  - title: "The Selecter"
+    trackNumber: 4
+    duration: "03:49"
+  - title: "Musical Servant (1927/1998)"
+    trackNumber: 5
+    duration: "02:46"
+  - title: "Bad Dog"
+    trackNumber: 6
+    duration: "03:39"
+  - title: "Madness (Tuff mix)"
+    trackNumber: 7
+    duration: "02:57"
+  - title: "Out on the Streets (live)"
+    trackNumber: 8
+    duration: "04:06"
+  - title: "Times Hard (live)"
+    trackNumber: 9
+    duration: "02:35"
+  - title: "I Want Justice (live)"
+    trackNumber: 10
+    duration: "02:41"
+  - title: "Rough Rider (live)"
+    trackNumber: 11
+    duration: "04:01"
+  - title: "James Bond (live)"
+    trackNumber: 12
+    duration: "03:06"
+  - title: "Sweet Dreams (live)"
+    trackNumber: 13
+    duration: "02:44"
+  - title: "Carry Go Bring Come (live)"
+    trackNumber: 14
+    duration: "03:56"
+  - title: "Orange Street (live)"
+    trackNumber: 15
+    duration: "03:29"
+  - title: "Celebrate the Bullet (live)"
+    trackNumber: 16
+    duration: "03:50"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/7fd1bda7-4d1d-3935-a467-16fffd2a0c83"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Too Much Pressure is a release by The Selecter released in 1999. It has been featured on 1 Sundown Sessions show. Featured tracks include Missing Words.
+
+

--- a/src/content/releases/t/the-silencers/a-letter-from-st-paul/index.md
+++ b/src/content/releases/t/the-silencers/a-letter-from-st-paul/index.md
@@ -1,0 +1,57 @@
+﻿---
+title: "A Letter from St. Paul"
+artist: "The Silencers"
+releaseDate: "1987"
+releaseType: "Album"
+genres:
+  - "alternative rock"
+  - "indie rock"
+  - "pop"
+  - "rock"
+  - "electronic"
+duration: "0:53:25"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+tracks:
+  - title: "Painted Moon"
+    trackNumber: 1
+    duration: "06:08"
+  - title: "I Can't Cry"
+    trackNumber: 2
+    duration: "05:23"
+  - title: "Bullets and Blue Eyes"
+    trackNumber: 3
+    duration: "05:07"
+  - title: "God's Gift"
+    trackNumber: 4
+    duration: "04:55"
+  - title: "I See Red"
+    trackNumber: 5
+    duration: "04:23"
+  - title: "I Ought to Know"
+    trackNumber: 6
+    duration: "04:30"
+  - title: "A Letter From St. Paul"
+    trackNumber: 7
+    duration: "04:37"
+  - title: "Blue Desire"
+    trackNumber: 8
+    duration: "04:11"
+  - title: "Possessed"
+    trackNumber: 9
+    duration: "07:32"
+  - title: "Painted Moon (full version)"
+    trackNumber: 10
+    duration: "06:37"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/94ca9c5a-9c52-39b5-af6c-d3612e0b3982"
+lastmod: "2026-06-25"
+---
+
+## About
+
+A Letter from St. Paul is a release by The Silencers released in 1987. It has been featured on 1 Sundown Sessions show. Featured tracks include Painted Moon.
+
+

--- a/src/content/releases/t/the-slow-readers-club/technofear/index.md
+++ b/src/content/releases/t/the-slow-readers-club/technofear/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Technofear"
+artist: "The Slow Readers Club"
+releaseDate: "2024"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Technofear is a release by The Slow Readers Club released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Technofear.
+
+## Tracks Featured on Sundown Sessions
+
+- Technofear
+
+

--- a/src/content/releases/t/the-slow-readers-club/the-joy-of-the-return/index.md
+++ b/src/content/releases/t/the-slow-readers-club/the-joy-of-the-return/index.md
@@ -1,0 +1,58 @@
+﻿---
+title: "The Joy Of The Return"
+artist: "The Slow Readers Club"
+releaseDate: "2020-03-20"
+releaseType: "Album"
+genres:
+  - "rock"
+labels:
+  - "Modern Sky UK"
+duration: "0:35:52"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "All I Hear"
+    trackNumber: 1
+    duration: "03:23"
+  - title: "Something Missing"
+    trackNumber: 2
+    duration: "02:58"
+  - title: "Problem Child"
+    trackNumber: 3
+    duration: "02:59"
+  - title: "Jericho"
+    trackNumber: 4
+    duration: "02:59"
+  - title: "No Surprise"
+    trackNumber: 5
+    duration: "03:30"
+  - title: "Paris"
+    trackNumber: 6
+    duration: "03:13"
+  - title: "Killing Me"
+    trackNumber: 7
+    duration: "03:27"
+  - title: "All the Idols"
+    trackNumber: 8
+    duration: "03:17"
+  - title: "Every Word"
+    trackNumber: 9
+    duration: "03:48"
+  - title: "Zero Hour"
+    trackNumber: 10
+    duration: "02:47"
+  - title: "The Wait"
+    trackNumber: 11
+    duration: "03:26"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/49c1aa34-7ecf-4e10-a235-01dd0d27f9ab"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Joy Of The Return is a release by The Slow Readers Club released in 2020-03-20. It has been featured on 1 Sundown Sessions show. Featured tracks include All I Hear.
+
+

--- a/src/content/releases/t/the-southern-death-cult/the-southern-death-cult/index.md
+++ b/src/content/releases/t/the-southern-death-cult/the-southern-death-cult/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "The Southern Death Cult"
+artist: "The Southern Death Cult"
+releaseDate: "1983"
+releaseType: "Album"
+genres:
+  - "gothic rock"
+  - "punk"
+  - "rock"
+labels:
+  - "Beggars Banquet"
+duration: "0:34:31"
+featuredInShows:
+  - "6"
+  - "20"
+shows:
+  - "6"
+  - "20"
+tracks:
+  - title: "All Glory"
+    trackNumber: 1
+    duration: "04:35"
+  - title: "Fatman"
+    trackNumber: 2
+    duration: "03:48"
+  - title: "Today"
+    trackNumber: 3
+    duration: "02:46"
+  - title: "False Faces"
+    trackNumber: 4
+    duration: "03:41"
+  - title: "The Crypt"
+    trackNumber: 5
+    duration: "03:05"
+  - title: "Crow"
+    trackNumber: 6
+    duration: "01:47"
+  - title: "Faith"
+    trackNumber: 7
+    duration: "04:10"
+  - title: "Vivisection"
+    trackNumber: 8
+    duration: "03:12"
+  - title: "Apache"
+    trackNumber: 9
+    duration: "02:41"
+  - title: "Moya"
+    trackNumber: 10
+    duration: "04:43"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/61e6939f-ec19-3466-890b-c059a64a969a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Southern Death Cult is a release by The Southern Death Cult released in 1983. It has been featured on 2 Sundown Sessions shows. Featured tracks include Apache, Moya.
+
+

--- a/src/content/releases/t/the-specials/stereo-typical-as-bs-and-rarities/index.md
+++ b/src/content/releases/t/the-specials/stereo-typical-as-bs-and-rarities/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Stereo-Typical: A's, B's & Rarities"
+artist: "The Specials"
+releaseDate: "2000"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Stereo-Typical: A's, B's & Rarities is a release by The Specials released in 2000. It has been featured on 1 Sundown Sessions show. Featured tracks include Ghost Town.
+
+## Tracks Featured on Sundown Sessions
+
+- Ghost Town
+
+

--- a/src/content/releases/t/the-stooges/the-stooges/index.md
+++ b/src/content/releases/t/the-stooges/the-stooges/index.md
@@ -1,0 +1,53 @@
+﻿---
+title: "The Stooges"
+artist: "The Stooges"
+releaseDate: "1969-08-05"
+releaseType: "Album"
+genres:
+  - "garage rock"
+  - "rock"
+  - "classic punk"
+  - "proto-punk"
+  - "alternative and punk"
+labels:
+  - "Elektra"
+duration: "0:34:22"
+featuredInShows:
+  - "11"
+shows:
+  - "11"
+tracks:
+  - title: "1969"
+    trackNumber: 1
+    duration: "04:05"
+  - title: "I Wanna Be Your Dog"
+    trackNumber: 2
+    duration: "03:10"
+  - title: "We Will Fall"
+    trackNumber: 3
+    duration: "10:13"
+  - title: "No Fun"
+    trackNumber: 4
+    duration: "05:15"
+  - title: "Real Cool Time"
+    trackNumber: 5
+    duration: "02:29"
+  - title: "Ann"
+    trackNumber: 6
+    duration: "03:00"
+  - title: "Not Right"
+    trackNumber: 7
+    duration: "02:49"
+  - title: "Little Doll"
+    trackNumber: 8
+    duration: "03:21"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/18037a41-2695-3a8f-a732-f6653a7f125b"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Stooges is a release by The Stooges released in 1969-08-05. It has been featured on 1 Sundown Sessions show. Featured tracks include 1969.
+
+

--- a/src/content/releases/t/the-stranglers/no-more-heroes/index.md
+++ b/src/content/releases/t/the-stranglers/no-more-heroes/index.md
@@ -1,0 +1,70 @@
+﻿---
+title: "No More Heroes"
+artist: "The Stranglers"
+releaseDate: "2007"
+releaseType: "Album"
+genres:
+  - "punk"
+  - "new wave"
+  - "rock"
+  - "alternative rock"
+labels:
+  - "Weton Exclusive"
+duration: "0:51:35"
+featuredInShows:
+  - "10"
+shows:
+  - "10"
+tracks:
+  - title: "No More Heroes"
+    trackNumber: 1
+    duration: "03:40"
+  - title: "Summer in the City"
+    trackNumber: 2
+    duration: "03:28"
+  - title: "Coup de grace"
+    trackNumber: 3
+    duration: "03:24"
+  - title: "Miss You"
+    trackNumber: 4
+    duration: "05:06"
+  - title: "Golden Brown"
+    trackNumber: 5
+    duration: "04:15"
+  - title: "In Heaven She Walks"
+    trackNumber: 6
+    duration: "03:50"
+  - title: "In a While"
+    trackNumber: 7
+    duration: "03:18"
+  - title: "Always the Sun"
+    trackNumber: 8
+    duration: "04:03"
+  - title: "Strange Little Girl"
+    trackNumber: 9
+    duration: "02:45"
+  - title: "Blue Sky"
+    trackNumber: 10
+    duration: "03:42"
+  - title: "Joy de Vita"
+    trackNumber: 11
+    duration: "03:39"
+  - title: "European Female"
+    trackNumber: 12
+    duration: "03:36"
+  - title: "5 Minutes"
+    trackNumber: 13
+    duration: "03:38"
+  - title: "All Day and All of the Night"
+    trackNumber: 14
+    duration: "03:11"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/873a1ca4-9820-4d13-9a27-4f6328e4c1d0"
+lastmod: "2026-06-25"
+---
+
+## About
+
+No More Heroes is a release by The Stranglers released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include No More Heroes.
+
+

--- a/src/content/releases/t/the-the/infected/index.md
+++ b/src/content/releases/t/the-the/infected/index.md
@@ -1,0 +1,53 @@
+﻿---
+title: "Infected"
+artist: "The The"
+releaseDate: "1986-11-17"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "alternative rock"
+  - "rock"
+  - "political"
+  - "post-punk"
+labels:
+  - "Epic"
+duration: "0:41:07"
+featuredInShows:
+  - "13"
+shows:
+  - "13"
+tracks:
+  - title: "Infected"
+    trackNumber: 1
+    duration: "04:48"
+  - title: "Out of the Blue (Into the Fire)"
+    trackNumber: 2
+    duration: "05:12"
+  - title: "Heartland"
+    trackNumber: 3
+    duration: "05:07"
+  - title: "Angels of Deception"
+    trackNumber: 4
+    duration: "04:36"
+  - title: "Sweet Bird of Truth"
+    trackNumber: 5
+    duration: "05:22"
+  - title: "Slow Train to Dawn"
+    trackNumber: 6
+    duration: "04:15"
+  - title: "Twilight of a Champion"
+    trackNumber: 7
+    duration: "04:21"
+  - title: "The Mercy Beat"
+    trackNumber: 8
+    duration: "07:23"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/1eb45345-2fee-3be5-8b0a-5b91238de4f4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Infected is a release by The The released in 1986-11-17. It has been featured on 1 Sundown Sessions show. Featured tracks include Infected.
+
+

--- a/src/content/releases/t/the-tony-hatch-orchestra/avengers-and-other-top-sixties-themes/index.md
+++ b/src/content/releases/t/the-tony-hatch-orchestra/avengers-and-other-top-sixties-themes/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Avengers and Other Top Sixties Themes"
+artist: "The Tony Hatch Orchestra"
+releaseDate: "1998"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Avengers and Other Top Sixties Themes is a release by The Tony Hatch Orchestra released in 1998. It has been featured on 1 Sundown Sessions show. Featured tracks include Theme from Crossroads.
+
+## Tracks Featured on Sundown Sessions
+
+- Theme from Crossroads
+
+

--- a/src/content/releases/t/the-vapors/new-clear-days/index.md
+++ b/src/content/releases/t/the-vapors/new-clear-days/index.md
@@ -1,0 +1,57 @@
+﻿---
+title: "New Clear Days"
+artist: "The Vapors"
+releaseDate: "1980"
+releaseType: "Album"
+genres:
+  - "classic rock"
+  - "rock"
+  - "new wave"
+labels:
+  - "United Artists"
+duration: "0:37:06"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+tracks:
+  - title: "Turning Japanese"
+    trackNumber: 1
+    duration: "03:44"
+  - title: "Sixty Second Interval"
+    trackNumber: 2
+    duration: "03:52"
+  - title: "Waiting for the Weekend"
+    trackNumber: 3
+    duration: "03:08"
+  - title: "Spring Collection"
+    trackNumber: 4
+    duration: "02:53"
+  - title: "Letter From Hiro"
+    trackNumber: 5
+    duration: "06:23"
+  - title: "News at Ten"
+    trackNumber: 6
+    duration: "03:18"
+  - title: "Somehow"
+    trackNumber: 7
+    duration: "03:34"
+  - title: "Prisoners"
+    trackNumber: 8
+    duration: "02:52"
+  - title: "Trains"
+    trackNumber: 9
+    duration: "03:27"
+  - title: "Bunkers"
+    trackNumber: 10
+    duration: "03:55"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/17e7d7fa-e491-3cfd-9053-430b89046432"
+lastmod: "2026-06-25"
+---
+
+## About
+
+New Clear Days is a release by The Vapors released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include News At Ten.
+
+

--- a/src/content/releases/t/the-vermin-poets/poets-of-england/index.md
+++ b/src/content/releases/t/the-vermin-poets/poets-of-england/index.md
@@ -1,0 +1,46 @@
+﻿---
+title: "Poets Of England"
+artist: "The Vermin Poets"
+releaseDate: "2010"
+releaseType: "Album"
+labels:
+  - "Damaged Goods"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+tracks:
+  - title: "Spartan Dregg"
+    trackNumber: 1
+  - title: "He's Taken His Eye Off the Sparrow"
+    trackNumber: 2
+  - title: "Like Poets Often Do"
+    trackNumber: 3
+  - title: "Baby Booming Bastards"
+    trackNumber: 4
+  - title: "Grandfathery"
+    trackNumber: 5
+  - title: "She's Got Ears"
+    trackNumber: 6
+  - title: "Vermin Poets"
+    trackNumber: 7
+  - title: "Arthur Was a Gun Runner"
+    trackNumber: 8
+  - title: "Musical Pamphlet"
+    trackNumber: 9
+  - title: "Poets of England"
+    trackNumber: 10
+  - title: "A Cup of Deadly Cheer"
+    trackNumber: 11
+  - title: "The Sun Was the Beginning of the Morning"
+    trackNumber: 12
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/99cff116-a850-453c-a775-5fdc41302b8b"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Poets Of England is a release by The Vermin Poets released in 2010. It has been featured on 1 Sundown Sessions show. Featured tracks include Like Poets Often Do.
+
+

--- a/src/content/releases/t/the-vintage-explosion/havin-such-a-good-time/index.md
+++ b/src/content/releases/t/the-vintage-explosion/havin-such-a-good-time/index.md
@@ -1,0 +1,50 @@
+﻿---
+title: "Havin' Such A Good Time"
+artist: "The Vintage Explosion"
+releaseDate: "2023"
+duration: "0:29:50"
+featuredInShows:
+  - "1"
+shows:
+  - "1"
+tracks:
+  - title: "Havin' Such A Good TIme"
+    trackNumber: 1
+    duration: "02:17"
+  - title: "Tired of Runnin'"
+    trackNumber: 2
+    duration: "02:34"
+  - title: "Stupid Heart"
+    trackNumber: 3
+    duration: "02:59"
+  - title: "Take My Troubles Away"
+    trackNumber: 4
+    duration: "04:27"
+  - title: "Ain't Got Enough Money (Money Honey)"
+    trackNumber: 5
+    duration: "02:17"
+  - title: "Lay In Your Arms"
+    trackNumber: 6
+    duration: "03:22"
+  - title: "Just A Little Bit"
+    trackNumber: 7
+    duration: "02:35"
+  - title: "That Girl Is Mine"
+    trackNumber: 8
+    duration: "03:01"
+  - title: "Don't Knock Upon My Door"
+    trackNumber: 9
+    duration: "03:06"
+  - title: "Rockin' Chair"
+    trackNumber: 10
+    duration: "03:06"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/327865c0-9ed8-4b31-814e-2e5cdffb2610"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Havin' Such A Good Time is a release by The Vintage Explosion released in 2023. It has been featured on 1 Sundown Sessions show. Featured tracks include Don't Knock Upon My Door.
+
+

--- a/src/content/releases/t/the-wolfmen/needle-in-the-camels-eye/index.md
+++ b/src/content/releases/t/the-wolfmen/needle-in-the-camels-eye/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Needle In The Camels Eye"
+artist: "The Wolfmen"
+releaseDate: "2008"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Needle In The Camels Eye is a release by The Wolfmen released in 2008. It has been featured on 1 Sundown Sessions show. Featured tracks include Needle In The Camels Eye.
+
+## Tracks Featured on Sundown Sessions
+
+- Needle In The Camels Eye
+
+

--- a/src/content/releases/t/the-woodentops/1986-rough-trade/index.md
+++ b/src/content/releases/t/the-woodentops/1986-rough-trade/index.md
@@ -1,0 +1,19 @@
+﻿---
+title: "1986 (Rough Trade)"
+artist: "The Woodentops"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+lastmod: "2026-06-25"
+---
+
+## About
+
+1986 (Rough Trade) is a release by The Woodentops. It has been featured on 1 Sundown Sessions show. Featured tracks include Travelling Man.
+
+## Tracks Featured on Sundown Sessions
+
+- Travelling Man
+
+

--- a/src/content/releases/t/theatre-of-hate/omens-studio-work-1980-2020/index.md
+++ b/src/content/releases/t/theatre-of-hate/omens-studio-work-1980-2020/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Omens: Studio Work 1980-2020"
+artist: "Theatre Of Hate"
+releaseDate: "2022"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Omens: Studio Work 1980-2020 is a release by Theatre Of Hate released in 2022. It has been featured on 1 Sundown Sessions show. Featured tracks include Do You Believe In The Westworld?.
+
+## Tracks Featured on Sundown Sessions
+
+- Do You Believe In The Westworld?
+
+

--- a/src/content/releases/t/thee-headcoats/the-kids-are-all-square-this-is-hip/index.md
+++ b/src/content/releases/t/thee-headcoats/the-kids-are-all-square-this-is-hip/index.md
@@ -1,0 +1,48 @@
+﻿---
+title: "The Kids Are All Square, This Is Hip!"
+artist: "Thee Headcoats"
+releaseDate: "1990-05"
+releaseType: "Album"
+genres:
+  - "garage rock"
+  - "punk"
+  - "rock"
+labels:
+  - "Hangman Records"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "I'm a Gamekeeper"
+    trackNumber: 1
+  - title: "Davey Crockett"
+    trackNumber: 2
+  - title: "Monkey's Paw"
+    trackNumber: 3
+  - title: "Ballad of the Fogbound Pinhead"
+    trackNumber: 4
+  - title: "All My Feelings Denied"
+    trackNumber: 5
+  - title: "Cowboys Are Square"
+    trackNumber: 6
+  - title: "I Can Destroy All Your Love"
+    trackNumber: 7
+  - title: "Poccahontas Was Her Name"
+    trackNumber: 8
+  - title: "Nanook of the North"
+    trackNumber: 9
+  - title: "A Town Named Squaresville"
+    trackNumber: 10
+  - title: "Karasal"
+    trackNumber: 11
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/b17731ab-aa54-4713-a9e3-a57207413dbf"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Kids Are All Square, This Is Hip! is a release by Thee Headcoats released in 1990-05. It has been featured on 1 Sundown Sessions show. Featured tracks include All My Feelings Denied.
+
+

--- a/src/content/releases/t/toni-fisher/presenting-toni-fisher/index.md
+++ b/src/content/releases/t/toni-fisher/presenting-toni-fisher/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Presenting Toni Fisher"
+artist: "Toni Fisher"
+releaseDate: "1959"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Presenting Toni Fisher is a release by Toni Fisher released in 1959. It has been featured on 1 Sundown Sessions show. Featured tracks include The Big Hurt.
+
+## Tracks Featured on Sundown Sessions
+
+- The Big Hurt
+
+

--- a/src/content/releases/t/tubeway-army/replicas/index.md
+++ b/src/content/releases/t/tubeway-army/replicas/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "Replicas"
+artist: "Tubeway Army"
+releaseDate: "1979-04"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "synth-pop"
+  - "electro"
+  - "synthpop"
+  - "classic pop and rock"
+labels:
+  - "Atlantic"
+duration: "0:41:57"
+featuredInShows:
+  - "14"
+shows:
+  - "14"
+tracks:
+  - title: "Me! I Disconnect From You"
+    trackNumber: 1
+    duration: "03:20"
+  - title: "Are ‘Friends’ Electric?"
+    trackNumber: 2
+    duration: "05:22"
+  - title: "The Machman"
+    trackNumber: 3
+    duration: "03:07"
+  - title: "Praying to the Aliens"
+    trackNumber: 4
+    duration: "03:56"
+  - title: "Down in the Park"
+    trackNumber: 5
+    duration: "04:22"
+  - title: "You Are in My Vision"
+    trackNumber: 6
+    duration: "03:13"
+  - title: "Replicas"
+    trackNumber: 7
+    duration: "04:58"
+  - title: "It Must Have Been Years"
+    trackNumber: 8
+    duration: "04:00"
+  - title: "When the Machines Rock"
+    trackNumber: 9
+    duration: "03:12"
+  - title: "I Nearly Married a Human"
+    trackNumber: 10
+    duration: "06:27"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/c1fa1051-0993-397d-be13-2daec83eb841"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Replicas is a release by Tubeway Army released in 1979-04. It has been featured on 1 Sundown Sessions show. Featured tracks include Are 'Friends' Electric?.
+
+

--- a/src/content/releases/u/ultravox/ha-ha-ha/index.md
+++ b/src/content/releases/u/ultravox/ha-ha-ha/index.md
@@ -1,0 +1,48 @@
+﻿---
+title: "Ha! Ha! Ha!"
+artist: "Ultravox"
+releaseDate: "1977-10-14"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "post-punk"
+  - "punk"
+  - "electronic"
+  - "rock"
+labels:
+  - "Island"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "ROckwrok"
+    trackNumber: 1
+  - title: "The Frozen Ones"
+    trackNumber: 2
+  - title: "Fear in the Western World"
+    trackNumber: 3
+  - title: "Distant Smile"
+    trackNumber: 4
+  - title: "The Man Who Dies Everyday"
+    trackNumber: 5
+  - title: "Artificial Life"
+    trackNumber: 6
+  - title: "While I’m Still Alive"
+    trackNumber: 7
+  - title: "Hiroshima Mon Amour"
+    trackNumber: 8
+  - title: "Quirks"
+    trackNumber: 1
+  - title: "Modern Love"
+    trackNumber: 2
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/be67ce51-1e0e-35da-9f55-9d13fdc262bc"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Ha! Ha! Ha! is a release by Ultravox released in 1977-10-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Young Savage.
+
+

--- a/src/content/releases/u/ultravox/the-collection/index.md
+++ b/src/content/releases/u/ultravox/the-collection/index.md
@@ -1,0 +1,71 @@
+﻿---
+title: "The Collection"
+artist: "Ultravox"
+releaseDate: "1984-11-02"
+releaseType: "Album"
+genres:
+  - "synth-pop"
+  - "rock"
+  - "offizielle charts"
+  - "5+ wochen"
+  - "laut.de"
+labels:
+  - "Chrysalis"
+duration: "0:56:55"
+featuredInShows:
+  - "9"
+shows:
+  - "9"
+tracks:
+  - title: "Dancing With Tears in My Eyes"
+    trackNumber: 1
+    duration: "04:11"
+  - title: "Hymn"
+    trackNumber: 2
+    duration: "04:27"
+  - title: "The Thin Wall"
+    trackNumber: 3
+    duration: "04:26"
+  - title: "The Voice"
+    trackNumber: 4
+    duration: "04:24"
+  - title: "Vienna"
+    trackNumber: 5
+    duration: "04:38"
+  - title: "Passing Strangers"
+    trackNumber: 6
+    duration: "03:51"
+  - title: "Sleepwalk"
+    trackNumber: 7
+    duration: "03:12"
+  - title: "Reap the Wild Wind"
+    trackNumber: 8
+    duration: "03:42"
+  - title: "All Stood Still"
+    trackNumber: 9
+    duration: "03:43"
+  - title: "Visions in Blue"
+    trackNumber: 10
+    duration: "04:15"
+  - title: "We Came to Dance"
+    trackNumber: 11
+    duration: "04:06"
+  - title: "One Small Day"
+    trackNumber: 12
+    duration: "04:29"
+  - title: "Love’s Great Adventure"
+    trackNumber: 13
+    duration: "03:07"
+  - title: "Lament"
+    trackNumber: 14
+    duration: "04:19"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/242ce7d4-2aea-3d6b-a490-064303dcc131"
+lastmod: "2026-06-25"
+---
+
+## About
+
+The Collection is a release by Ultravox released in 1984-11-02. It has been featured on 1 Sundown Sessions show. Featured tracks include All Stood Still.
+
+

--- a/src/content/releases/u/ultravox/vienna/index.md
+++ b/src/content/releases/u/ultravox/vienna/index.md
@@ -1,0 +1,35 @@
+﻿---
+title: "Vienna"
+artist: "Ultravox"
+releaseDate: "1981-01-15"
+releaseType: "Single"
+genres:
+  - "synth-pop"
+  - "new romantic"
+  - "art pop"
+  - "electronic"
+  - "synthpop"
+labels:
+  - "Chrysalis"
+duration: "0:08:58"
+featuredInShows:
+  - "7"
+shows:
+  - "7"
+tracks:
+  - title: "Vienna"
+    trackNumber: 1
+    duration: "04:38"
+  - title: "Passionate Reply"
+    trackNumber: 2
+    duration: "04:20"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/cd130148-b956-4bde-af35-f7c616263880"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Vienna is a release by Ultravox released in 1981-01-15. It has been featured on 1 Sundown Sessions show. Featured tracks include Astradyne.
+
+

--- a/src/content/releases/u/uriah-heep/very-eavy-very-umble/index.md
+++ b/src/content/releases/u/uriah-heep/very-eavy-very-umble/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Very 'Eavy, Very 'Umble"
+artist: "Uriah Heep"
+releaseDate: "1970"
+featuredInShows:
+  - "12"
+shows:
+  - "12"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Very 'Eavy, Very 'Umble is a release by Uriah Heep released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Gypsy.
+
+## Tracks Featured on Sundown Sessions
+
+- Gypsy
+
+

--- a/src/content/releases/v/van-halen/5150/index.md
+++ b/src/content/releases/v/van-halen/5150/index.md
@@ -1,0 +1,33 @@
+﻿---
+title: "5150"
+artist: "Van Halen"
+releaseDate: "1986-09-03"
+releaseType: "Single"
+genres:
+  - "glam"
+  - "heavy metal"
+  - "rock"
+labels:
+  - "Warner Bros. Records"
+duration: "0:11:28"
+featuredInShows:
+  - "46"
+shows:
+  - "46"
+tracks:
+  - title: "“5150”"
+    trackNumber: 1
+    duration: "05:44"
+  - title: "“5150”"
+    trackNumber: 2
+    duration: "05:44"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/4f2ad93b-092d-45ba-a8a2-8e05cc9b81ce"
+lastmod: "2026-06-25"
+---
+
+## About
+
+5150 is a release by Van Halen released in 1986-09-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Why Can't This Be Love.
+
+

--- a/src/content/releases/v/viagra-boys/cave-world/index.md
+++ b/src/content/releases/v/viagra-boys/cave-world/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "Cave World"
+artist: "Viagra Boys"
+releaseDate: "2022-07-08"
+releaseType: "Album"
+genres:
+  - "dance-punk"
+  - "post-punk"
+  - "covid-19"
+  - "offizielle charts"
+  - "ph_2_stars"
+labels:
+  - "YEAR0001"
+duration: "0:40:22"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+tracks:
+  - title: "Baby Criminal"
+    trackNumber: 1
+    duration: "04:39"
+  - title: "Cave Hole"
+    trackNumber: 2
+    duration: "00:39"
+  - title: "Troglodyte"
+    trackNumber: 3
+    duration: "03:19"
+  - title: "Punk Rock Loser"
+    trackNumber: 4
+    duration: "03:57"
+  - title: "Creepy Crawlers"
+    trackNumber: 5
+    duration: "03:09"
+  - title: "The Cognitive Trade-Off Hypothesis"
+    trackNumber: 6
+    duration: "03:55"
+  - title: "Globe Earth"
+    trackNumber: 7
+    duration: "00:41"
+  - title: "Ain’t No Thief"
+    trackNumber: 8
+    duration: "03:59"
+  - title: "Big Boy"
+    trackNumber: 9
+    duration: "05:30"
+  - title: "ADD"
+    trackNumber: 10
+    duration: "03:37"
+  - title: "Human Error"
+    trackNumber: 11
+    duration: "00:29"
+  - title: "Return to Monke"
+    trackNumber: 12
+    duration: "06:28"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/bed07eb0-f5b6-4e42-b6b8-c2416b86cbfc"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Cave World is a release by Viagra Boys released in 2022-07-08. It has been featured on 1 Sundown Sessions show. Featured tracks include Troglodyte.
+
+

--- a/src/content/releases/v/villagers/that-golden-time/index.md
+++ b/src/content/releases/v/villagers/that-golden-time/index.md
@@ -1,0 +1,53 @@
+﻿---
+title: "That Golden Time"
+artist: "Villagers"
+releaseDate: "2024-05-10"
+releaseType: "Album"
+labels:
+  - "Domino"
+duration: "0:44:00"
+featuredInShows:
+  - "19"
+shows:
+  - "19"
+tracks:
+  - title: "Truly Alone"
+    trackNumber: 1
+    duration: "03:36"
+  - title: "First Responder"
+    trackNumber: 2
+    duration: "04:39"
+  - title: "I Want What I Don’t Need"
+    trackNumber: 3
+    duration: "03:35"
+  - title: "You Lucky One"
+    trackNumber: 4
+    duration: "04:54"
+  - title: "That Golden Time"
+    trackNumber: 5
+    duration: "04:50"
+  - title: "Keepsake"
+    trackNumber: 6
+    duration: "04:11"
+  - title: "Brother Hen"
+    trackNumber: 7
+    duration: "03:41"
+  - title: "No Drama"
+    trackNumber: 8
+    duration: "04:31"
+  - title: "Behind That Curtain"
+    trackNumber: 9
+    duration: "06:03"
+  - title: "Money on the Mind"
+    trackNumber: 10
+    duration: "03:54"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/1a699eb2-8911-460e-a28f-466853458a48"
+lastmod: "2026-06-25"
+---
+
+## About
+
+That Golden Time is a release by Villagers released in 2024-05-10. It has been featured on 1 Sundown Sessions show. Featured tracks include That Golden Time.
+
+

--- a/src/content/releases/v/virgin-prunes/if-i-die-i-die-2004-remaster/index.md
+++ b/src/content/releases/v/virgin-prunes/if-i-die-i-die-2004-remaster/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "...If I Die, I Die (2004 Remaster)"
+artist: "Virgin Prunes"
+releaseDate: "1982"
+featuredInShows:
+  - "20"
+shows:
+  - "20"
+lastmod: "2026-06-25"
+---
+
+## About
+
+...If I Die, I Die (2004 Remaster) is a release by Virgin Prunes released in 1982. It has been featured on 1 Sundown Sessions show. Featured tracks include Caucasian Walk - 2004 Remaster.
+
+## Tracks Featured on Sundown Sessions
+
+- Caucasian Walk - 2004 Remaster
+
+

--- a/src/content/releases/w/westlife/greatest-hits/index.md
+++ b/src/content/releases/w/westlife/greatest-hits/index.md
@@ -1,0 +1,235 @@
+﻿---
+title: "Greatest Hits"
+artist: "Westlife"
+releaseDate: "2011-11-18"
+releaseType: "Album"
+genres:
+  - "ballad"
+  - "pop"
+  - "europop"
+  - "adult contemporary"
+labels:
+  - "RCA"
+  - "Sony Music"
+duration: "4:06:10"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+tracks:
+  - title: "Swear It Again"
+    trackNumber: 1
+    duration: "04:07"
+  - title: "If I Let You Go"
+    trackNumber: 2
+    duration: "03:41"
+  - title: "Flying Without Wings"
+    trackNumber: 3
+    duration: "03:34"
+  - title: "I Have a Dream"
+    trackNumber: 4
+    duration: "04:13"
+  - title: "Against All Odds"
+    trackNumber: 5
+    duration: "03:19"
+  - title: "My Love"
+    trackNumber: 6
+    duration: "03:50"
+  - title: "Uptown Girl"
+    trackNumber: 7
+    duration: "03:04"
+  - title: "Queen of My Heart"
+    trackNumber: 8
+    duration: "04:17"
+  - title: "World of Our Own"
+    trackNumber: 9
+    duration: "03:28"
+  - title: "Mandy"
+    trackNumber: 10
+    duration: "03:16"
+  - title: "You Raise Me Up"
+    trackNumber: 11
+    duration: "03:59"
+  - title: "Home"
+    trackNumber: 12
+    duration: "03:24"
+  - title: "What About Now"
+    trackNumber: 13
+    duration: "03:59"
+  - title: "Safe"
+    trackNumber: 14
+    duration: "03:51"
+  - title: "Lighthouse"
+    trackNumber: 15
+    duration: "04:22"
+  - title: "Beautiful World"
+    trackNumber: 16
+    duration: "04:02"
+  - title: "Wide Open"
+    trackNumber: 17
+    duration: "03:41"
+  - title: "Last Mile of the Way"
+    trackNumber: 18
+    duration: "03:49"
+  - title: "Seasons in the Sun"
+    trackNumber: 1
+    duration: "04:06"
+  - title: "Fool Again"
+    trackNumber: 2
+    duration: "03:53"
+  - title: "What Makes a Man"
+    trackNumber: 3
+    duration: "03:52"
+  - title: "When You’re Looking Like That"
+    trackNumber: 4
+    duration: "03:52"
+  - title: "Bop Bop Baby"
+    trackNumber: 5
+    duration: "04:27"
+  - title: "Unbreakable"
+    trackNumber: 6
+    duration: "04:32"
+  - title: "Hey Whatever"
+    trackNumber: 7
+    duration: "03:26"
+  - title: "Obvious"
+    trackNumber: 8
+    duration: "03:28"
+  - title: "When You Tell Me That You Love Me"
+    trackNumber: 9
+    duration: "03:54"
+  - title: "Amazing"
+    trackNumber: 10
+    duration: "02:48"
+  - title: "The Rose"
+    trackNumber: 11
+    duration: "03:38"
+  - title: "Us Against the World"
+    trackNumber: 12
+    duration: "03:58"
+  - title: "What About Now (live at the O2)"
+    trackNumber: 13
+    duration: "04:15"
+  - title: "Uptown Girl (live at the O2)"
+    trackNumber: 14
+    duration: "03:58"
+  - title: "Mandy (live at the O2)"
+    trackNumber: 15
+    duration: "03:49"
+  - title: "Home (live at the O2)"
+    trackNumber: 16
+    duration: "03:40"
+  - title: "Flying Without Wings (live at Proms in the Park 2011)"
+    trackNumber: 17
+    duration: "04:28"
+  - title: "You Raise Me Up (live at Proms in the Park 2011)"
+    trackNumber: 18
+    duration: "04:51"
+  - title: "Sweat It Again"
+    trackNumber: 1
+    duration: "04:06"
+  - title: "If I Let You Go"
+    trackNumber: 2
+    duration: "03:38"
+  - title: "Flying Without Wings"
+    trackNumber: 3
+    duration: "03:46"
+  - title: "I Have a Dream"
+    trackNumber: 4
+  - title: "Seasons in the Sun"
+    trackNumber: 5
+    duration: "04:01"
+  - title: "Fool Again"
+    trackNumber: 6
+    duration: "04:16"
+  - title: "Against All Odds"
+    trackNumber: 7
+  - title: "My Love"
+    trackNumber: 8
+    duration: "04:14"
+  - title: "What Makes a Man"
+    trackNumber: 9
+  - title: "I Lay My Love on You"
+    trackNumber: 10
+    duration: "03:28"
+  - title: "Uptown Girl"
+    trackNumber: 11
+    duration: "04:11"
+  - title: "When You’re Looking Like That"
+    trackNumber: 12
+    duration: "04:00"
+  - title: "Queen of My Heart"
+    trackNumber: 13
+    duration: "04:27"
+  - title: "World of Our Own"
+    trackNumber: 14
+  - title: "Bop Bop Baby"
+    trackNumber: 15
+    duration: "04:58"
+  - title: "Unbreakable"
+    trackNumber: 16
+    duration: "04:33"
+  - title: "Tonight"
+    trackNumber: 17
+    duration: "04:31"
+  - title: "Miss You Nights"
+    trackNumber: 18
+    duration: "03:12"
+  - title: "Hey Whatever"
+    trackNumber: 19
+    duration: "03:35"
+  - title: "Mandy"
+    trackNumber: 20
+    duration: "03:17"
+  - title: "Obvious"
+    trackNumber: 21
+    duration: "03:28"
+  - title: "Ain’t That a Kick in the Head"
+    trackNumber: 22
+    duration: "02:26"
+  - title: "Smile"
+    trackNumber: 23
+    duration: "02:48"
+  - title: "Angel"
+    trackNumber: 24
+    duration: "04:22"
+  - title: "You Raise Me Up"
+    trackNumber: 25
+  - title: "When You Tell Me That You Love Me"
+    trackNumber: 26
+    duration: "04:00"
+  - title: "Amazing"
+    trackNumber: 27
+  - title: "The Rose"
+    trackNumber: 28
+    duration: "03:32"
+  - title: "Home"
+    trackNumber: 29
+    duration: "03:29"
+  - title: "Us Against the World"
+    trackNumber: 30
+    duration: "03:56"
+  - title: "Something Right"
+    trackNumber: 31
+    duration: "03:14"
+  - title: "What About Now"
+    trackNumber: 32
+    duration: "04:09"
+  - title: "Safe"
+    trackNumber: 33
+    duration: "03:50"
+  - title: "Swear It Again (US version)"
+    trackNumber: 34
+  - title: "World of Our Own (US version)"
+    trackNumber: 35
+    duration: "03:34"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/7f7ef0e7-135a-4546-8f22-3281cfe1796c"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Greatest Hits is a release by Westlife released in 2011-11-18. It has been featured on 1 Sundown Sessions show. Featured tracks include Unbreakable.
+
+

--- a/src/content/releases/w/white-lies/as-i-try-not-to-fall-apart/index.md
+++ b/src/content/releases/w/white-lies/as-i-try-not-to-fall-apart/index.md
@@ -1,0 +1,59 @@
+﻿---
+title: "As I Try Not To Fall Apart"
+artist: "White Lies"
+releaseDate: "2022-02-18"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "offizielle charts"
+  - "laut.de"
+  - "ph_temp_checken"
+  - "1â4 wochen"
+labels:
+  - "[PIAS] Recordings"
+duration: "0:47:30"
+featuredInShows:
+  - "6"
+shows:
+  - "6"
+tracks:
+  - title: "Am I Really Going to Die"
+    trackNumber: 1
+    duration: "04:48"
+  - title: "As I Try Not to Fall Apart"
+    trackNumber: 2
+    duration: "04:58"
+  - title: "Breathe"
+    trackNumber: 3
+    duration: "04:46"
+  - title: "I Don’t Want to Go to Mars"
+    trackNumber: 4
+    duration: "04:38"
+  - title: "Step Outside"
+    trackNumber: 5
+    duration: "04:05"
+  - title: "Roll December"
+    trackNumber: 6
+    duration: "06:44"
+  - title: "Ragworm"
+    trackNumber: 7
+    duration: "04:32"
+  - title: "Blue Drift"
+    trackNumber: 8
+    duration: "05:00"
+  - title: "The End"
+    trackNumber: 9
+    duration: "03:54"
+  - title: "There Is No Cure for It"
+    trackNumber: 10
+    duration: "04:05"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/6a175121-dee8-4ce8-a386-b304b57bf678"
+lastmod: "2026-06-25"
+---
+
+## About
+
+As I Try Not To Fall Apart is a release by White Lies released in 2022-02-18. It has been featured on 1 Sundown Sessions show. Featured tracks include I Don't Want To Go To Mars.
+
+

--- a/src/content/releases/w/white-lies/there-goes-our-love-again-remixes/index.md
+++ b/src/content/releases/w/white-lies/there-goes-our-love-again-remixes/index.md
@@ -1,0 +1,41 @@
+﻿---
+title: "There Goes Our Love Again (Remixes)"
+artist: "White Lies"
+releaseDate: "2013-06-20"
+releaseType: "EP"
+genres:
+  - "house"
+  - "electro"
+  - "indie rock"
+  - "alternative rock"
+  - "rock"
+labels:
+  - "[PIAS] Recordings Catalogue"
+duration: "0:20:22"
+featuredInShows:
+  - "5"
+shows:
+  - "5"
+tracks:
+  - title: "There Goes Our Love Again (GOOSE version)"
+    trackNumber: 1
+    duration: "05:11"
+  - title: "There Goes Our Love Again (Hostage remix)"
+    trackNumber: 2
+    duration: "04:42"
+  - title: "There Goes Our Love Again (TORN remix)"
+    trackNumber: 3
+    duration: "04:58"
+  - title: "There Goes Our Love Again (Night Engine remix)"
+    trackNumber: 4
+    duration: "05:30"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/8af6d433-d89d-474b-bde9-ef5dd46e4709"
+lastmod: "2026-06-25"
+---
+
+## About
+
+There Goes Our Love Again (Remixes) is a release by White Lies released in 2013-06-20. It has been featured on 1 Sundown Sessions show. Featured tracks include There Goes Our Love Again.
+
+

--- a/src/content/releases/w/willie-nelson/born-for-trouble/index.md
+++ b/src/content/releases/w/willie-nelson/born-for-trouble/index.md
@@ -1,0 +1,58 @@
+﻿---
+title: "Born for Trouble"
+artist: "Willie Nelson"
+releaseDate: "1990"
+releaseType: "Album"
+genres:
+  - "country"
+  - "progressive country"
+  - "traditional country"
+labels:
+  - "CBS"
+  - "Columbia"
+duration: "0:32:43"
+featuredInShows:
+  - "8"
+shows:
+  - "8"
+tracks:
+  - title: "Ain't Necessarily So"
+    trackNumber: 1
+    duration: "03:06"
+  - title: "(I Don't Have a Reason) To Go to California Anymore"
+    trackNumber: 2
+    duration: "03:10"
+  - title: "Ten With a Two"
+    trackNumber: 3
+    duration: "02:40"
+  - title: "The Piper Came Today"
+    trackNumber: 4
+    duration: "03:26"
+  - title: "You Decide"
+    trackNumber: 5
+    duration: "03:51"
+  - title: "Pieces of My Life"
+    trackNumber: 6
+    duration: "03:34"
+  - title: "It'll Come to Me"
+    trackNumber: 7
+    duration: "02:59"
+  - title: "This Is How Without You Goes"
+    trackNumber: 8
+    duration: "03:05"
+  - title: "Born for Trouble"
+    trackNumber: 9
+    duration: "03:17"
+  - title: "Little Things Mean a Lot"
+    trackNumber: 10
+    duration: "03:32"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/d6d0450d-f28f-3df5-9f00-5f4606f5e93a"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Born for Trouble is a release by Willie Nelson released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include Ten with a Two.
+
+

--- a/src/content/releases/w/win/uh-tears-baby/index.md
+++ b/src/content/releases/w/win/uh-tears-baby/index.md
@@ -1,0 +1,20 @@
+﻿---
+title: "Uh... Tears Baby"
+artist: "Win"
+releaseDate: "1985"
+featuredInShows:
+  - "4"
+shows:
+  - "4"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Uh... Tears Baby is a release by Win released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include You've Got the Power.
+
+## Tracks Featured on Sundown Sessions
+
+- You've Got the Power
+
+

--- a/src/content/releases/w/wings/venus-and-mars/index.md
+++ b/src/content/releases/w/wings/venus-and-mars/index.md
@@ -1,0 +1,63 @@
+﻿---
+title: "Venus And Mars"
+artist: "Wings"
+releaseDate: "1975-05-30"
+releaseType: "Album"
+genres:
+  - "rock"
+  - "pop rock"
+  - "soft rock"
+  - "offizielle charts"
+  - "5+ wochen"
+duration: "0:41:56"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Venus And Mars"
+    trackNumber: 1
+    duration: "01:18"
+  - title: "Rock Show"
+    trackNumber: 2
+    duration: "05:32"
+  - title: "Love In Song"
+    trackNumber: 3
+    duration: "03:03"
+  - title: "You Gave Me The Answer"
+    trackNumber: 4
+    duration: "02:14"
+  - title: "Magneto And Titanium Man"
+    trackNumber: 5
+    duration: "03:16"
+  - title: "Letting Go"
+    trackNumber: 6
+    duration: "04:32"
+  - title: "Venus And Mars-Reprise"
+    trackNumber: 7
+    duration: "02:05"
+  - title: "Spirits Of Ancient Egypt"
+    trackNumber: 8
+    duration: "02:58"
+  - title: "Medicine Jar"
+    trackNumber: 9
+    duration: "03:37"
+  - title: "Call Me Back Again"
+    trackNumber: 10
+    duration: "04:58"
+  - title: "Listen To What The Man Said"
+    trackNumber: 11
+    duration: "04:00"
+  - title: "Treat Her Gently-Lonely Old People"
+    trackNumber: 12
+    duration: "04:23"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/0dd4d0ee-1a30-3d65-b11d-bb9d4e305ffa"
+lastmod: "2026-06-25"
+---
+
+## About
+
+Venus And Mars is a release by Wings released in 1975-05-30. It has been featured on 1 Sundown Sessions show. Featured tracks include Crossroads.
+
+

--- a/src/content/releases/x/xtc/white-music/index.md
+++ b/src/content/releases/x/xtc/white-music/index.md
@@ -1,0 +1,65 @@
+﻿---
+title: "White Music"
+artist: "XTC"
+releaseDate: "1978-01-20"
+releaseType: "Album"
+genres:
+  - "new wave"
+  - "rock"
+  - "post-punk"
+  - "zolo"
+  - "humorous"
+labels:
+  - "Virgin"
+duration: "0:36:07"
+featuredInShows:
+  - "15"
+shows:
+  - "15"
+tracks:
+  - title: "Radios in Motion"
+    trackNumber: 1
+    duration: "02:54"
+  - title: "Cross Wires"
+    trackNumber: 2
+    duration: "02:05"
+  - title: "This Is Pop"
+    trackNumber: 3
+    duration: "02:41"
+  - title: "Do What You Do"
+    trackNumber: 4
+    duration: "01:16"
+  - title: "Statue of Liberty"
+    trackNumber: 5
+    duration: "02:54"
+  - title: "All Along the Watchtower"
+    trackNumber: 6
+    duration: "05:42"
+  - title: "Into the Atom Age"
+    trackNumber: 7
+    duration: "02:33"
+  - title: "I’ll Set Myself on Fire"
+    trackNumber: 8
+    duration: "03:02"
+  - title: "I’m Bugged"
+    trackNumber: 9
+    duration: "03:59"
+  - title: "New Town Animal in a Furnished Cage"
+    trackNumber: 10
+    duration: "01:53"
+  - title: "Spinning Top"
+    trackNumber: 11
+    duration: "02:40"
+  - title: "Neon Shuffle"
+    trackNumber: 12
+    duration: "04:28"
+links:
+  MusicBrainz: "https://musicbrainz.org/release-group/576e4598-dfdd-3888-bc7c-6ab01aa28a06"
+lastmod: "2026-06-25"
+---
+
+## About
+
+White Music is a release by XTC released in 1978-01-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Statue Of Liberty.
+
+


### PR DESCRIPTION
## Summary
- add an idempotent PowerShell generator for missing release pages from show metadata
- generate 249 release pages under `src/content/releases`
- add a report covering scanned shows, generated pages, duplicates, and manual-review metadata gaps

## Verification
- `powershell -ExecutionPolicy Bypass -File scripts\generate-missing-release-pages.ps1 -WhatIf`
- Final dry run reported `Release pages created: 0`
- Hugo build not run locally because `hugo` is not installed in this environment

## Notes
- 176 generated pages include MusicBrainz metadata.
- 73 generated pages are local-metadata only and are listed for manual review in `reports/missing-release-pages-report.md`.