### PR TITLE
Add dedicated Listen Live page

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1,3 +1,15 @@
+/* Listen Live page: native player sizing inside article prose. */
+
+.listen-live-player {
+  margin: 2rem 0 1.25rem;
+}
+
+.listen-live-player audio {
+  display: block;
+  width: 100%;
+  max-width: 42rem;
+}
+
 /* Hero section: subtle contrast enhancements for improved text readability */
 
 .hero-overlay {

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -1,0 +1,16 @@
+---
+title: "Listen Live"
+description: "Listen live to Sundown Sessions."
+showDate: false
+showReadingTime: false
+showAuthor: false
+showTableOfContents: false
+---
+
+Tune in to Sundown Sessions live.
+
+Alternative music, exclusive tracks, artist interviews and carefully curated playlists from across the independent music landscape.
+
+{{< listen-live-player >}}
+
+If the player doesn't load, you can [listen directly using the NuCast player](https://betelgeuse.nucast.co.uk/public/8062).

--- a/src/layouts/partials/header/components/desktop-menu.html
+++ b/src/layouts/partials/header/components/desktop-menu.html
@@ -31,15 +31,11 @@
     </div>
   {{ end }}
 
-  {{ $listenURL := .Site.Params.listen_live_stream_url | default "#" }}
+  {{ $listenURL := "/listen-live/" | relURL }}
   <a
     href="{{ $listenURL }}"
     data-analytics-event="listen_live_click"
-    data-analytics-provider="live-stream"
-    {{ if and (ne $listenURL "#") (or (strings.HasPrefix $listenURL "http:") (strings.HasPrefix $listenURL "https:")) }}
-      target="_blank"
-      rel="noopener noreferrer"
-    {{ end }}
+    data-analytics-provider="listen-live-page"
     aria-label="Listen Live"
     class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary-600 text-neutral-50 hover:bg-primary-500 transition-colors font-medium text-sm">
     <span class="flex items-center justify-center h-3 w-3">

--- a/src/layouts/partials/header/components/mobile-menu.html
+++ b/src/layouts/partials/header/components/mobile-menu.html
@@ -137,16 +137,12 @@
 {{ end }}
 
 {{ define "mobile-listen-live" }}
-  {{ $listenURL := .Site.Params.listen_live_stream_url | default "#" }}
+  {{ $listenURL := "/listen-live/" | relURL }}
   <div class="px-2">
     <a
       href="{{ $listenURL }}"
       data-analytics-event="listen_live_click"
-      data-analytics-provider="live-stream"
-      {{ if and (ne $listenURL "#") (or (strings.HasPrefix $listenURL "http:") (strings.HasPrefix $listenURL "https:")) }}
-        target="_blank"
-        rel="noopener noreferrer"
-      {{ end }}
+      data-analytics-provider="listen-live-page"
       aria-label="Listen Live"
       class="inline-flex items-center gap-3 px-6 py-3 rounded-full bg-primary-600 text-neutral-50 hover:bg-primary-500 transition-colors font-medium">
       <span class="flex items-center justify-center h-5 w-5">

--- a/src/layouts/shortcodes/listen-live-player.html
+++ b/src/layouts/shortcodes/listen-live-player.html
@@ -1,0 +1,9 @@
+{{ $streamURL := .Get "src" | default "https://betelgeuse.nucast.co.uk:8062/stream" }}
+{{ $streamType := .Get "type" | default "audio/mpeg" }}
+
+<div class="listen-live-player">
+  <audio controls preload="none" aria-label="Sundown Sessions live stream">
+    <source src="{{ $streamURL }}" type="{{ $streamType }}">
+    Your browser does not support the audio element.
+  </audio>
+</div>


### PR DESCRIPTION
## Summary
- add a dedicated /listen-live/ Hugo page for the NuCast stream
- render the live stream with a native HTML5 audio player shortcode
- update desktop and mobile header Listen Live buttons to navigate to the page

## Testing
- Not run: Hugo is not available on PATH in this environment.