### PR TITLE
feat(src): add provider agnostic analytics layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ hugo --environment production
 
 The local site is available at [http://localhost:1313](http://localhost:1313) by default.
 
+### Website Analytics
+
+Analytics is configured under `params.analytics` in
+[`src/config/_default/params.toml`](src/config/_default/params.toml).
+Placeholder values disable providers, so no live provider scripts are loaded
+until real IDs are supplied.
+
+- GA4 requires replacing `todo-measurement_id` with a real measurement ID.
+- Microsoft Clarity requires replacing `todo-project_id` with a real project ID.
+- Plausible and self-hosted Umami are reserved in configuration for future use.
+- Custom events are sent through `window.sundownAnalytics.track(...)`.
+
 ### ContentOps .NET Local Setup
 
 Prerequisites:

--- a/src/config/_default/params.toml
+++ b/src/config/_default/params.toml
@@ -17,6 +17,20 @@ mainSections = ["shows", "releases", "artists"]
 # a follow-up slice; kept here so editorial config remains in a single file.
 listen_live_stream_url = ""
 
+[analytics]
+  [analytics.google]
+    measurementId = "todo-measurement_id"
+
+  [analytics.clarity]
+    projectId = "todo-project_id"
+
+  [analytics.plausible]
+    domain = "todo-domain"
+
+  [analytics.umami]
+    websiteId = "todo-website_id"
+    scriptUrl = "todo-script_url"
+
 # Path to the circular avatar image displayed in the header alongside the site title.
 # Resolved as a static file path (e.g. /images/my-logo.jpg).
 headerAvatar = "/images/sundown-sessions-logo.jpg"

--- a/src/layouts/partials/analytics-clarity.html
+++ b/src/layouts/partials/analytics-clarity.html
@@ -1,0 +1,13 @@
+{{- $projectId := "" -}}
+{{- with .Site.Params.analytics.clarity.projectId -}}
+  {{- $projectId = strings.TrimSpace . -}}
+{{- end -}}
+{{- if and $projectId (ne $projectId "todo-project_id") -}}
+  <script>
+    (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "{{ $projectId }}");
+  </script>
+{{- end -}}

--- a/src/layouts/partials/analytics-events.html
+++ b/src/layouts/partials/analytics-events.html
@@ -1,0 +1,100 @@
+{{- $pageType := .Section | default .Kind -}}
+{{- $viewEvent := "" -}}
+{{- if and .IsPage (eq .Section "artists") -}}
+  {{- $viewEvent = "artist_view" -}}
+{{- else if and .IsPage (eq .Section "releases") -}}
+  {{- $viewEvent = "release_view" -}}
+{{- else if and .IsPage (eq .Section "tracks") -}}
+  {{- $viewEvent = "track_view" -}}
+{{- end -}}
+<script>
+  window.sundownAnalytics = window.sundownAnalytics || {};
+
+  window.sundownAnalytics.track = function(eventName, params) {
+    params = params || {};
+
+    if (typeof window.gtag === "function") {
+      window.gtag("event", eventName, params);
+    }
+
+    if (typeof window.clarity === "function") {
+      window.clarity("event", eventName);
+    }
+  };
+
+  (function() {
+    const pageParams = {
+      title: {{ .Title | plainify | jsonify | safeJS }},
+      page_type: {{ $pageType | jsonify | safeJS }},
+      url: {{ .RelPermalink | jsonify | safeJS }}
+    };
+
+    function textFor(element) {
+      return (element.textContent || element.getAttribute("aria-label") || element.title || "").trim();
+    }
+
+    function closestFromEvent(event, selector) {
+      const target = event.target;
+      if (!target) return null;
+      const element = target.closest ? target : target.parentElement;
+      return element && element.closest ? element.closest(selector) : null;
+    }
+
+    document.addEventListener("click", event => {
+      const tracked = closestFromEvent(event, "[data-analytics-event]");
+      if (tracked) {
+        const params = Object.assign({}, pageParams, {
+          destination: tracked.href || tracked.getAttribute("action") || "",
+          taxonomy: tracked.dataset.analyticsTaxonomy || "",
+          provider: tracked.dataset.analyticsProvider || "",
+          link_text: textFor(tracked)
+        });
+        window.sundownAnalytics.track(tracked.dataset.analyticsEvent, params);
+      }
+
+      const link = closestFromEvent(event, "a[href]");
+      if (!link) return;
+
+      try {
+        const destination = new URL(link.href, window.location.href);
+        if ((destination.protocol === "http:" || destination.protocol === "https:") && destination.hostname !== window.location.hostname) {
+          window.sundownAnalytics.track("external_link_click", {
+            destination: destination.hostname,
+            link_text: textFor(link),
+            current_path: window.location.pathname
+          });
+        }
+      } catch (_) {}
+    });
+
+    document.addEventListener("submit", event => {
+      const form = closestFromEvent(event, "[data-analytics-event]");
+      if (!form) return;
+      window.sundownAnalytics.track(form.dataset.analyticsEvent, Object.assign({}, pageParams, {
+        destination: form.action || "",
+        provider: form.dataset.analyticsProvider || ""
+      }));
+    });
+
+    document.addEventListener("input", event => {
+      const input = closestFromEvent(event, "input[type='search'], #search-query, #search input");
+      if (!input) return;
+      window.clearTimeout(input.dataset.analyticsSearchTimer);
+      input.dataset.analyticsSearchTimer = window.setTimeout(() => {
+        const query = (input.value || "").trim();
+        if (query.length < 2) return;
+        window.sundownAnalytics.track("search", {
+          query: query,
+          page_type: "search",
+          url: window.location.pathname
+        });
+      }, 800);
+    });
+
+    {{- with $viewEvent }}
+      window.addEventListener("DOMContentLoaded", () => {
+        window.sundownAnalytics.track({{ . | jsonify | safeJS }}, pageParams);
+      }, { once: true });
+    {{- end }}
+  })();
+</script>

--- a/src/layouts/partials/analytics-google.html
+++ b/src/layouts/partials/analytics-google.html
@@ -1,0 +1,13 @@
+{{- $measurementId := "" -}}
+{{- with .Site.Params.analytics.google.measurementId -}}
+  {{- $measurementId = strings.TrimSpace . -}}
+{{- end -}}
+{{- if and $measurementId (ne $measurementId "todo-measurement_id") -}}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ $measurementId }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "{{ $measurementId }}");
+  </script>
+{{- end -}}

