### PR TITLE
feat(contentops): add playlist content enrichment

### DIFF
--- a/.github/workflows/content-enrichment.yml
+++ b/.github/workflows/content-enrichment.yml
@@ -1,0 +1,113 @@
+name: Content Enrichment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - src/content/shows/**/playlist.md
+      - src/content/shows/**/track-info.md
+  workflow_dispatch:
+    inputs:
+      changed_paths:
+        description: Optional comma-separated show playlist or track-info paths to enrich. Leave blank to scan all shows.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  DOTNET_DIR: automation/dotnet
+  HUGO_VERSION: 0.146.5
+  REPORT_PATH: reports/content-enrichment-report.md
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source using v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup .NET using v4.3.1
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: ${{ env.DOTNET_DIR }}/global.json
+
+      - name: Detect changed show files
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed_paths=${{ inputs.changed_paths }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          before="${{ github.event.before }}"
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            before="$(git rev-list --max-parents=0 HEAD)"
+          fi
+
+          changed_paths="$(git diff --name-only "$before" "${{ github.sha }}" -- \
+            'src/content/shows/**/playlist.md' \
+            'src/content/shows/**/track-info.md' | paste -sd, -)"
+          echo "changed_paths=$changed_paths" >> "$GITHUB_OUTPUT"
+
+      - name: Restore ContentOps
+        run: dotnet restore SundownMedia.ContentOps.sln
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Run content enrichment
+        run: >
+          dotnet run --project src/SundownMedia.ContentOps.Cli/SundownMedia.ContentOps.Cli.csproj --
+          content enrich
+          --site-root ../../src
+          --report-path ../../${{ env.REPORT_PATH }}
+          --changed-paths "${{ steps.changes.outputs.changed_paths }}"
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Test ContentOps
+        run: dotnet test SundownMedia.ContentOps.sln --configuration Release --no-restore
+        working-directory: ${{ env.DOTNET_DIR }}
+
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Validate Hugo content
+        run: |
+          hugo \
+            --source src \
+            --printPathWarnings \
+            --panicOnWarning \
+            --environment production \
+            --baseURL https://example.invalid/
+
+      - name: Check generated changes
+        id: generated
+        shell: bash
+        run: |
+          if git diff --quiet -- src/content; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update editorial review PR using v6.1.0
+        if: steps.generated.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+        with:
+          branch: automation/content-enrichment
+          delete-branch: true
+          title: "feat(content): enrich playlist-derived pages"
+          commit-message: "feat(content): enrich playlist-derived pages"
+          body-path: ${{ env.REPORT_PATH }}
+          labels: automated,content-enrichment
+          add-paths: |
+            src/content
+            reports/content-enrichment-report.md

--- a/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/ContentEnrichmentGenerator.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/ContentEnrichmentGenerator.cs
@@ -1,0 +1,1035 @@
+// <copyright file="ContentEnrichmentGenerator.cs" company="SundownMedia">
+// Copyright (c) SundownMedia. All rights reserved.
+// </copyright>
+
+namespace SundownMedia.ContentOps.Application.Features.ContentEnrichment
+{
+    using System.Globalization;
+    using System.Text;
+    using System.Text.RegularExpressions;
+
+    public static partial class ContentEnrichmentGenerator
+    {
+        private const string IndexFileName = "index.md";
+
+        public static EnrichContentResult Enrich(EnrichContentCommand command)
+        {
+            var siteRoot = Path.GetFullPath(command.SiteRoot);
+            var contentRoot = Path.Combine(siteRoot, "content");
+            var showsRoot = Path.Combine(contentRoot, "shows");
+            var reportPath = Path.GetFullPath(command.ReportPath);
+
+            var showDirectories = GetShowDirectories(showsRoot, command.ChangedPaths).ToList();
+            var existing = ExistingContentIndex.Build(contentRoot);
+            var parsed = PlaylistParser.Parse(showDirectories);
+            var report = new EnrichmentReport();
+
+            var candidates = BuildCandidates(parsed.Entries);
+
+            foreach (var candidate in candidates)
+            {
+                CreateArtistPage(contentRoot, existing, candidate, report);
+                CreateTrackPage(contentRoot, existing, candidate, report);
+            }
+
+            foreach (var release in BuildReleaseCandidates(candidates))
+            {
+                CreateReleasePage(contentRoot, existing, release, report);
+            }
+
+            report.Write(reportPath, showDirectories.Count, parsed.PlaylistEntriesParsed, parsed.TrackInfoEntriesParsed);
+
+            return new EnrichContentResult(
+                reportPath,
+                showDirectories.Count,
+                parsed.PlaylistEntriesParsed,
+                parsed.TrackInfoEntriesParsed,
+                report.CreatedArtists.Count,
+                report.CreatedReleases.Count,
+                report.CreatedTracks.Count,
+                report.SkippedArtists.Count,
+                report.SkippedReleases.Count,
+                report.SkippedTracks.Count,
+                report.Ambiguous.Count,
+                command.CorrelationId);
+        }
+
+        public static string NormalizeKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var normalized = value.Normalize(NormalizationForm.FormKD).ToLowerInvariant();
+            normalized = normalized.Replace("&", " and ", StringComparison.Ordinal);
+            normalized = ApostropheRegex().Replace(normalized, string.Empty);
+            normalized = NonAlphaNumericRegex().Replace(normalized, " ");
+            return WhitespaceRegex().Replace(normalized, " ").Trim();
+        }
+
+        public static string ToSlug(string value)
+        {
+            var key = NormalizeKey(value);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return "unknown";
+            }
+
+            return key.Replace(' ', '-');
+        }
+
+        private static IEnumerable<string> GetShowDirectories(string showsRoot, IReadOnlyList<string> changedPaths)
+        {
+            if (!Directory.Exists(showsRoot))
+            {
+                return [];
+            }
+
+            if (changedPaths.Count == 0)
+            {
+                return Directory
+                    .EnumerateDirectories(showsRoot)
+                    .Where(HasPlaylistData)
+                    .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
+            }
+
+            var root = Path.GetFullPath(Path.Combine(showsRoot, "..", ".."));
+            var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var rawPath in changedPaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+            {
+                var fullPath = ResolveChangedPath(root, rawPath);
+                var fileName = Path.GetFileName(fullPath);
+
+                if (!IsShowDataFile(fileName))
+                {
+                    continue;
+                }
+
+                var directory = Path.GetDirectoryName(fullPath);
+                if (!string.IsNullOrWhiteSpace(directory) &&
+                    Directory.Exists(directory) &&
+                    IsUnderDirectory(directory, showsRoot))
+                {
+                    directories.Add(directory);
+                }
+            }
+
+            return directories.OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static string ResolveChangedPath(string siteRoot, string rawPath)
+        {
+            var path = rawPath.Replace('/', Path.DirectorySeparatorChar);
+            if (Path.IsPathRooted(path))
+            {
+                return Path.GetFullPath(path);
+            }
+
+            var direct = Path.GetFullPath(Path.Combine(siteRoot, path));
+            if (File.Exists(direct))
+            {
+                return direct;
+            }
+
+            var siteRootName = Path.GetFileName(siteRoot.TrimEnd(Path.DirectorySeparatorChar));
+            if (!string.IsNullOrWhiteSpace(siteRootName) &&
+                path.StartsWith(siteRootName + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            {
+                return Path.GetFullPath(Path.Combine(siteRoot, path[(siteRootName.Length + 1)..]));
+            }
+
+            return direct;
+        }
+
+        private static bool HasPlaylistData(string directory)
+        {
+            return File.Exists(Path.Combine(directory, "playlist.md")) ||
+                File.Exists(Path.Combine(directory, "track-info.md"));
+        }
+
+        private static bool IsShowDataFile(string fileName)
+        {
+            return string.Equals(fileName, "playlist.md", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(fileName, "track-info.md", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsUnderDirectory(string path, string root)
+        {
+            var fullPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            return fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static IReadOnlyList<ContentCandidate> BuildCandidates(IReadOnlyList<ParsedPlaylistEntry> entries)
+        {
+            var candidates = new Dictionary<string, ContentCandidate>(StringComparer.Ordinal);
+
+            foreach (var entry in entries)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Artist) || string.IsNullOrWhiteSpace(entry.Track))
+                {
+                    continue;
+                }
+
+                var key = $"{NormalizeKey(entry.Artist)}|{NormalizeKey(entry.Track)}";
+                if (!candidates.TryGetValue(key, out var candidate))
+                {
+                    candidate = new ContentCandidate(entry.Artist, entry.Track);
+                    candidates.Add(key, candidate);
+                }
+
+                candidate.Shows.Add(entry.ShowId);
+
+                if (!string.IsNullOrWhiteSpace(entry.Duration))
+                {
+                    candidate.Duration = entry.Duration;
+                }
+
+                if (!string.IsNullOrWhiteSpace(entry.ReleaseTitle))
+                {
+                    candidate.ReleaseTitle = entry.ReleaseTitle;
+                }
+
+                if (!string.IsNullOrWhiteSpace(entry.ReleaseYear))
+                {
+                    candidate.ReleaseYear = entry.ReleaseYear;
+                }
+
+                if (!string.IsNullOrWhiteSpace(entry.ReleaseArtist))
+                {
+                    candidate.ReleaseArtist = entry.ReleaseArtist;
+                }
+            }
+
+            return candidates.Values
+                .OrderBy(candidate => candidate.Artist, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(candidate => candidate.Track, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static IReadOnlyList<ReleaseCandidate> BuildReleaseCandidates(IReadOnlyList<ContentCandidate> candidates)
+        {
+            var releases = new Dictionary<string, ReleaseCandidate>(StringComparer.Ordinal);
+
+            foreach (var candidate in candidates.Where(candidate => !string.IsNullOrWhiteSpace(candidate.ReleaseTitle)))
+            {
+                var releaseArtist = candidate.ReleaseArtist ?? candidate.Artist;
+                var key = $"{NormalizeKey(releaseArtist)}|{NormalizeKey(candidate.ReleaseTitle!)}";
+                if (!releases.TryGetValue(key, out var release))
+                {
+                    release = new ReleaseCandidate(releaseArtist, candidate.ReleaseTitle!);
+                    releases.Add(key, release);
+                }
+
+                foreach (var show in candidate.Shows)
+                {
+                    release.Shows.Add(show);
+                }
+
+                if (!string.IsNullOrWhiteSpace(candidate.ReleaseYear))
+                {
+                    release.Year = candidate.ReleaseYear;
+                }
+
+                release.Tracks.Add(new ReleaseTrack(candidate.Track, candidate.Duration));
+            }
+
+            return releases.Values
+                .OrderBy(candidate => candidate.Artist, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(candidate => candidate.Title, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static void CreateArtistPage(
+            string contentRoot,
+            ExistingContentIndex existing,
+            ContentCandidate candidate,
+            EnrichmentReport report)
+        {
+            var matches = existing.FindArtist(candidate.Artist);
+            if (matches.Count > 1)
+            {
+                report.Ambiguous.Add($"Artist: {candidate.Artist} matched {string.Join(", ", matches)}");
+                return;
+            }
+
+            if (matches.Count == 1)
+            {
+                report.SkippedArtists.Add(candidate.Artist);
+                return;
+            }
+
+            var path = GetArtistPath(contentRoot, candidate.Artist);
+            if (File.Exists(path))
+            {
+                report.SkippedArtists.Add(candidate.Artist);
+                return;
+            }
+
+            WriteFile(path, PageBuilder.BuildArtist(candidate));
+            existing.AddArtist(candidate.Artist, path);
+            report.CreatedArtists.Add(RelativeToRepository(path));
+        }
+
+        private static void CreateReleasePage(
+            string contentRoot,
+            ExistingContentIndex existing,
+            ReleaseCandidate candidate,
+            EnrichmentReport report)
+        {
+            var matches = existing.FindRelease(candidate.Artist, candidate.Title);
+            if (matches.Count > 1)
+            {
+                report.Ambiguous.Add($"Release: {candidate.Artist} - {candidate.Title} matched {string.Join(", ", matches)}");
+                return;
+            }
+
+            if (matches.Count == 1)
+            {
+                report.SkippedReleases.Add($"{candidate.Artist} - {candidate.Title}");
+                return;
+            }
+
+            var path = GetReleasePath(contentRoot, candidate.Artist, candidate.Title);
+            if (File.Exists(path))
+            {
+                report.SkippedReleases.Add($"{candidate.Artist} - {candidate.Title}");
+                return;
+            }
+
+            WriteFile(path, PageBuilder.BuildRelease(candidate));
+            existing.AddRelease(candidate.Artist, candidate.Title, path);
+            report.CreatedReleases.Add(RelativeToRepository(path));
+        }
+
+        private static void CreateTrackPage(
+            string contentRoot,
+            ExistingContentIndex existing,
+            ContentCandidate candidate,
+            EnrichmentReport report)
+        {
+            var matches = existing.FindTrack(candidate.Artist, candidate.Track);
+            if (matches.Count > 1)
+            {
+                report.Ambiguous.Add($"Track: {candidate.Artist} - {candidate.Track} matched {string.Join(", ", matches)}");
+                return;
+            }
+
+            if (matches.Count == 1)
+            {
+                report.SkippedTracks.Add($"{candidate.Artist} - {candidate.Track}");
+                return;
+            }
+
+            var path = GetTrackPath(contentRoot, candidate.Artist, candidate.Track);
+            if (File.Exists(path))
+            {
+                report.SkippedTracks.Add($"{candidate.Artist} - {candidate.Track}");
+                return;
+            }
+
+            WriteFile(path, PageBuilder.BuildTrack(candidate));
+            existing.AddTrack(candidate.Artist, candidate.Track, path);
+            report.CreatedTracks.Add(RelativeToRepository(path));
+        }
+
+        private static string GetArtistPath(string contentRoot, string artist)
+        {
+            var artistSlug = ToSlug(artist);
+            return Path.Combine(contentRoot, "artists", GetFirstBucket(artistSlug), artistSlug, IndexFileName);
+        }
+
+        private static string GetReleasePath(string contentRoot, string artist, string release)
+        {
+            var artistSlug = ToSlug(artist);
+            var releaseSlug = ToSlug(release);
+            return Path.Combine(contentRoot, "releases", GetFirstBucket(artistSlug), artistSlug, releaseSlug, IndexFileName);
+        }
+
+        private static string GetTrackPath(string contentRoot, string artist, string track)
+        {
+            var artistSlug = ToSlug(artist);
+            var trackSlug = ToSlug(track);
+            return Path.Combine(contentRoot, "tracks", GetFirstBucket(artistSlug), artistSlug, trackSlug, IndexFileName);
+        }
+
+        private static string GetFirstBucket(string slug)
+        {
+            var first = slug.Length > 0 ? slug[0] : '0';
+            return char.IsAsciiLetterOrDigit(first) ? first.ToString() : "0";
+        }
+
+        private static void WriteFile(string path, string content)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content, Encoding.UTF8);
+        }
+
+        private static string RelativeToRepository(string path)
+        {
+            return Path.GetRelativePath(Directory.GetCurrentDirectory(), path).Replace('\\', '/');
+        }
+
+        [GeneratedRegex("[\u2018\u2019\u201A\u201B']")]
+        private static partial Regex ApostropheRegex();
+
+        [GeneratedRegex("[^a-z0-9]+")]
+        private static partial Regex NonAlphaNumericRegex();
+
+        [GeneratedRegex("\\s+")]
+        private static partial Regex WhitespaceRegex();
+
+        private sealed class ParsedPlaylistResult
+        {
+            public ParsedPlaylistResult(IReadOnlyList<ParsedPlaylistEntry> entries, int playlistEntriesParsed, int trackInfoEntriesParsed)
+            {
+                this.Entries = entries;
+                this.PlaylistEntriesParsed = playlistEntriesParsed;
+                this.TrackInfoEntriesParsed = trackInfoEntriesParsed;
+            }
+
+            public IReadOnlyList<ParsedPlaylistEntry> Entries { get; }
+
+            public int PlaylistEntriesParsed { get; }
+
+            public int TrackInfoEntriesParsed { get; }
+        }
+
+        private sealed class ParsedPlaylistEntry
+        {
+            public ParsedPlaylistEntry(string showId, string artist, string track)
+            {
+                this.ShowId = showId;
+                this.Artist = artist;
+                this.Track = track;
+            }
+
+            public string ShowId { get; }
+
+            public string Artist { get; }
+
+            public string Track { get; }
+
+            public string? ReleaseTitle { get; set; }
+
+            public string? ReleaseArtist { get; set; }
+
+            public string? ReleaseYear { get; set; }
+
+            public string? Duration { get; set; }
+        }
+
+        private sealed class ContentCandidate
+        {
+            public ContentCandidate(string artist, string track)
+            {
+                this.Artist = artist;
+                this.Track = track;
+            }
+
+            public string Artist { get; }
+
+            public string Track { get; }
+
+            public SortedSet<string> Shows { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+            public string? ReleaseTitle { get; set; }
+
+            public string? ReleaseArtist { get; set; }
+
+            public string? ReleaseYear { get; set; }
+
+            public string? Duration { get; set; }
+        }
+
+        private sealed class ReleaseCandidate
+        {
+            public ReleaseCandidate(string artist, string title)
+            {
+                this.Artist = artist;
+                this.Title = title;
+            }
+
+            public string Artist { get; }
+
+            public string Title { get; }
+
+            public string? Year { get; set; }
+
+            public SortedSet<string> Shows { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+            public List<ReleaseTrack> Tracks { get; } = [];
+        }
+
+        private sealed record ReleaseTrack(string Title, string? Duration);
+
+        private static partial class PlaylistParser
+        {
+            public static ParsedPlaylistResult Parse(IReadOnlyList<string> showDirectories)
+            {
+                var entries = new Dictionary<string, ParsedPlaylistEntry>(StringComparer.Ordinal);
+                var playlistEntriesParsed = 0;
+                var trackInfoEntriesParsed = 0;
+
+                foreach (var showDirectory in showDirectories)
+                {
+                    var showId = Path.GetFileName(showDirectory) ?? string.Empty;
+
+                    foreach (var entry in ParsePlaylist(Path.Combine(showDirectory, "playlist.md"), showId))
+                    {
+                        playlistEntriesParsed++;
+                        entries.TryAdd(GetEntryKey(entry), entry);
+                    }
+
+                    foreach (var entry in ParseTrackInfo(Path.Combine(showDirectory, "track-info.md"), showId))
+                    {
+                        trackInfoEntriesParsed++;
+                        entries[GetEntryKey(entry)] = entry;
+                    }
+                }
+
+                return new ParsedPlaylistResult(entries.Values.ToList(), playlistEntriesParsed, trackInfoEntriesParsed);
+            }
+
+            private static IEnumerable<ParsedPlaylistEntry> ParsePlaylist(string path, string showId)
+            {
+                if (!File.Exists(path))
+                {
+                    yield break;
+                }
+
+                foreach (var line in File.ReadLines(path))
+                {
+                    var match = PlaylistLineRegex().Match(line);
+                    if (!match.Success)
+                    {
+                        continue;
+                    }
+
+                    var title = CleanMarkdown(match.Groups["track"].Value);
+                    var artist = ExtractArtist(match.Groups["artist"].Value);
+                    if (!string.IsNullOrWhiteSpace(artist) && !string.IsNullOrWhiteSpace(title))
+                    {
+                        yield return new ParsedPlaylistEntry(showId, artist, title);
+                    }
+                }
+            }
+
+            private static IEnumerable<ParsedPlaylistEntry> ParseTrackInfo(string path, string showId)
+            {
+                if (!File.Exists(path))
+                {
+                    yield break;
+                }
+
+                foreach (var line in File.ReadLines(path))
+                {
+                    if (!TrackInfoRowRegex().IsMatch(line))
+                    {
+                        continue;
+                    }
+
+                    var cells = SplitMarkdownTableRow(line);
+                    if (cells.Count < 4 || cells[1].Contains("track-info-featured-guest", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var titleArtist = ParseTitleArtist(cells[1]);
+                    if (string.IsNullOrWhiteSpace(titleArtist.Track) || string.IsNullOrWhiteSpace(titleArtist.Artist))
+                    {
+                        continue;
+                    }
+
+                    var entry = new ParsedPlaylistEntry(showId, titleArtist.Artist, titleArtist.Track)
+                    {
+                        Duration = CleanMarkdown(cells[3]),
+                    };
+
+                    var release = ParseRelease(cells[2], titleArtist.Artist);
+                    if (release is not null)
+                    {
+                        entry.ReleaseTitle = release.Title;
+                        entry.ReleaseArtist = release.Artist;
+                        entry.ReleaseYear = release.Year;
+                    }
+
+                    yield return entry;
+                }
+            }
+
+            private static string GetEntryKey(ParsedPlaylistEntry entry)
+            {
+                return $"{entry.ShowId}|{NormalizeKey(entry.Artist)}|{NormalizeKey(entry.Track)}";
+            }
+
+            private static IReadOnlyList<string> SplitMarkdownTableRow(string line)
+            {
+                var trimmed = line.Trim();
+                if (!trimmed.StartsWith('|') || !trimmed.EndsWith('|'))
+                {
+                    return [];
+                }
+
+                return trimmed[1..^1].Split('|').Select(cell => cell.Trim()).ToList();
+            }
+
+            private static TitleArtist ParseTitleArtist(string cell)
+            {
+                var shortcode = TitleShortcodeRegex().Match(cell);
+                if (shortcode.Success)
+                {
+                    var parts = shortcode.Groups["value"].Value.Split("--", StringSplitOptions.TrimEntries);
+                    if (parts.Length >= 2)
+                    {
+                        return new TitleArtist(parts[0], parts[1]);
+                    }
+                }
+
+                return new TitleArtist(CleanMarkdown(cell), string.Empty);
+            }
+
+            private static ReleaseInfo? ParseRelease(string cell, string fallbackArtist)
+            {
+                if (string.IsNullOrWhiteSpace(cell))
+                {
+                    return null;
+                }
+
+                var releaseShortcode = ReleaseShortcodeRegex().Match(cell);
+                if (releaseShortcode.Success)
+                {
+                    var parts = releaseShortcode.Groups["value"].Value.Split("--", StringSplitOptions.TrimEntries);
+                    if (parts.Length >= 2)
+                    {
+                        var title = StripYear(parts[0], out var year);
+                        return new ReleaseInfo(title, parts[1], year);
+                    }
+                }
+
+                var clean = CleanMarkdown(cell);
+                if (string.IsNullOrWhiteSpace(clean) ||
+                    UnknownReleaseRegex().IsMatch(clean))
+                {
+                    return null;
+                }
+
+                var releaseTitle = StripYear(clean, out var releaseYear);
+                return string.IsNullOrWhiteSpace(releaseTitle)
+                    ? null
+                    : new ReleaseInfo(releaseTitle, fallbackArtist, releaseYear);
+            }
+
+            private static string StripYear(string value, out string? year)
+            {
+                year = null;
+                var match = YearSuffixRegex().Match(value);
+                if (match.Success)
+                {
+                    year = match.Groups["year"].Value;
+                    return match.Groups["title"].Value.Trim();
+                }
+
+                return value.Trim();
+            }
+
+            private static string ExtractArtist(string value)
+            {
+                var artistShortcode = ArtistShortcodeRegex().Match(value);
+                return artistShortcode.Success
+                    ? artistShortcode.Groups["artist"].Value.Trim()
+                    : CleanMarkdown(value);
+            }
+
+            private static string CleanMarkdown(string value)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return string.Empty;
+                }
+
+                var clean = ShortcodeRegex().Replace(value, string.Empty);
+                clean = MarkdownLinkRegex().Replace(clean, "${text}");
+                clean = MarkdownStyleRegex().Replace(clean, string.Empty);
+                return WhitespaceRegex().Replace(clean, " ").Trim();
+            }
+
+            [GeneratedRegex("^\\s*\\d+[.)]\\s*(?<artist>.+?)\\s+-\\s+(?<track>.+?)\\s*$")]
+            private static partial Regex PlaylistLineRegex();
+
+            [GeneratedRegex("^\\s*\\|\\s*\\d+\\s*\\|")]
+            private static partial Regex TrackInfoRowRegex();
+
+            [GeneratedRegex("\\{\\{<\\s*artist-wikilink\\s+\"(?<artist>[^\"]+)\"\\s*>\\}\\}", RegexOptions.IgnoreCase)]
+            private static partial Regex ArtistShortcodeRegex();
+
+            [GeneratedRegex("\\{\\{<\\s*title\\s+\"(?<value>[^\"]+)\"\\s*>\\}\\}", RegexOptions.IgnoreCase)]
+            private static partial Regex TitleShortcodeRegex();
+
+            [GeneratedRegex("\\{\\{<\\s*release\\s+\"(?<value>[^\"]+)\"\\s*>\\}\\}", RegexOptions.IgnoreCase)]
+            private static partial Regex ReleaseShortcodeRegex();
+
+            [GeneratedRegex("^(single|n/?a|unknown|non[- ]album|tbc|-+)$", RegexOptions.IgnoreCase)]
+            private static partial Regex UnknownReleaseRegex();
+
+            [GeneratedRegex("^(?<title>.*?)\\s*\\((?<year>\\d{4})\\)\\s*$")]
+            private static partial Regex YearSuffixRegex();
+
+            [GeneratedRegex("\\{\\{<[^>]+>\\}\\}")]
+            private static partial Regex ShortcodeRegex();
+
+            [GeneratedRegex("\\[(?<text>[^\\]]+)\\]\\([^)]+\\)")]
+            private static partial Regex MarkdownLinkRegex();
+
+            [GeneratedRegex("\\*\\*|__|_")]
+            private static partial Regex MarkdownStyleRegex();
+
+            private sealed record TitleArtist(string Track, string Artist);
+
+            private sealed record ReleaseInfo(string Title, string Artist, string? Year);
+        }
+
+        private sealed class ExistingContentIndex
+        {
+            private readonly Dictionary<string, HashSet<string>> artists = new(StringComparer.Ordinal);
+            private readonly Dictionary<string, HashSet<string>> releases = new(StringComparer.Ordinal);
+            private readonly Dictionary<string, HashSet<string>> tracks = new(StringComparer.Ordinal);
+
+            public static ExistingContentIndex Build(string contentRoot)
+            {
+                var index = new ExistingContentIndex();
+                index.AddExistingArtists(Path.Combine(contentRoot, "artists"));
+                index.AddExistingReleases(Path.Combine(contentRoot, "releases"));
+                index.AddExistingTracks(Path.Combine(contentRoot, "tracks"));
+                return index;
+            }
+
+            public IReadOnlyList<string> FindArtist(string artist)
+            {
+                return this.Find(this.artists, NormalizeKey(artist));
+            }
+
+            public IReadOnlyList<string> FindRelease(string artist, string release)
+            {
+                return this.Find(this.releases, PairKey(artist, release));
+            }
+
+            public IReadOnlyList<string> FindTrack(string artist, string track)
+            {
+                return this.Find(this.tracks, PairKey(artist, track));
+            }
+
+            public void AddArtist(string artist, string path)
+            {
+                this.Add(this.artists, NormalizeKey(artist), path);
+                this.Add(this.artists, NormalizeKey(ToSlug(artist)), path);
+            }
+
+            public void AddRelease(string artist, string release, string path)
+            {
+                this.Add(this.releases, PairKey(artist, release), path);
+                this.Add(this.releases, PairKey(ToSlug(artist), ToSlug(release)), path);
+            }
+
+            public void AddTrack(string artist, string track, string path)
+            {
+                this.Add(this.tracks, PairKey(artist, track), path);
+                this.Add(this.tracks, PairKey(ToSlug(artist), ToSlug(track)), path);
+            }
+
+            private static string PairKey(string first, string second)
+            {
+                return $"{NormalizeKey(first)}|{NormalizeKey(second)}";
+            }
+
+            private void AddExistingArtists(string root)
+            {
+                foreach (var file in EnumerateIndexFiles(root))
+                {
+                    var frontMatter = FrontMatterReader.Read(file);
+                    var title = frontMatter.GetValueOrDefault("title");
+                    if (!string.IsNullOrWhiteSpace(title))
+                    {
+                        this.AddArtist(title, file);
+                    }
+
+                    this.Add(this.artists, NormalizeKey(Path.GetFileName(Path.GetDirectoryName(file)) ?? string.Empty), file);
+                }
+            }
+
+            private void AddExistingReleases(string root)
+            {
+                foreach (var file in EnumerateIndexFiles(root))
+                {
+                    var frontMatter = FrontMatterReader.Read(file);
+                    var title = frontMatter.GetValueOrDefault("title");
+                    var artist = frontMatter.GetValueOrDefault("artist");
+                    if (!string.IsNullOrWhiteSpace(title) && !string.IsNullOrWhiteSpace(artist))
+                    {
+                        this.AddRelease(artist, title, file);
+                    }
+
+                    var releaseSlug = Path.GetFileName(Path.GetDirectoryName(file)) ?? string.Empty;
+                    var artistSlug = Path.GetFileName(Path.GetDirectoryName(Path.GetDirectoryName(file) ?? string.Empty)) ?? string.Empty;
+                    this.Add(this.releases, PairKey(artistSlug, releaseSlug), file);
+                }
+            }
+
+            private void AddExistingTracks(string root)
+            {
+                foreach (var file in EnumerateIndexFiles(root))
+                {
+                    var frontMatter = FrontMatterReader.Read(file);
+                    var title = frontMatter.GetValueOrDefault("title");
+                    var artist = frontMatter.GetValueOrDefault("artist");
+                    if (!string.IsNullOrWhiteSpace(title) && !string.IsNullOrWhiteSpace(artist))
+                    {
+                        this.AddTrack(artist, title, file);
+                    }
+
+                    var trackSlug = Path.GetFileName(Path.GetDirectoryName(file)) ?? string.Empty;
+                    var artistSlug = Path.GetFileName(Path.GetDirectoryName(Path.GetDirectoryName(file) ?? string.Empty)) ?? string.Empty;
+                    this.Add(this.tracks, PairKey(artistSlug, trackSlug), file);
+                }
+            }
+
+            private static IEnumerable<string> EnumerateIndexFiles(string root)
+            {
+                return Directory.Exists(root)
+                    ? Directory.EnumerateFiles(root, IndexFileName, SearchOption.AllDirectories)
+                    : [];
+            }
+
+            private IReadOnlyList<string> Find(Dictionary<string, HashSet<string>> index, string key)
+            {
+                return index.TryGetValue(key, out var paths)
+                    ? paths.OrderBy(path => path, StringComparer.OrdinalIgnoreCase).Select(RelativeToRepository).ToList()
+                    : [];
+            }
+
+            private void Add(Dictionary<string, HashSet<string>> index, string key, string path)
+            {
+                if (string.IsNullOrWhiteSpace(key))
+                {
+                    return;
+                }
+
+                if (!index.TryGetValue(key, out var paths))
+                {
+                    paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    index.Add(key, paths);
+                }
+
+                paths.Add(path);
+            }
+        }
+
+        private static class FrontMatterReader
+        {
+            public static IReadOnlyDictionary<string, string> Read(string path)
+            {
+                var lines = File.ReadLines(path).ToList();
+                if (lines.Count < 3 || !string.Equals(lines[0].Trim(), "---", StringComparison.Ordinal))
+                {
+                    return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var line in lines.Skip(1))
+                {
+                    if (string.Equals(line.Trim(), "---", StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+
+                    var separator = line.IndexOf(':', StringComparison.Ordinal);
+                    if (separator <= 0)
+                    {
+                        continue;
+                    }
+
+                    var key = line[..separator].Trim();
+                    var value = line[(separator + 1)..].Trim().Trim('"', '\'');
+                    if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
+                    {
+                        values[key] = value;
+                    }
+                }
+
+                return values;
+            }
+        }
+
+        private static class PageBuilder
+        {
+            public static string BuildArtist(ContentCandidate candidate)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("---");
+                AddYamlScalar(builder, "title", candidate.Artist);
+                builder.AppendLine("artist_page: true");
+                builder.AppendLine("draft: true");
+                builder.AppendLine("---");
+                builder.AppendLine();
+                builder.AppendLine("## About");
+                builder.AppendLine();
+                builder.AppendLine($"{candidate.Artist} has been featured on Sundown Sessions. This draft page was generated from show playlist data and needs editorial review.");
+                return builder.ToString();
+            }
+
+            public static string BuildRelease(ReleaseCandidate candidate)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("---");
+                AddYamlScalar(builder, "title", candidate.Title);
+                AddYamlScalar(builder, "artist", candidate.Artist);
+                AddYamlScalar(builder, "releaseDate", candidate.Year);
+                AddYamlList(builder, "featuredInShows", candidate.Shows);
+                AddYamlList(builder, "shows", candidate.Shows);
+                builder.AppendLine("tracks:");
+                foreach (var track in candidate.Tracks.DistinctBy(track => NormalizeKey(track.Title)))
+                {
+                    builder.AppendLine(CultureInfo.InvariantCulture, $"  - title: {YamlQuote(track.Title)}");
+                    if (!string.IsNullOrWhiteSpace(track.Duration))
+                    {
+                        builder.AppendLine(CultureInfo.InvariantCulture, $"    duration: {YamlQuote(track.Duration)}");
+                    }
+                }
+
+                builder.AppendLine("draft: true");
+                builder.AppendLine("---");
+                builder.AppendLine();
+                builder.AppendLine("## About");
+                builder.AppendLine();
+                builder.AppendLine($"{candidate.Title} is a release by {candidate.Artist}. This draft page was generated from Sundown Sessions playlist data and needs editorial review.");
+                builder.AppendLine();
+                builder.AppendLine("## Tracks Featured on Sundown Sessions");
+                builder.AppendLine();
+                foreach (var track in candidate.Tracks.DistinctBy(track => NormalizeKey(track.Title)))
+                {
+                    builder.AppendLine(CultureInfo.InvariantCulture, $"- {track.Title}");
+                }
+
+                return builder.ToString();
+            }
+
+            public static string BuildTrack(ContentCandidate candidate)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("---");
+                AddYamlScalar(builder, "title", candidate.Track);
+                AddYamlScalar(builder, "artist", candidate.Artist);
+                AddYamlScalar(builder, "release", candidate.ReleaseTitle);
+                if (!string.IsNullOrWhiteSpace(candidate.ReleaseTitle))
+                {
+                    AddYamlScalar(builder, "release_slug", ToSlug(candidate.ReleaseTitle));
+                }
+
+                AddYamlList(builder, "featuredInShows", candidate.Shows);
+                builder.AppendLine("track_page: true");
+                builder.AppendLine("draft: true");
+                builder.AppendLine("---");
+                builder.AppendLine();
+                builder.AppendLine("## About");
+                builder.AppendLine();
+                builder.AppendLine($"{candidate.Track} by {candidate.Artist} has been featured on Sundown Sessions. This draft page was generated from show playlist data and needs editorial review.");
+                return builder.ToString();
+            }
+
+            private static void AddYamlScalar(StringBuilder builder, string key, string? value)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    builder.AppendLine(CultureInfo.InvariantCulture, $"{key}: {YamlQuote(value)}");
+                }
+            }
+
+            private static void AddYamlList(StringBuilder builder, string key, IEnumerable<string> values)
+            {
+                var clean = values.Where(value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                if (clean.Count == 0)
+                {
+                    return;
+                }
+
+                builder.AppendLine(CultureInfo.InvariantCulture, $"{key}:");
+                foreach (var value in clean)
+                {
+                    builder.AppendLine(CultureInfo.InvariantCulture, $"  - {YamlQuote(value)}");
+                }
+            }
+
+            private static string YamlQuote(string value)
+            {
+                return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+            }
+        }
+
+        private sealed class EnrichmentReport
+        {
+            public List<string> CreatedArtists { get; } = [];
+
+            public List<string> CreatedReleases { get; } = [];
+
+            public List<string> CreatedTracks { get; } = [];
+
+            public List<string> SkippedArtists { get; } = [];
+
+            public List<string> SkippedReleases { get; } = [];
+
+            public List<string> SkippedTracks { get; } = [];
+
+            public List<string> Ambiguous { get; } = [];
+
+            public void Write(string path, int showsScanned, int playlistEntriesParsed, int trackInfoEntriesParsed)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, this.Build(showsScanned, playlistEntriesParsed, trackInfoEntriesParsed), Encoding.UTF8);
+            }
+
+            private string Build(int showsScanned, int playlistEntriesParsed, int trackInfoEntriesParsed)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("# Content Enrichment Report");
+                builder.AppendLine();
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Shows scanned: {showsScanned}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Playlist entries parsed: {playlistEntriesParsed}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Track info entries parsed: {trackInfoEntriesParsed}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Artist pages created: {this.CreatedArtists.Count}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Release pages created: {this.CreatedReleases.Count}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Track pages created: {this.CreatedTracks.Count}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Existing artists skipped: {this.SkippedArtists.Count}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Existing releases skipped: {this.SkippedReleases.Count}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Existing tracks skipped: {this.SkippedTracks.Count}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"- Ambiguous items: {this.Ambiguous.Count}");
+                builder.AppendLine();
+                AddSection(builder, "Created Artists", this.CreatedArtists);
+                AddSection(builder, "Created Releases", this.CreatedReleases);
+                AddSection(builder, "Created Tracks", this.CreatedTracks);
+                AddSection(builder, "Manual Review Required", this.Ambiguous);
+                return builder.ToString();
+            }
+
+            private static void AddSection(StringBuilder builder, string title, IReadOnlyList<string> items)
+            {
+                builder.AppendLine(CultureInfo.InvariantCulture, $"## {title}");
+                builder.AppendLine();
+                if (items.Count == 0)
+                {
+                    builder.AppendLine("- None");
+                }
+                else
+                {
+                    foreach (var item in items.OrderBy(item => item, StringComparer.OrdinalIgnoreCase))
+                    {
+                        builder.AppendLine(CultureInfo.InvariantCulture, $"- {item}");
+                    }
+                }
+
+                builder.AppendLine();
+            }
+        }
+    }
+}

--- a/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentCommand.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentCommand.cs
@@ -1,0 +1,15 @@
+// <copyright file="EnrichContentCommand.cs" company="SundownMedia">
+// Copyright (c) SundownMedia. All rights reserved.
+// </copyright>
+
+namespace SundownMedia.ContentOps.Application.Features.ContentEnrichment
+{
+    using ErrorOr;
+    using Mediator;
+
+    public sealed record EnrichContentCommand(
+        string SiteRoot,
+        IReadOnlyList<string> ChangedPaths,
+        string ReportPath,
+        string CorrelationId) : IRequest<ErrorOr<EnrichContentResult>>;
+}

--- a/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentCommandHandler.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentCommandHandler.cs
@@ -1,0 +1,26 @@
+// <copyright file="EnrichContentCommandHandler.cs" company="SundownMedia">
+// Copyright (c) SundownMedia. All rights reserved.
+// </copyright>
+
+namespace SundownMedia.ContentOps.Application.Features.ContentEnrichment
+{
+    using ErrorOr;
+    using Mediator;
+
+    public sealed class EnrichContentCommandHandler : IRequestHandler<EnrichContentCommand, ErrorOr<EnrichContentResult>>
+    {
+        public ValueTask<ErrorOr<EnrichContentResult>> Handle(
+            EnrichContentCommand command,
+            CancellationToken cancellationToken)
+        {
+            if (!Directory.Exists(command.SiteRoot))
+            {
+                return ValueTask.FromResult<ErrorOr<EnrichContentResult>>(
+                    Error.Validation("ContentEnrichment.SiteRoot", "Site root does not exist."));
+            }
+
+            var result = ContentEnrichmentGenerator.Enrich(command);
+            return ValueTask.FromResult<ErrorOr<EnrichContentResult>>(result);
+        }
+    }
+}

--- a/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentCommandValidator.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentCommandValidator.cs
@@ -1,0 +1,18 @@
+// <copyright file="EnrichContentCommandValidator.cs" company="SundownMedia">
+// Copyright (c) SundownMedia. All rights reserved.
+// </copyright>
+
+namespace SundownMedia.ContentOps.Application.Features.ContentEnrichment
+{
+    using FluentValidation;
+
+    public sealed class EnrichContentCommandValidator : AbstractValidator<EnrichContentCommand>
+    {
+        public EnrichContentCommandValidator()
+        {
+            this.RuleFor(command => command.SiteRoot).NotEmpty();
+            this.RuleFor(command => command.ReportPath).NotEmpty();
+            this.RuleFor(command => command.CorrelationId).NotEmpty();
+        }
+    }
+}

--- a/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentResult.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ContentEnrichment/EnrichContentResult.cs
@@ -1,0 +1,23 @@
+// <copyright file="EnrichContentResult.cs" company="SundownMedia">
+// Copyright (c) SundownMedia. All rights reserved.
+// </copyright>
+
+namespace SundownMedia.ContentOps.Application.Features.ContentEnrichment
+{
+    public sealed record EnrichContentResult(
+        string ReportPath,
+        int ShowsScanned,
+        int PlaylistEntriesParsed,
+        int TrackInfoEntriesParsed,
+        int ArtistPagesCreated,
+        int ReleasePagesCreated,
+        int TrackPagesCreated,
+        int ExistingArtistsSkipped,
+        int ExistingReleasesSkipped,
+        int ExistingTracksSkipped,
+        int AmbiguousItems,
+        string CorrelationId)
+    {
+        public int PagesCreated => this.ArtistPagesCreated + this.ReleasePagesCreated + this.TrackPagesCreated;
+    }
+}

--- a/automation/dotnet/src/SundownMedia.ContentOps.Cli/ArgumentParser.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Cli/ArgumentParser.cs
@@ -6,6 +6,8 @@ namespace SundownMedia.ContentOps.Cli;
 
 public static class ArgumentParser
 {
+    private static readonly char[] ChangedPathSeparators = [',', ';', '\n', '\r'];
+
     public static bool TryParse(string[] args, out CliOptions? options)
     {
         options = null;
@@ -25,6 +27,12 @@ public static class ArgumentParser
             string.Equals(args[1], "create-frontmatter", StringComparison.OrdinalIgnoreCase))
         {
             return TryParseShowCreateFrontmatter(args, out options);
+        }
+
+        if (string.Equals(args[0], "content", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(args[1], "enrich", StringComparison.OrdinalIgnoreCase))
+        {
+            return TryParseContentEnrich(args, out options);
         }
 
         return false;
@@ -147,6 +155,54 @@ public static class ArgumentParser
             .AsReadOnly();
 
         options = new ShowNotesFrontmatterCliOptions(showNumber, featuredGuest, broadcastDate, keywords, outputPath, correlationId, spotifyEpisodeId, charity);
+        return true;
+    }
+
+    private static bool TryParseContentEnrich(string[] args, out CliOptions? options)
+    {
+        options = null;
+
+        string? siteRoot = null;
+        string? changedPathsRaw = null;
+        string? reportPath = null;
+        string? correlationId = null;
+        var changedPaths = new List<string>();
+
+        for (var i = 2; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], "--site-root", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                siteRoot = args[++i];
+            }
+            else if (string.Equals(args[i], "--changed-paths", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                changedPathsRaw = args[++i];
+            }
+            else if (string.Equals(args[i], "--changed-path", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                changedPaths.Add(args[++i]);
+            }
+            else if (string.Equals(args[i], "--report-path", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                reportPath = args[++i];
+            }
+            else if (string.Equals(args[i], "--correlation-id", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                correlationId = args[++i];
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(changedPathsRaw))
+        {
+            changedPaths.AddRange(changedPathsRaw.Split(ChangedPathSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+
+        if (string.IsNullOrWhiteSpace(siteRoot) || string.IsNullOrWhiteSpace(reportPath))
+        {
+            return false;
+        }
+
+        options = new ContentEnrichmentCliOptions(siteRoot, changedPaths.AsReadOnly(), reportPath, correlationId);
         return true;
     }
 }

--- a/automation/dotnet/src/SundownMedia.ContentOps.Cli/ContentEnrichmentCliOptions.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Cli/ContentEnrichmentCliOptions.cs
@@ -1,0 +1,12 @@
+// <copyright file="ContentEnrichmentCliOptions.cs" company="SundownMedia">
+// Copyright (c) SundownMedia. All rights reserved.
+// </copyright>
+
+namespace SundownMedia.ContentOps.Cli;
+
+public sealed record ContentEnrichmentCliOptions(
+    string SiteRoot,
+    IReadOnlyList<string> ChangedPaths,
+    string ReportPath,
+    string? CorrelationId)
+    : CliOptions(CorrelationId);

--- a/automation/dotnet/src/SundownMedia.ContentOps.Cli/HelpPrinter.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Cli/HelpPrinter.cs
@@ -12,5 +12,6 @@ public static class HelpPrinter
         Console.WriteLine("Usage:");
         Console.WriteLine("  contentops intake start --source <path> --working-root <path> --master-root <path> [--correlation-id <guid>]");
         Console.WriteLine("  contentops show create-frontmatter --show-number <n> --featured-guest <name> --broadcast-date <ISO 8601> --keywords <artist1,artist2,...> --output-path <path> [--charity <name>] [--spotify-episode-id <id>] [--correlation-id <guid>]");
+        Console.WriteLine("  contentops content enrich --site-root <path> --report-path <path> [--changed-paths <path1,path2,...>] [--changed-path <path>] [--correlation-id <guid>]");
     }
 }

--- a/automation/dotnet/src/SundownMedia.ContentOps.Cli/Program.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Cli/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SundownMedia.ContentOps.Application.DependencyInjection;
 using SundownMedia.ContentOps.Application.Features.AlbumReview.Intake;
+using SundownMedia.ContentOps.Application.Features.ContentEnrichment;
 using SundownMedia.ContentOps.Application.Features.ShowNotes.CreateFrontmatter;
 using SundownMedia.ContentOps.Cli;
 using SundownMedia.ContentOps.Contracts.Correlation;
@@ -67,5 +68,30 @@ else if (options is ShowNotesFrontmatterCliOptions showOptions)
     }
 
     Console.WriteLine($"Show notes frontmatter written to: {result.Value.OutputPath}");
+    Console.WriteLine($"CorrelationId: {result.Value.CorrelationId}");
+}
+else if (options is ContentEnrichmentCliOptions enrichOptions)
+{
+    var command = new EnrichContentCommand(
+        enrichOptions.SiteRoot,
+        enrichOptions.ChangedPaths,
+        enrichOptions.ReportPath,
+        correlationId);
+
+    var result = await sender.Send(command, CancellationToken.None);
+
+    if (result.IsError)
+    {
+        Console.Error.WriteLine(result.FirstError.Description);
+        Environment.ExitCode = 1;
+        return;
+    }
+
+    Console.WriteLine($"Content enrichment report written to: {result.Value.ReportPath}");
+    Console.WriteLine($"Pages created: {result.Value.PagesCreated}");
+    Console.WriteLine($"Artists created: {result.Value.ArtistPagesCreated}");
+    Console.WriteLine($"Releases created: {result.Value.ReleasePagesCreated}");
+    Console.WriteLine($"Tracks created: {result.Value.TrackPagesCreated}");
+    Console.WriteLine($"Ambiguous items: {result.Value.AmbiguousItems}");
     Console.WriteLine($"CorrelationId: {result.Value.CorrelationId}");
 }

--- a/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/ArgumentParserContentEnrichmentTests.cs
+++ b/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/ArgumentParserContentEnrichmentTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using SundownMedia.ContentOps.Cli;
+
+namespace SundownMedia.ContentOps.Application.Tests;
+
+public sealed class ArgumentParserContentEnrichmentTests
+{
+    [Fact]
+    public void TryParse_ReturnsContentEnrichmentOptions()
+    {
+        var parsed = ArgumentParser.TryParse(
+            [
+                "content",
+                "enrich",
+                "--site-root",
+                "src",
+                "--report-path",
+                "reports/content-enrichment-report.md",
+                "--changed-paths",
+                "src/content/shows/1/playlist.md,src/content/shows/1/track-info.md",
+                "--changed-path",
+                "src/content/shows/2/playlist.md",
+                "--correlation-id",
+                "abc",
+            ],
+            out var options);
+
+        parsed.Should().BeTrue();
+        var enrichOptions = options.Should().BeOfType<ContentEnrichmentCliOptions>().Subject;
+        enrichOptions.SiteRoot.Should().Be("src");
+        enrichOptions.ReportPath.Should().Be("reports/content-enrichment-report.md");
+        enrichOptions.CorrelationId.Should().Be("abc");
+        enrichOptions.ChangedPaths.Should().ContainInOrder(
+            "src/content/shows/2/playlist.md",
+            "src/content/shows/1/playlist.md",
+            "src/content/shows/1/track-info.md");
+    }
+
+    [Fact]
+    public void TryParse_ReturnsFalse_WhenRequiredContentEnrichmentArgumentsAreMissing()
+    {
+        var parsed = ArgumentParser.TryParse(["content", "enrich", "--site-root", "src"], out var options);
+
+        parsed.Should().BeFalse();
+        options.Should().BeNull();
+    }
+}

--- a/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/ContentEnrichmentGeneratorTests.cs
+++ b/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/ContentEnrichmentGeneratorTests.cs
@@ -1,0 +1,261 @@
+using FluentAssertions;
+using SundownMedia.ContentOps.Application.Features.ContentEnrichment;
+
+namespace SundownMedia.ContentOps.Application.Tests;
+
+public sealed class ContentEnrichmentGeneratorTests : IDisposable
+{
+    private readonly string root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    private readonly string siteRoot;
+
+    public ContentEnrichmentGeneratorTests()
+    {
+        this.siteRoot = Path.Combine(this.root, "src");
+        Directory.CreateDirectory(Path.Combine(this.siteRoot, "content", "shows", "1"));
+    }
+
+    [Fact]
+    public void Enrich_GeneratesDraftPages_FromPlaylistAndTrackInfo()
+    {
+        this.WriteShowFiles(
+            "1",
+            """
+            ---
+            ---
+            1. {{< artist-wikilink "Nick Cave & The Bad Seeds" >}} - Red Right Hand
+            """,
+            """
+            ---
+            ---
+            | # | Title | Album | Duration | Notes |
+            |:-:|-------|-------|:--------:|-------|
+            | 1 | {{<title "Red Right Hand--Nick Cave & The Bad Seeds">}} | {{<release "Let Love In (1994)--Nick Cave & The Bad Seeds--let-love-in">}} | 6:10 | |
+            """);
+
+        var command = new EnrichContentCommand(
+            this.siteRoot,
+            [],
+            Path.Combine(this.root, "reports", "content-enrichment-report.md"),
+            Guid.NewGuid().ToString("D"));
+
+        var result = ContentEnrichmentGenerator.Enrich(command);
+
+        result.ArtistPagesCreated.Should().Be(1);
+        result.ReleasePagesCreated.Should().Be(1);
+        result.TrackPagesCreated.Should().Be(1);
+
+        var artistPage = this.ReadContent("artists", "n", "nick-cave-and-the-bad-seeds", "index.md");
+        artistPage.Should().Contain("title: \"Nick Cave & The Bad Seeds\"");
+        artistPage.Should().Contain("artist_page: true");
+        artistPage.Should().Contain("draft: true");
+
+        var releasePage = this.ReadContent("releases", "n", "nick-cave-and-the-bad-seeds", "let-love-in", "index.md");
+        releasePage.Should().Contain("title: \"Let Love In\"");
+        releasePage.Should().Contain("artist: \"Nick Cave & The Bad Seeds\"");
+        releasePage.Should().Contain("releaseDate: \"1994\"");
+        releasePage.Should().Contain("featuredInShows:");
+        releasePage.Should().Contain("- \"1\"");
+        releasePage.Should().Contain("duration: \"6:10\"");
+
+        var trackPage = this.ReadContent("tracks", "n", "nick-cave-and-the-bad-seeds", "red-right-hand", "index.md");
+        trackPage.Should().Contain("title: \"Red Right Hand\"");
+        trackPage.Should().Contain("artist: \"Nick Cave & The Bad Seeds\"");
+        trackPage.Should().Contain("release: \"Let Love In\"");
+        trackPage.Should().Contain("release_slug: \"let-love-in\"");
+        trackPage.Should().Contain("track_page: true");
+        trackPage.Should().Contain("draft: true");
+    }
+
+    [Fact]
+    public void Enrich_IsIdempotent_WhenRunTwice()
+    {
+        this.WriteShowFiles(
+            "1",
+            "1. {{< artist-wikilink \"The Cure\" >}} - A Forest",
+            "| 1 | {{<title \"A Forest--The Cure\">}} | Seventeen Seconds (1980) | 5:55 | |");
+
+        var command = new EnrichContentCommand(
+            this.siteRoot,
+            [],
+            Path.Combine(this.root, "reports", "content-enrichment-report.md"),
+            Guid.NewGuid().ToString("D"));
+
+        var first = ContentEnrichmentGenerator.Enrich(command);
+        var second = ContentEnrichmentGenerator.Enrich(command);
+
+        first.PagesCreated.Should().Be(3);
+        second.PagesCreated.Should().Be(0);
+        second.ExistingArtistsSkipped.Should().Be(1);
+        second.ExistingReleasesSkipped.Should().Be(1);
+        second.ExistingTracksSkipped.Should().Be(1);
+    }
+
+    [Fact]
+    public void Enrich_SkipsExistingPages_UsingTolerantNormalization()
+    {
+        this.WriteShowFiles(
+            "1",
+            "1. {{< artist-wikilink \"Nick Cave & The Bad Seeds\" >}} - Red Right Hand",
+            "| 1 | {{<title \"Red Right Hand--Nick Cave & The Bad Seeds\">}} | Let Love In (1994) | 6:10 | |");
+
+        this.WriteContent(
+            "artists",
+            "n",
+            "nick-cave-and-the-bad-seeds",
+            "index.md",
+            """
+            ---
+            title: "Nick Cave and The Bad Seeds"
+            ---
+            """);
+        this.WriteContent(
+            "releases",
+            "n",
+            "nick-cave-and-the-bad-seeds",
+            "let-love-in",
+            "index.md",
+            """
+            ---
+            title: "Let Love In"
+            artist: "Nick Cave and The Bad Seeds"
+            ---
+            """);
+        this.WriteContent(
+            "tracks",
+            "n",
+            "nick-cave-and-the-bad-seeds",
+            "red-right-hand",
+            "index.md",
+            """
+            ---
+            title: "Red Right Hand"
+            artist: "Nick Cave and The Bad Seeds"
+            ---
+            """);
+
+        var command = new EnrichContentCommand(
+            this.siteRoot,
+            [],
+            Path.Combine(this.root, "reports", "content-enrichment-report.md"),
+            Guid.NewGuid().ToString("D"));
+
+        var result = ContentEnrichmentGenerator.Enrich(command);
+
+        result.PagesCreated.Should().Be(0);
+        result.ExistingArtistsSkipped.Should().Be(1);
+        result.ExistingReleasesSkipped.Should().Be(1);
+        result.ExistingTracksSkipped.Should().Be(1);
+    }
+
+    [Fact]
+    public void Enrich_ReportsAmbiguousMatches_WithoutWritingCandidate()
+    {
+        this.WriteShowFiles(
+            "1",
+            "1. {{< artist-wikilink \"The Sound\" >}} - Winning",
+            "| 1 | {{<title \"Winning--The Sound\">}} | From The Lions Mouth (1981) | 4:18 | |");
+
+        this.WriteContent(
+            "artists",
+            "t",
+            "the-sound",
+            "index.md",
+            """
+            ---
+            title: "The Sound"
+            ---
+            """);
+        this.WriteContent(
+            "artists",
+            "t",
+            "the-sound-2",
+            "index.md",
+            """
+            ---
+            title: "The Sound"
+            ---
+            """);
+
+        var command = new EnrichContentCommand(
+            this.siteRoot,
+            [],
+            Path.Combine(this.root, "reports", "content-enrichment-report.md"),
+            Guid.NewGuid().ToString("D"));
+
+        var result = ContentEnrichmentGenerator.Enrich(command);
+
+        result.AmbiguousItems.Should().BeGreaterThan(0);
+        result.ArtistPagesCreated.Should().Be(0);
+        File.ReadAllText(command.ReportPath).Should().Contain("Artist: The Sound matched");
+    }
+
+    [Fact]
+    public void Enrich_UsesChangedPaths_ToLimitShows()
+    {
+        this.WriteShowFiles(
+            "1",
+            "1. {{< artist-wikilink \"Wire\" >}} - Outdoor Miner",
+            "| 1 | {{<title \"Outdoor Miner--Wire\">}} | Chairs Missing (1978) | 1:45 | |");
+        this.WriteShowFiles(
+            "2",
+            "1. {{< artist-wikilink \"Magazine\" >}} - Shot By Both Sides",
+            "| 1 | {{<title \"Shot By Both Sides--Magazine\">}} | Real Life (1978) | 4:01 | |");
+
+        var command = new EnrichContentCommand(
+            this.siteRoot,
+            ["src/content/shows/2/track-info.md"],
+            Path.Combine(this.root, "reports", "content-enrichment-report.md"),
+            Guid.NewGuid().ToString("D"));
+
+        var result = ContentEnrichmentGenerator.Enrich(command);
+
+        result.ShowsScanned.Should().Be(1);
+        result.PagesCreated.Should().Be(3);
+        this.ContentExists("artists", "m", "magazine", "index.md").Should().BeTrue();
+        this.ContentExists("artists", "w", "wire", "index.md").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Nick Cave & The Bad Seeds", "nick cave and the bad seeds")]
+    [InlineData("O'Hara", "ohara")]
+    [InlineData("Cafe\u0301 Society", "cafe society")]
+    [InlineData("  RED   RIGHT--HAND  ", "red right hand")]
+    public void NormalizeKey_NormalizesLookupValues(string value, string expected)
+    {
+        ContentEnrichmentGenerator.NormalizeKey(value).Should().Be(expected);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.root))
+        {
+            Directory.Delete(this.root, recursive: true);
+        }
+    }
+
+    private void WriteShowFiles(string showId, string playlist, string trackInfo)
+    {
+        var showDirectory = Path.Combine(this.siteRoot, "content", "shows", showId);
+        Directory.CreateDirectory(showDirectory);
+        File.WriteAllText(Path.Combine(showDirectory, "playlist.md"), playlist);
+        File.WriteAllText(Path.Combine(showDirectory, "track-info.md"), trackInfo);
+    }
+
+    private void WriteContent(params string[] partsAndContent)
+    {
+        var content = partsAndContent[^1];
+        var path = Path.Combine([this.siteRoot, "content", .. partsAndContent[..^1]]);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    private string ReadContent(params string[] parts)
+    {
+        return File.ReadAllText(Path.Combine([this.siteRoot, "content", .. parts]));
+    }
+
+    private bool ContentExists(params string[] parts)
+    {
+        return File.Exists(Path.Combine([this.siteRoot, "content", .. parts]));
+    }
+}

--- a/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/SundownMedia.ContentOps.Application.Tests.csproj
+++ b/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/SundownMedia.ContentOps.Application.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\SundownMedia.ContentOps.Application\SundownMedia.ContentOps.Application.csproj" />
+    <ProjectReference Include="..\..\src\SundownMedia.ContentOps.Cli\SundownMedia.ContentOps.Cli.csproj" />
     <ProjectReference Include="..\..\src\SundownMedia.ContentOps.Contracts\SundownMedia.ContentOps.Contracts.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Adds deterministic ContentOps playlist enrichment via `content enrich`
- Generates missing draft artist, release, and track pages without overwriting existing content
- Adds tolerant duplicate detection, report generation, and a GitHub Actions workflow to open editorial review PRs

Closes #600

## Verification
- `git diff --check`

## Notes
- I could not run `dotnet test automation/dotnet/SundownMedia.ContentOps.sln` locally because this machine has no .NET SDK installed and the repo pins SDK `10.0.100`.