### PR TITLE
feat: drive playlist sale badges from front matter

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -310,6 +310,29 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
     );
 }
 
+.for-sale-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-left: 0.4rem;
+  border: 1px solid #f59e0b; /* amber-500 */
+  border-radius: 999px;
+  background-color: #fffbeb; /* amber-50 */
+  padding: 0.12rem 0.5rem;
+  vertical-align: baseline;
+  color: #92400e; /* amber-800 */
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.dark .for-sale-badge {
+  border-color: #fbbf24; /* amber-400 */
+  background-color: rgba(120, 53, 15, 0.35); /* amber-900/35 */
+  color: #fde68a; /* amber-200 */
+}
+
 /* Release artists: compact creator profile links between release metadata and
    the About section. */
 

--- a/src/content/shows/56/playlist
+++ b/src/content/shows/56/playlist
@@ -1,4 +1,8 @@
 ---
+forSaleTracks:
+  - "Scarlet Joy - Cut Diamond"
+  - "Scarlet Joy - Rescue"
+  - "Scarlet Joy - Back For More"
 ---
 01. Show Intro - Poltergeist Theme - 00:00:00
 02. Viagra Boys - Research Chemicals - 00:05:52
@@ -7,7 +11,7 @@
 
 ADVERTS - 00:29:01
 
-05. Scarlet Joy - Cut Diamond - 00:31:09 {{< for-sale >}}
+05. Scarlet Joy - Cut Diamond - 00:31:09
 06. The Creation - Creation - 00:37:52
 07. Air Traffic - Charlotte - 00:41:35
 08. Assembly Now - Graphs, Maps & Trees - 00:43:55
@@ -21,10 +25,10 @@ ADVERTS - 00:29:01
 ADVERTS - 01:19:12
 
 15. PJ Harvey - Oh My Lover - 01:20:57
-16. Scarlet Joy - Rescue - 01:25:46 {{< for-sale >}}
+16. Scarlet Joy - Rescue - 01:25:46
 17. Live - Where Do We Go From Here? - 01:30:42
 18. Fiona Apple - Window - 01:39:09
 19. Angelfish - Suffocate Me - 01:47:12
 20. Goodbye Mr Mackenzie - House On Fire - 01:55:27
-21. Scarlet Joy - Back For More - 02:01:19 {{< for-sale >}}
+21. Scarlet Joy - Back For More - 02:01:19
 22. Cigarettes After Sex - Hideaway - 02:08:21

--- a/src/layouts/partials/for-sale-badge.html
+++ b/src/layouts/partials/for-sale-badge.html
@@ -1,0 +1,1 @@
+<span class="for-sale-badge">Available to buy</span>

--- a/src/layouts/shortcodes/for-sale.html
+++ b/src/layouts/shortcodes/for-sale.html
@@ -1,1 +1,1 @@
-<span class="for-sale-badge">Available to buy</span>
+{{ partial "for-sale-badge.html" . }}