--- a/src/layouts/partials/analytics.html
+++ b/src/layouts/partials/analytics.html
@@ -1,0 +1,23 @@
+{{- partial "analytics-events.html" . -}}
+
+{{- $googleId := "" -}}
+{{- with .Site.Params.analytics.google.measurementId -}}
+  {{- $googleId = strings.TrimSpace . -}}
+{{- end -}}
+{{- if and $googleId (ne $googleId "todo-measurement_id") -}}
+  {{- partial "analytics-google.html" . -}}
+{{- end -}}
+
+{{- $clarityId := "" -}}
+{{- with .Site.Params.analytics.clarity.projectId -}}
+  {{- $clarityId = strings.TrimSpace . -}}
+{{- end -}}
+{{- if and $clarityId (ne $clarityId "todo-project_id") -}}
+  {{- partial "analytics-clarity.html" . -}}
+{{- end -}}
+
+{{/*
+Future provider placeholders:
+- Plausible: .Site.Params.analytics.plausible.domain
+- Umami: .Site.Params.analytics.umami.websiteId and .Site.Params.analytics.umami.scriptUrl
+*/}}

--- a/src/layouts/partials/components/explore-further.html
+++ b/src/layouts/partials/components/explore-further.html
@@ -24,6 +24,12 @@
           <a
             class="{{ $rowClass }} flex w-full items-center justify-between gap-4 px-4 py-3 text-neutral-700 no-underline transition dark:text-neutral-200"
             href="{{ $link.url | safeURL }}"
+            {{ with $link.analyticsEvent }}
+              data-analytics-event="{{ . }}"
+            {{ end }}
+            {{ with $link.provider }}
+              data-analytics-provider="{{ . }}"
+            {{ end }}
             target="_blank"
             rel="noopener noreferrer external"
             aria-label="{{ $label }} (opens in a new tab)">

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -11,6 +11,8 @@
               <a
                 class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2"
                 href="{{ $listenURL }}"
+                data-analytics-event="listen_live_click"
+                data-analytics-provider="live-stream"
                 {{ if or (strings.HasPrefix $listenURL "http:") (strings.HasPrefix $listenURL "https:") }}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/src/layouts/partials/head.html
+++ b/src/layouts/partials/head.html
@@ -205,9 +205,7 @@
   {{ partial "schema.html" . }}
 
   {{/* Analytics */}}
-  {{ if hugo.IsProduction }}
-    {{ partial "analytics/main.html" . }}
-  {{ end }}
+  {{ partial "analytics.html" . }}
 
   {{/* Extend head - eg. for custom analytics scripts, etc. */}}
   {{ if templates.Exists "partials/extend-head.html" }}

--- a/src/layouts/partials/header/components/desktop-menu.html
+++ b/src/layouts/partials/header/components/desktop-menu.html
@@ -34,6 +34,8 @@
   {{ $listenURL := .Site.Params.listen_live_stream_url | default "#" }}
   <a
     href="{{ $listenURL }}"
