### PR TITLE
Align music content type templates

### DIFF
--- a/src/layouts/artists/single.html
+++ b/src/layouts/artists/single.html
@@ -9,8 +9,6 @@
     {{ partial "artist-why-we-play-them.html" . }}
 
     {{/* Featured on Sundown Sessions — show cards, above biography */}}
-    {{ partial "artist-featured-shows.html" . }}
-
     {{/* Body */}}
     <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
       {{ $enableToc := site.Params.article.showTableOfContents | default false }}
@@ -28,6 +26,9 @@
       <div class="w-full min-w-0 min-h-0">
         {{ partial "series/series.html" . }}
         {{ partial "artist-content.html" . }}
+        {{ partial "artist-featured-releases.html" . }}
+        {{ partial "artist-featured-tracks.html" . }}
+        {{ partial "artist-featured-shows.html" . }}
         {{ partial "series/series-closed.html" . }}
         {{ partial "related.html" . }}
       </div>

--- a/src/layouts/partials/artist-featured-releases.html
+++ b/src/layouts/partials/artist-featured-releases.html
@@ -1,0 +1,91 @@
+{{/* Releases connected to an artist through release front matter or bundle path. */}}
+
+{{ $artistName := .Title }}
+{{ $artistKey := lower (urlize $artistName) }}
+{{ $releases := slice }}
+
+{{ range where site.RegularPages "Section" "releases" }}
+  {{ $release := . }}
+  {{ $artistMatches := false }}
+
+  {{ range $field := slice .Params.artist .Params.artists }}
+    {{ with $field }}
+      {{ if reflect.IsSlice . }}
+        {{ range . }}
+          {{ $name := "" }}
+          {{ if reflect.IsMap . }}
+            {{ $name = index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug") | default "" }}
+          {{ else }}
+            {{ $name = . }}
+          {{ end }}
+          {{ if eq (lower (urlize (printf "%v" $name))) $artistKey }}{{ $artistMatches = true }}{{ end }}
+        {{ end }}
+      {{ else if reflect.IsMap . }}
+        {{ $name := index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug") | default "" }}
+        {{ if eq (lower (urlize (printf "%v" $name))) $artistKey }}{{ $artistMatches = true }}{{ end }}
+      {{ else }}
+        {{ if eq (lower (urlize (printf "%v" .))) $artistKey }}{{ $artistMatches = true }}{{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{ if and (not $artistMatches) .File }}
+    {{ $releaseDir := strings.TrimSuffix "/" (replace .File.Dir "\\" "/") }}
+    {{ if eq (lower (urlize (path.Base (path.Dir $releaseDir)))) $artistKey }}
+      {{ $artistMatches = true }}
+    {{ end }}
+  {{ end }}
+
+  {{ if $artistMatches }}
+    {{ $releases = $releases | append $release }}
+  {{ end }}
+{{ end }}
+
+{{ if gt (len $releases) 0 }}
+  <section class="mb-10 not-prose" role="region" aria-labelledby="artist-featured-releases-heading">
+    <h2 id="artist-featured-releases-heading" class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">
+      Releases Featured on Sundown Sessions
+    </h2>
+    <div class="release-discover-more__grid">
+      {{ range first 6 ($releases.ByTitle) }}
+        {{ $release := . }}
+        {{ $artworkParam := $release.Params.artwork | default $release.Params.cover | default $release.Params.image | default $release.Params.featureimage | default $release.Params.featured_image }}
+        {{ $artwork := "" }}
+        {{ $artworkURL := "" }}
+        {{ with $artworkParam }}
+          {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+            {{ $artworkURL = . }}
+          {{ else }}
+            {{ $artwork = $release.Resources.GetMatch . }}
+            {{ if not $artwork }}{{ $artwork = $release.Resources.GetMatch (path.Base .) }}{{ end }}
+            {{ if not $artwork }}{{ $artwork = resources.Get . }}{{ end }}
+            {{ if not $artwork }}{{ $artworkURL = . | relURL }}{{ end }}
+          {{ end }}
+        {{ end }}
+        {{ if not (or $artwork $artworkURL) }}
+          {{ $images := $release.Resources.ByType "image" }}
+          {{ range slice "*artwork*" "*cover*" "*image*" "*feature*" "*thumbnail*" }}
+            {{ if not $artwork }}{{ $artwork = $images.GetMatch . }}{{ end }}
+          {{ end }}
+        {{ end }}
+        {{ if not $artworkURL }}{{ with $artwork }}{{ $artworkURL = .RelPermalink }}{{ end }}{{ end }}
+
+        <article class="release-discover-card">
+          <a class="release-discover-card__link" href="{{ $release.RelPermalink }}">
+            {{ with $artworkURL }}
+              <span class="release-discover-card__media">
+                <img src="{{ . }}" alt="{{ $release.Title }} artwork" loading="lazy" decoding="async">
+              </span>
+            {{ end }}
+            <span class="release-discover-card__body">
+              <span class="release-discover-card__title">{{ $release.Title | emojify }}</span>
+              {{ with ($release.Params.releaseDate | default $release.Params.release_date | default $release.Params.releaseType | default $release.Params.release_type) }}
+                <span class="release-discover-card__meta">{{ . }}</span>
+              {{ end }}
+            </span>
+          </a>
+        </article>
+      {{ end }}
+    </div>
+  </section>
+{{ end }}

--- a/src/layouts/partials/artist-featured-tracks.html
+++ b/src/layouts/partials/artist-featured-tracks.html
@@ -1,0 +1,36 @@
+{{/* Tracks connected to an artist through track front matter. */}}
+
+{{ $artistKey := lower (urlize .Title) }}
+{{ $tracks := slice }}
+
+{{ range where site.RegularPages "Section" "tracks" }}
+  {{ $track := . }}
+  {{ $trackArtist := .Params.artist | default .Params.artists | default "" }}
+  {{ $matched := false }}
+  {{ if reflect.IsSlice $trackArtist }}
+    {{ range $trackArtist }}
+      {{ if eq (lower (urlize (printf "%v" .))) $artistKey }}{{ $matched = true }}{{ end }}
+    {{ end }}
+  {{ else }}
+    {{ if eq (lower (urlize (printf "%v" $trackArtist))) $artistKey }}{{ $matched = true }}{{ end }}
+  {{ end }}
+  {{ if $matched }}{{ $tracks = $tracks | append $track }}{{ end }}
+{{ end }}
+
+{{ if gt (len $tracks) 0 }}
+  <section class="release-featured-shows not-prose" role="region" aria-labelledby="artist-featured-tracks-heading">
+    <h2 id="artist-featured-tracks-heading" class="release-featured-shows__heading">Tracks Featured on Sundown Sessions</h2>
+    <ul class="release-featured-shows__list">
+      {{ range first 12 ($tracks.ByTitle) }}
+        <li class="release-featured-shows__row">
+          <a class="release-featured-shows__link" href="{{ .RelPermalink }}">
+            <span class="release-featured-shows__title">{{ .Title | emojify }}</span>
+            {{ with .Params.release }}
+              <span class="release-featured-shows__date">{{ . }}</span>
+            {{ end }}
+          </a>
+        </li>
+      {{ end }}
+    </ul>
+  </section>
+{{ end }}

--- a/src/layouts/partials/show/featured-artists.html
+++ b/src/layouts/partials/show/featured-artists.html
@@ -1,0 +1,22 @@
+{{ $artistPages := slice }}
+{{ $artistLookup := dict }}
+{{ range where site.RegularPages ".Params.artist_page" true }}
+  {{ $artistLookup = merge $artistLookup (dict (lower .Title) .) }}
+{{ end }}
+
+{{ range .Params.tags | default (slice) }}
+  {{ with index $artistLookup (lower .) }}
+    {{ $artistPages = $artistPages | append . }}
+  {{ end }}
+{{ end }}
+
+{{ if gt (len $artistPages) 0 }}
+  <section class="mb-10 not-prose" role="region" aria-labelledby="show-featured-artists-heading">
+    <h2 id="show-featured-artists-heading" class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">Featured Artists</h2>
+    <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4" role="list">
+      {{ range first 12 $artistPages }}
+        {{ partial "article-link/artist-card.html" . }}
+      {{ end }}
+    </div>
+  </section>
+{{ end }}

--- a/src/layouts/partials/show/featured-releases.html
+++ b/src/layouts/partials/show/featured-releases.html
@@ -1,0 +1,46 @@
+{{ $showRefs := slice }}
+{{ with .File }}
+  {{ $showRefs = $showRefs | append (path.Base (strings.TrimSuffix "/" .Dir)) }}
+{{ end }}
+{{ $showRefs = $showRefs | append .Slug | append (strings.TrimSuffix "/" (strings.TrimPrefix "/" .RelPermalink)) }}
+{{ $releasePages := slice }}
+
+{{ range where site.RegularPages "Section" "releases" }}
+  {{ $release := . }}
+  {{ $matched := false }}
+  {{ with ($release.Params.featuredInShows | default $release.Params.featured_in_shows | default $release.Params.shows) }}
+    {{ $entries := . }}
+    {{ if not (reflect.IsSlice $entries) }}{{ $entries = slice $entries }}{{ end }}
+    {{ range $entry := $entries }}
+      {{ $ref := "" }}
+      {{ if reflect.IsMap $entry }}
+        {{ $ref = index $entry "show" | default (index $entry "page") | default (index $entry "path") | default (index $entry "slug") | default (index $entry "url") | default "" }}
+      {{ else }}
+        {{ $ref = $entry }}
+      {{ end }}
+      {{ $ref = lower (strings.TrimSuffix "/" (strings.TrimPrefix "/" (printf "%v" $ref))) }}
+      {{ range $showRefs }}
+        {{ if eq $ref (lower (strings.TrimSuffix "/" (strings.TrimPrefix "/" (printf "%v" .)))) }}{{ $matched = true }}{{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ if $matched }}{{ $releasePages = $releasePages | append $release }}{{ end }}
+{{ end }}
+
+{{ if gt (len $releasePages) 0 }}
+  <section class="mb-10 not-prose" role="region" aria-labelledby="show-featured-releases-heading">
+    <h2 id="show-featured-releases-heading" class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">Featured Releases</h2>
+    <div class="release-discover-more__grid">
+      {{ range first 6 $releasePages }}
+        <article class="release-discover-card">
+          <a class="release-discover-card__link" href="{{ .RelPermalink }}">
+            <span class="release-discover-card__body">
+              <span class="release-discover-card__title">{{ .Title | emojify }}</span>
+              {{ with .Params.artist }}<span class="release-discover-card__artist">{{ . }}</span>{{ end }}
+            </span>
+          </a>
+        </article>
+      {{ end }}
+    </div>
+  </section>
+{{ end }}

--- a/src/layouts/partials/show/hero.html
+++ b/src/layouts/partials/show/hero.html
@@ -1,0 +1,50 @@
+{{ $featureImage := .Params.featureimage | default .Params.featured_image }}
+{{ $featured := "" }}
+{{ $featuredURL := "" }}
+{{ with $featureImage }}
+  {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+    {{ $featuredURL = . }}
+  {{ else }}
+    {{ $featured = $.Resources.GetMatch . }}
+    {{ if not $featured }}{{ $featured = $.Resources.GetMatch (path.Base .) }}{{ end }}
+    {{ if not $featured }}{{ $featured = resources.Get . }}{{ end }}
+    {{ if not $featured }}{{ $featuredURL = . | relURL }}{{ end }}
+  {{ end }}
+{{ end }}
+{{ if not (or $featured $featuredURL) }}
+  {{ $images := .Resources.ByType "image" }}
+  {{ range slice "*show-logo*" "*feature*" "*cover*" "*thumbnail*" }}
+    {{ if not $featured }}{{ $featured = $images.GetMatch . }}{{ end }}
+  {{ end }}
+{{ end }}
+{{ if not $featuredURL }}{{ with $featured }}{{ $featuredURL = .RelPermalink }}{{ end }}{{ end }}
+
+<section class="mb-10 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70" role="region" aria-labelledby="show-hero-heading">
+  <div class="flex flex-col sm:flex-row">
+    {{ with $featuredURL }}
+      <div class="flex items-center justify-center bg-neutral-100 p-4 dark:bg-neutral-800 sm:w-64 sm:shrink-0">
+        <img src="{{ . }}" alt="{{ $.Title }} artwork" loading="eager" decoding="async" fetchpriority="high" class="nozoom h-auto max-h-96 w-full object-contain">
+      </div>
+    {{ end }}
+    <div class="flex flex-1 flex-col justify-center gap-4 p-6 sm:p-8">
+      {{ if $.Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
+        <div class="mb-1 text-sm">{{ partial "breadcrumbs.html" $ }}</div>
+      {{ end }}
+      <p class="mb-0 text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Broadcast</p>
+      <h1 id="show-hero-heading" class="mt-0 text-3xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral sm:text-4xl lg:text-5xl">
+        {{ $.Title | emojify }}
+      </h1>
+      {{ with $.Description }}
+        <p class="text-base text-neutral-600 dark:text-neutral-300">{{ . }}</p>
+      {{ end }}
+      {{ if not $.Date.IsZero }}
+        <dl class="artist-header-stats">
+          <div>
+            <dt>Broadcast Date</dt>
+            <dd>{{ $.Date | time.Format (site.Params.dateFormat | default "2 January 2006") }}</dd>
+          </div>
+        </dl>
+      {{ end }}
+    </div>
+  </div>
+</section>

--- a/src/layouts/partials/show/listen-again.html
+++ b/src/layouts/partials/show/listen-again.html
@@ -1,0 +1,39 @@
+{{ $links := slice }}
+{{ range $field := slice .Params.listenAgain .Params.listen_again .Params.listen .Params.links }}
+  {{ with $field }}
+    {{ if reflect.IsMap . }}
+      {{ range $key, $value := . }}
+        {{ $url := "" }}
+        {{ $label := $key }}
+        {{ if reflect.IsMap $value }}
+          {{ $url = index $value "url" | default (index $value "href") | default (index $value "link") | default "" }}
+          {{ $label = index $value "label" | default (index $value "title") | default $key }}
+        {{ else }}
+          {{ $url = $value }}
+        {{ end }}
+        {{ with $url }}{{ $links = $links | append (dict "url" . "label" $label "icon" "play") }}{{ end }}
+      {{ end }}
+    {{ else if reflect.IsSlice . }}
+      {{ range . }}
+        {{ if reflect.IsMap . }}
+          {{ $url := index . "url" | default (index . "href") | default (index . "link") | default "" }}
+          {{ $label := index . "label" | default (index . "title") | default "Listen Again" }}
+          {{ with $url }}{{ $links = $links | append (dict "url" . "label" $label "icon" "play") }}{{ end }}
+        {{ else }}
+          {{ $links = $links | append (dict "url" . "label" "Listen Again" "icon" "play") }}
+        {{ end }}
+      {{ end }}
+    {{ else }}
+      {{ $links = $links | append (dict "url" . "label" "Listen Again" "icon" "play") }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ partial "components/explore-further.html" (dict
+  "links" $links
+  "heading" "Listen Again"
+  "headingId" "show-listen-again-heading"
+  "sectionClass" "mb-10 max-w-prose not-prose"
+  "rowClass" "explore-further__row"
+  "iconClass" "explore-further__icon"
+) }}

--- a/src/layouts/partials/show/more-shows.html
+++ b/src/layouts/partials/show/more-shows.html
@@ -1,0 +1,19 @@
+{{ $shows := where site.RegularPages "Section" "shows" }}
+{{ $current := . }}
+{{ $moreShows := slice }}
+{{ range $shows.ByDate.Reverse }}
+  {{ if and (ne .RelPermalink $current.RelPermalink) (lt (len $moreShows) 4) }}
+    {{ $moreShows = $moreShows | append . }}
+  {{ end }}
+{{ end }}
+
+{{ if gt (len $moreShows) 0 }}
+  <section class="mb-10 not-prose" role="region" aria-labelledby="more-shows-heading">
+    <h2 id="more-shows-heading" class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">More Shows</h2>
+    <div class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {{ range $moreShows }}
+        {{ partial "article-link/card.html" . }}
+      {{ end }}
+    </div>
+  </section>
+{{ end }}

--- a/src/layouts/partials/track/details.html
+++ b/src/layouts/partials/track/details.html
@@ -1,0 +1,21 @@
+{{ $fields := slice }}
+{{ with .Params.artist }}{{ $fields = $fields | append (dict "term" "Artist" "value" .) }}{{ end }}
+{{ with .Params.release }}{{ $fields = $fields | append (dict "term" "Release" "value" .) }}{{ end }}
+{{ with .Params.release_date }}{{ $fields = $fields | append (dict "term" "Released" "value" .) }}{{ end }}
+{{ with .Params.duration }}{{ $fields = $fields | append (dict "term" "Duration" "value" .) }}{{ end }}
+{{ with .Params.label }}{{ $fields = $fields | append (dict "term" "Label" "value" .) }}{{ end }}
+{{ with .Params.genre }}{{ $fields = $fields | append (dict "term" "Genre" "value" .) }}{{ end }}
+
+{{ if gt (len $fields) 0 }}
+  <section class="mb-10 max-w-prose rounded-lg border border-neutral-200 bg-neutral-50/70 p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/60" role="region" aria-labelledby="track-details-heading">
+    <h2 id="track-details-heading" class="mt-0 mb-4 text-xl font-bold text-neutral-800 dark:text-neutral-100">Track Details</h2>
+    <dl class="m-0 grid gap-x-6 gap-y-3 sm:grid-cols-2">
+      {{ range $fields }}
+        <div class="min-w-0 border-t border-neutral-200 pt-3 first:border-t-0 first:pt-0 sm:first:border-t sm:first:pt-3 dark:border-neutral-700">
+          <dt class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{{ .term }}</dt>
+          <dd class="mt-1 break-words text-base font-medium text-neutral-900 dark:text-neutral-100">{{ .value }}</dd>
+        </div>
+      {{ end }}
+    </dl>
+  </section>
+{{ end }}

--- a/src/layouts/partials/track/explore-further.html
+++ b/src/layouts/partials/track/explore-further.html
@@ -1,0 +1,23 @@
+{{ $rawLinks := slice }}
+{{ $externalSection := "" }}
+{{ range split .RawContent "\n## " }}
+  {{ $section := . | strings.TrimSpace }}
+  {{ if or (hasPrefix $section "External Links") (hasPrefix $section "Explore Further") }}
+    {{ $externalSection = $section }}
+  {{ end }}
+{{ end }}
+{{ $linkPattern := `(?m)^\s*-\s+\{\{<\s*new-tab-link\s+"(?:([^":\[]+):\s+)?\[([^\]]+)\]\((https?://[^)]+)\)"\s*>\}\}\s*$` }}
+{{ range findRESubmatch $linkPattern $externalSection }}
+  {{ $label := printf "%v" (index . 1 | default (index . 2)) | strings.TrimSpace }}
+  {{ $url := printf "%v" (index . 3 | default "") | strings.TrimSpace }}
+  {{ if $url }}{{ $rawLinks = $rawLinks | append (dict "url" $url "label" ($label | default "External Link") "icon" "link") }}{{ end }}
+{{ end }}
+
+{{ partial "components/explore-further.html" (dict
+  "links" $rawLinks
+  "heading" "Explore Further"
+  "headingId" "track-explore-further-heading"
+  "sectionClass" "mb-10 max-w-prose not-prose"
+  "rowClass" "explore-further__row"
+  "iconClass" "explore-further__icon"
+) }}

--- a/src/layouts/partials/track/featured-shows.html
+++ b/src/layouts/partials/track/featured-shows.html
@@ -1,0 +1,35 @@
+{{ $artist := lower (printf "%v" (.Params.artist | default "")) }}
+{{ $title := lower .Title }}
+{{ $featuredShows := slice }}
+
+{{ range where site.RegularPages "Section" "shows" }}
+  {{ $show := . }}
+  {{ $showText := lower .RawContent }}
+  {{ with .File }}
+    {{ $trackInfoPath := printf "content/%s/track-info.md" (path.Dir (replace .Path "\\" "/")) }}
+    {{ if fileExists $trackInfoPath }}
+      {{ $showText = printf "%s\n%s" $showText (lower (readFile $trackInfoPath)) }}
+    {{ end }}
+  {{ end }}
+  {{ if and (in $showText $title) (or (not $artist) (in $showText $artist)) }}
+    {{ $featuredShows = $featuredShows | append $show }}
+  {{ end }}
+{{ end }}
+
+{{ if gt (len $featuredShows) 0 }}
+  <section class="release-featured-shows not-prose" role="region" aria-labelledby="track-featured-shows-heading">
+    <h2 id="track-featured-shows-heading" class="release-featured-shows__heading">Featured in Shows</h2>
+    <ul class="release-featured-shows__list">
+      {{ range $featuredShows.ByDate.Reverse }}
+        <li class="release-featured-shows__row">
+          <a class="release-featured-shows__link" href="{{ .RelPermalink }}">
+            <span class="release-featured-shows__title">{{ partial "release/show-card-title.html" . }}</span>
+            {{ if not .Date.IsZero }}
+              <span class="release-featured-shows__date">{{ .Date | time.Format (site.Params.dateFormat | default "2 January 2006") }}</span>
+            {{ end }}
+          </a>
+        </li>
+      {{ end }}
+    </ul>
+  </section>
+{{ end }}

--- a/src/layouts/partials/track/hero.html
+++ b/src/layouts/partials/track/hero.html
@@ -1,0 +1,20 @@
+{{ $artist := .Params.artist | default .Params.artists }}
+{{ if reflect.IsSlice $artist }}{{ $artist = delimit $artist ", " }}{{ end }}
+{{ $release := .Params.release | default .Params.album }}
+
+<header id="single_header" class="mb-8 max-w-prose">
+  {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
+    <div class="mb-5">
+      {{ partial "breadcrumbs.html" . }}
+    </div>
+  {{ end }}
+  <p class="mb-2 text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Track</p>
+  <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
+    {{ .Title | emojify }}
+  </h1>
+  {{ if or $artist $release }}
+    <p class="mt-2 text-lg font-medium text-neutral-700 dark:text-neutral-300">
+      {{ with $artist }}{{ . }}{{ end }}{{ if and $artist $release }} &middot; {{ end }}{{ with $release }}{{ . }}{{ end }}
+    </p>
+  {{ end }}
+</header>

--- a/src/layouts/partials/track/related-tracks.html
+++ b/src/layouts/partials/track/related-tracks.html
@@ -1,0 +1,30 @@
+{{ $current := . }}
+{{ $artist := lower (urlize (printf "%v" (.Params.artist | default ""))) }}
+{{ $release := lower (urlize (printf "%v" (.Params.release | default ""))) }}
+{{ $related := slice }}
+
+{{ range where site.RegularPages "Section" "tracks" }}
+  {{ if ne .RelPermalink $current.RelPermalink }}
+    {{ $sameArtist := and $artist (eq (lower (urlize (printf "%v" (.Params.artist | default "")))) $artist) }}
+    {{ $sameRelease := and $release (eq (lower (urlize (printf "%v" (.Params.release | default "")))) $release) }}
+    {{ if or $sameArtist $sameRelease }}
+      {{ $related = $related | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ if gt (len $related) 0 }}
+  <section class="release-featured-shows not-prose" role="region" aria-labelledby="related-tracks-heading">
+    <h2 id="related-tracks-heading" class="release-featured-shows__heading">Related Tracks</h2>
+    <ul class="release-featured-shows__list">
+      {{ range first 8 ($related.ByTitle) }}
+        <li class="release-featured-shows__row">
+          <a class="release-featured-shows__link" href="{{ .RelPermalink }}">
+            <span class="release-featured-shows__title">{{ .Title | emojify }}</span>
+            {{ with .Params.release }}<span class="release-featured-shows__date">{{ . }}</span>{{ end }}
+          </a>
+        </li>
+      {{ end }}
+    </ul>
+  </section>
+{{ end }}

--- a/src/layouts/shows/single.html
+++ b/src/layouts/shows/single.html
@@ -1,0 +1,49 @@
+{{ define "main" }}
+  {{ .Scratch.Set "scope" "single" }}
+  <article>
+    {{ partial "show/hero.html" . }}
+
+    <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
+      {{ $enableToc := site.Params.article.showTableOfContents | default false }}
+      {{ $enableToc = .Params.showTableOfContents | default (.Params.toc | default $enableToc) }}
+      {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+      {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+      {{ if $showToc }}
+        <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
+          <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+            {{ partial "toc.html" . }}
+          </div>
+        </div>
+      {{ end }}
+
+      <div class="min-w-0 min-h-0 max-w-fit">
+        {{ partial "series/series.html" . }}
+        <div class="article-content max-w-prose mb-10">
+          {{ .Content }}
+        </div>
+        {{ partial "show/featured-artists.html" . }}
+        {{ partial "show/featured-releases.html" . }}
+        {{ partial "show/listen-again.html" . }}
+        {{ partial "show/more-shows.html" . }}
+        {{ partial "series/series-closed.html" . }}
+        {{ partial "sharing-links.html" . }}
+        {{ partial "related.html" . }}
+      </div>
+    </section>
+
+    {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
+      <footer class="pt-8 max-w-prose print:hidden">
+        {{ if templates.Exists "partials/comments.html" }}
+          <div class="pt-3">
+            <hr class="border-dotted border-neutral-300 dark:border-neutral-600" />
+            <div class="pt-3">
+              {{ partial "comments.html" . }}
+            </div>
+          </div>
+        {{ else }}
+          {{ warnf "[BLOWFISH] Comments are enabled for %s but no comments partial exists." .File.Path }}
+        {{ end }}
+      </footer>
+    {{ end }}
+  </article>
+{{ end }}

--- a/src/layouts/tracks/single.html
+++ b/src/layouts/tracks/single.html
@@ -1,0 +1,51 @@
+{{ define "main" }}
+  {{ .Scratch.Set "scope" "single" }}
+  <article>
+    {{ partial "track/hero.html" . }}
+    {{ partial "track/details.html" . }}
+
+    <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
+      {{ $enableToc := site.Params.article.showTableOfContents | default false }}
+      {{ $enableToc = .Params.showTableOfContents | default $enableToc }}
+      {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+      {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+      {{ if $showToc }}
+        <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
+          <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+            {{ partial "toc.html" . }}
+          </div>
+        </div>
+      {{ end }}
+
+      <div class="min-w-0 min-h-0 max-w-fit">
+        {{ partial "series/series.html" . }}
+        <div class="article-content max-w-prose mb-10">
+          {{ $trackContent := .Content | strings.TrimSpace }}
+          {{ $trackContent = replaceRE `(?is)<h2\b[^>]*>\s*(External Links|Explore Further)\s*.*?</h2>\s*.*?(<h2\b[^>]*>|$)` "$2" $trackContent | strings.TrimSpace }}
+          {{ $trackContent | safeHTML }}
+        </div>
+        {{ partial "track/featured-shows.html" . }}
+        {{ partial "track/related-tracks.html" . }}
+        {{ partial "track/explore-further.html" . }}
+        {{ partial "series/series-closed.html" . }}
+        {{ partial "sharing-links.html" . }}
+        {{ partial "related.html" . }}
+      </div>
+    </section>
+
+    {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
+      <footer class="pt-8 max-w-prose print:hidden">
+        {{ if templates.Exists "partials/comments.html" }}
+          <div class="pt-3">
+            <hr class="border-dotted border-neutral-300 dark:border-neutral-600" />
+            <div class="pt-3">
+              {{ partial "comments.html" . }}
+            </div>
+          </div>
+        {{ else }}
+          {{ warnf "[BLOWFISH] Comments are enabled for %s but no comments partial exists." .File.Path }}
+        {{ end }}
+      </footer>
+    {{ end }}
+  </article>
+{{ end }}


### PR DESCRIPTION
## Summary
- add local show and track single templates with shared archive-style structure
- add reusable show and track partials for heroes, details, internal links, and discovery sections
- align artist pages so biography is followed by featured releases, tracks, shows, related artists, and Explore Further links

## Validation
- Used Hugo 0.146.5 extended in a temp location, matching CI.
- Direct build is blocked by existing content issues outside this change:
  - malformed YAML in `src/content/releases/w/white-lies/as-i-try-not-to-fall-apart/index.md`
  - Windows-invalid taxonomy output from label `Warner/Chappell Music, Inc.`
- Template validation passed in a temporary copy after excluding those existing content blockers: 1757 pages rendered.