--- a/src/layouts/shortcodes/include_content.html
+++ b/src/layouts/shortcodes/include_content.html
@@ -1,3 +1,84 @@
-{{ $path := .Get 0 }}
-{{ $content := readFile (printf "content/%s.md" $path) }}
-{{ $.Page.RenderString $content }}
+{{ $path := strings.TrimPrefix "/" (.Get 0) }}
+{{ $includedPage := site.GetPage $path }}
+{{ $contentPath := "" }}
+{{ with $includedPage }}
+  {{ with .File }}
+    {{ $contentPath = printf "content/%s" (replace .Path "\\" "/") }}
+  {{ end }}
+{{ end }}
+{{ if not $contentPath }}
+  {{ range slice (printf "content/%s.md" $path) (printf "content/%s" $path) }}
+    {{ if and (not $contentPath) (fileExists .) }}
+      {{ $contentPath = . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ with $contentPath }}
+  {{ $rawContent := readFile . }}
+  {{ $normalisedContent := replace $rawContent "\r\n" "\n" }}
+  {{ $content := $normalisedContent }}
+  {{ $frontMatter := "" }}
+
+  {{ if hasPrefix $normalisedContent "---\n" }}
+    {{ $parts := split $normalisedContent "\n---\n" }}
+    {{ if ge (len $parts) 2 }}
+      {{ $frontMatter = strings.TrimPrefix "---\n" (index $parts 0) }}
+      {{ $content = delimit (after 1 $parts) "\n---\n" }}
+    {{ end }}
+  {{ end }}
+
+  {{ $forSaleTracks := slice }}
+  {{ with $includedPage }}
+    {{ with (.Params.forSaleTracks | default .Params.for_sale_tracks) }}
+      {{ if reflect.IsSlice . }}
+        {{ range . }}
+          {{ $forSaleTracks = $forSaleTracks | append . }}
+        {{ end }}
+      {{ else }}
+        {{ $forSaleTracks = $forSaleTracks | append . }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{ $collectForSaleTracks := false }}
+  {{ if eq (len $forSaleTracks) 0 }}
+    {{ range split $frontMatter "\n" }}
+      {{ $line := strings.TrimSpace . }}
+      {{ if or (eq $line "forSaleTracks:") (eq $line "for_sale_tracks:") }}
+        {{ $collectForSaleTracks = true }}
+      {{ else if $collectForSaleTracks }}
+        {{ if hasPrefix $line "-" }}
+          {{ $track := strings.TrimSpace (strings.TrimPrefix "-" $line) }}
+          {{ $track = strings.Trim $track "\"'" }}
+          {{ with $track }}
+            {{ $forSaleTracks = $forSaleTracks | append . }}
+          {{ end }}
+        {{ else if ne $line "" }}
+          {{ $collectForSaleTracks = false }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{ if gt (len $forSaleTracks) 0 }}
+    {{ $lines := slice }}
+    {{ range split $content "\n" }}
+      {{ $line := . }}
+      {{ $isForSaleTrack := false }}
+      {{ $lowerLine := lower $line }}
+      {{ range $forSaleTracks }}
+        {{ if and (not $isForSaleTrack) (in $lowerLine (lower (printf "%v" .))) }}
+          {{ $isForSaleTrack = true }}
+        {{ end }}
+      {{ end }}
+      {{ if and $isForSaleTrack (not (in $line "{{< for-sale >}}")) }}
+        {{ $line = printf "%s {{< for-sale >}}" $line }}
+      {{ end }}
+      {{ $lines = $lines | append $line }}
+    {{ end }}
+    {{ $content = delimit $lines "\n" }}
+  {{ end }}
+
+  {{ $.Page.RenderString $content }}
+{{ end }}

--- a/src/layouts/shortcodes/release.html
+++ b/src/layouts/shortcodes/release.html
@@ -10,5 +10,5 @@
         {{ with index $parts 2 | strings.TrimSpace }}{{ $releaseSlug = . | urlize }}{{ end }}
     {{ end }}
     {{ $releasePage := $.Site.GetPage (printf "releases/%s/%s/%s" $artistFirstChar $artistSlug $releaseSlug) }}
-    {{ if $releasePage }}<a href="{{ $releasePage.Permalink }}">{{ $releaseName }}</a>{{ if $releasePage.Params.for_sale }} <span class="for-sale-badge">Available to buy</span>{{ end }}{{ else }}{{ $releaseName }}{{ end }}
+    {{ if $releasePage }}<a href="{{ $releasePage.Permalink }}">{{ $releaseName }}</a>{{ if $releasePage.Params.for_sale }} {{ partial "for-sale-badge.html" . }}{{ end }}{{ else }}{{ $releaseName }}{{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- add a reusable Available to buy badge partial
- support forSaleTracks / for_sale_tracks on included playlist content
- migrate show 56 playlist availability from inline shortcodes to front matter

Closes #46

## Verification
- hugo --environment production using Hugo Extended 0.146.5
- git diff --check