+    data-analytics-event="listen_live_click"
+    data-analytics-provider="live-stream"
     {{ if and (ne $listenURL "#") (or (strings.HasPrefix $listenURL "http:") (strings.HasPrefix $listenURL "https:")) }}
       target="_blank"
       rel="noopener noreferrer"

--- a/src/layouts/partials/header/components/mobile-menu.html
+++ b/src/layouts/partials/header/components/mobile-menu.html
@@ -141,6 +141,8 @@
   <div class="px-2">
     <a
       href="{{ $listenURL }}"
+      data-analytics-event="listen_live_click"
+      data-analytics-provider="live-stream"
       {{ if and (ne $listenURL "#") (or (strings.HasPrefix $listenURL "http:") (strings.HasPrefix $listenURL "https:")) }}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/layouts/partials/release/metadata-link-list.html
+++ b/src/layouts/partials/release/metadata-link-list.html
@@ -37,7 +37,9 @@
   {{- with $termPage -}}
     <a
       class="decoration-primary-500 hover:underline hover:underline-offset-2"
-      href="{{ .RelPermalink }}">{{ $value }}</a>
+      href="{{ .RelPermalink }}"
+      data-analytics-event="taxonomy_navigation"
+      data-analytics-taxonomy="{{ $taxonomyPath }}">{{ $value }}</a>
   {{- else -}}
     <span>{{ $value }}</span>
   {{- end -}}

--- a/src/layouts/partials/show/listen-again.html
+++ b/src/layouts/partials/show/listen-again.html
@@ -11,20 +11,20 @@
         {{ else }}
           {{ $url = $value }}
         {{ end }}
-        {{ with $url }}{{ $links = $links | append (dict "url" . "label" $label "icon" "play") }}{{ end }}
+        {{ with $url }}{{ $links = $links | append (dict "url" . "label" $label "icon" "play" "analyticsEvent" "listen_again_click" "provider" $label) }}{{ end }}
       {{ end }}
     {{ else if reflect.IsSlice . }}
       {{ range . }}
         {{ if reflect.IsMap . }}
           {{ $url := index . "url" | default (index . "href") | default (index . "link") | default "" }}
           {{ $label := index . "label" | default (index . "title") | default "Listen Again" }}
-          {{ with $url }}{{ $links = $links | append (dict "url" . "label" $label "icon" "play") }}{{ end }}
+          {{ with $url }}{{ $links = $links | append (dict "url" . "label" $label "icon" "play" "analyticsEvent" "listen_again_click" "provider" $label) }}{{ end }}
         {{ else }}
-          {{ $links = $links | append (dict "url" . "label" "Listen Again" "icon" "play") }}
+          {{ $links = $links | append (dict "url" . "label" "Listen Again" "icon" "play" "analyticsEvent" "listen_again_click" "provider" "Listen Again") }}
         {{ end }}
       {{ end }}
     {{ else }}
-      {{ $links = $links | append (dict "url" . "label" "Listen Again" "icon" "play") }}
+      {{ $links = $links | append (dict "url" . "label" "Listen Again" "icon" "play" "analyticsEvent" "listen_again_click" "provider" "Listen Again") }}
     {{ end }}
   {{ end }}
 {{ end }}

--- a/src/layouts/shortcodes/form-contact.html
+++ b/src/layouts/shortcodes/form-contact.html
@@ -3,7 +3,7 @@
 {{ $statusID := printf "contact-form-status-%d" .Ordinal }}
 {{ if $action }}
   <div class="not-prose mt-10 rounded-2xl border border-neutral-300 bg-neutral-50 px-6 py-6 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
-    <form id="{{ $formID }}" action="{{ $action }}" method="POST" accept-charset="UTF-8" class="space-y-6">
+    <form id="{{ $formID }}" action="{{ $action }}" method="POST" accept-charset="UTF-8" class="space-y-6" data-analytics-event="contact_submit" data-analytics-provider="formspree">
       <input type="hidden" name="_subject" value="Sundown Sessions website enquiry" />
       <div class="hidden">
         <label for="{{ $formID }}-company">Company</label>


### PR DESCRIPTION
## Summary
- add placeholder-aware analytics configuration for GA4, Clarity, Plausible, and Umami
- add reusable Hugo analytics partials and a provider-neutral `window.sundownAnalytics.track(...)` wrapper
- track key discovery interactions through data attributes and central event handling
- document analytics setup and placeholder behaviour

## Verification
- `git diff --check`
- Hugo build not run locally because `hugo` is not available on PATH in this shell