### PR TITLE
Fix release content build blockers

### DIFF
--- a/src/content/releases/l/led-zeppelin/led-zeppelin/index.md
+++ b/src/content/releases/l/led-zeppelin/led-zeppelin/index.md
@@ -4,7 +4,7 @@ artist: "Led Zeppelin"
 releaseDate: "2001"
 releaseType: "Album"
 labels:
-  - "Warner/Chappell Music, Inc."
+  - "Warner Chappell Music Inc"
 duration: "3:37:34"
 featuredInShows:
   - "12"

--- a/src/content/releases/w/white-lies/as-i-try-not-to-fall-apart/index.md
+++ b/src/content/releases/w/white-lies/as-i-try-not-to-fall-apart/index.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "As I Try Not To Fall Apart"
 artist: "White Lies"
 releaseDate: "2022-02-18"
@@ -8,7 +8,7 @@ genres:
   - "offizielle charts"
   - "laut.de"
   - "ph_temp_checken"
-  - "1â4 wochen"
+  - "1-4 wochen"
 labels:
   - "[PIAS] Recordings"
 duration: "0:47:30"
@@ -26,7 +26,7 @@ tracks:
   - title: "Breathe"
     trackNumber: 3
     duration: "04:46"
-  - title: "I Don’t Want to Go to Mars"
+  - title: "I Don't Want to Go to Mars"
     trackNumber: 4
     duration: "04:38"
   - title: "Step Outside"
@@ -55,5 +55,3 @@ lastmod: "2026-06-25"
 ## About
 
 As I Try Not To Fall Apart is a release by White Lies released in 2022-02-18. It has been featured on 1 Sundown Sessions show. Featured tracks include I Don't Want To Go To Mars.
-
-


### PR DESCRIPTION
## Summary
- remove the BOM/control character from the White Lies release front matter
- normalize mojibake and curly punctuation in that release page
- normalize the Led Zeppelin label value so Hugo does not generate a problematic taxonomy path

## Context
PR #603 was merged before this content-fix commit was pushed to its branch, so this follow-up carries only the missed build-blocker fixes.

## Validation
- `hugo --source src --printPathWarnings --panicOnWarning --environment production --baseURL https://example.invalid/`
- Result: 1767 pages rendered successfully.