### PR TITLE
Remove breadcrumb from release pages

### DIFF
--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -1,12 +1,6 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "single" }}
   <article>
-    {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
-      <div class="mb-5 max-w-prose">
-        {{ partial "breadcrumbs.html" . }}
-      </div>
-    {{ end }}
-
     {{ partial "release/hero.html" . }}
     {{ partial "release/metadata-card.html" . }}
     {{ partial "release/artists.html" . }}


### PR DESCRIPTION
## Summary
- remove the breadcrumb block from the local release single template
- let release pages begin directly with the release hero
- leave list, taxonomy, theme, and other content-type templates unchanged

## Validation
- confirmed release layouts/partials no longer render breadcrumbs
- \\hugo --gc --minify\\ not run locally because Hugo is not installed on this PATH