### PR TITLE
Align release hero artwork sizing

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -12,6 +12,10 @@
 
 /* Hero section: subtle contrast enhancements for improved text readability */
 
+:root {
+  --hero-artwork-height: 16rem;
+}
+
 .hero-overlay {
   background: rgba(0, 0, 0, 0.15);
 }
@@ -34,7 +38,7 @@
 }
 
 @media (min-width: 1024px) {
-  .lg\:w-64    { width: 16rem; }
+  .lg\:w-64    { width: var(--hero-artwork-height); }
   .lg\:text-5xl {
     font-size: 3rem;
     line-height: 1;
@@ -397,7 +401,7 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   }
 
   .release-hero__artwork img {
-    height: 100%;
+    height: var(--hero-artwork-height);
     max-width: none;
     width: auto;
   }


### PR DESCRIPTION
## Summary
- add a shared hero artwork height custom property
- reuse that property for the Artist hero large artwork measure
- size Release hero artwork directly from the shared property instead of filling the full card height

## Verification
- ran \git diff --check\
- attempted \hugo --minify\, but Hugo is not installed/on PATH in this environment