### PR TITLE
feat: reimagine about page

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -919,3 +919,443 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
+
+/* About page: editorial introduction for the Sundown Sessions story. */
+
+.about-page {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  margin-bottom: 5rem;
+}
+
+.about-hero {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+  margin-top: 1.5rem;
+}
+
+.about-hero__copy {
+  min-width: 0;
+}
+
+.about-kicker {
+  margin: 0 0 0.75rem;
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.dark .about-kicker {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.about-hero h1,
+.about-section h2,
+.about-cta h2 {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-weight: 850;
+  letter-spacing: 0;
+}
+
+.dark .about-hero h1,
+.dark .about-section h2,
+.dark .about-cta h2 {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.about-hero h1 {
+  max-width: 12ch;
+  font-size: 2.5rem;
+  line-height: 0.95;
+}
+
+.about-hero__lede {
+  max-width: 42rem;
+  margin: 1.35rem 0 0;
+  color: #404040; /* neutral-700 */
+  font-size: 1.12rem;
+  line-height: 1.75;
+}
+
+.dark .about-hero__lede {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.about-hero__media {
+  margin: 0;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  background: #f5f5f5; /* neutral-100 */
+  box-shadow: 0 18px 50px rgb(0 0 0 / 0.16);
+}
+
+.dark .about-hero__media {
+  border-color: #404040; /* neutral-700 */
+  background: #171717; /* neutral-900 */
+}
+
+.about-hero__media img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.about-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.about-actions--center {
+  justify-content: center;
+}
+
+.about-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  border-radius: 0.5rem;
+  padding: 0.7rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 750;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.about-button:focus-visible,
+.about-socials a:focus-visible {
+  outline: 3px solid rgba(var(--color-primary-500), 0.6);
+  outline-offset: 3px;
+}
+
+.about-button--primary {
+  background: #171717; /* neutral-900 */
+  color: #ffffff;
+}
+
+.about-button--primary:hover {
+  background: rgba(var(--color-primary-700), 1);
+  color: #ffffff;
+}
+
+.dark .about-button--primary {
+  background: #f5f5f5; /* neutral-100 */
+  color: #171717; /* neutral-900 */
+}
+
+.dark .about-button--primary:hover {
+  background: rgba(var(--color-primary-300), 1);
+  color: #171717; /* neutral-900 */
+}
+
+.about-button--secondary {
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  background: #ffffff;
+  color: #171717; /* neutral-900 */
+}
+
+.about-button--secondary:hover {
+  border-color: #737373; /* neutral-500 */
+  background: #f5f5f5; /* neutral-100 */
+  color: #171717; /* neutral-900 */
+}
+
+.dark .about-button--secondary {
+  border-color: #525252; /* neutral-600 */
+  background: #262626; /* neutral-800 */
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.dark .about-button--secondary:hover {
+  border-color: #a3a3a3; /* neutral-400 */
+  background: #404040; /* neutral-700 */
+  color: #ffffff;
+}
+
+.about-button--text {
+  color: #404040; /* neutral-700 */
+  padding-inline: 0.25rem;
+}
+
+.about-button--text:hover {
+  color: rgba(var(--color-primary-700), 1);
+  text-decoration: underline;
+  text-underline-offset: 0.16rem;
+}
+
+.dark .about-button--text {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.dark .about-button--text:hover {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.about-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.about-section--intro {
+  padding-top: 0.5rem;
+}
+
+.about-section__header {
+  max-width: 44rem;
+}
+
+.about-section h2,
+.about-cta h2 {
+  max-width: 16ch;
+  font-size: 1.9rem;
+  line-height: 1.05;
+}
+
+.about-prose {
+  max-width: 46rem;
+  color: #404040; /* neutral-700 */
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.about-prose p {
+  margin: 0;
+}
+
+.about-prose p + p {
+  margin-top: 1rem;
+}
+
+.dark .about-prose {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.about-feature-grid,
+.about-statement-grid,
+.about-values {
+  display: grid;
+  gap: 1rem;
+}
+
+.about-feature,
+.about-statement,
+.about-values li,
+.about-presenter {
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.5rem;
+  background: rgb(255 255 255 / 0.74);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+}
+
+.dark .about-feature,
+.dark .about-statement,
+.dark .about-values li,
+.dark .about-presenter {
+  border-color: #404040; /* neutral-700 */
+  background: rgb(23 23 23 / 0.72);
+}
+
+.about-feature,
+.about-statement {
+  padding: 1.35rem;
+}
+
+.about-feature h3,
+.about-statement h3,
+.about-presenter h3 {
+  margin: 0 0 0.65rem;
+  color: #171717; /* neutral-900 */
+  font-size: 1.1rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.dark .about-feature h3,
+.dark .about-statement h3,
+.dark .about-presenter h3 {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.about-feature p,
+.about-statement p,
+.about-presenter p,
+.about-cta p {
+  margin: 0;
+  color: #525252; /* neutral-600 */
+  line-height: 1.7;
+}
+
+.dark .about-feature p,
+.dark .about-statement p,
+.dark .about-presenter p,
+.dark .about-cta p {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.about-presenter {
+  display: grid;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 1rem;
+}
+
+.about-presenter img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 0.4rem;
+  object-fit: cover;
+}
+
+.about-presenter__role {
+  margin-bottom: 0.8rem;
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.about-values {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.about-values li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1.1rem;
+}
+
+.about-values strong {
+  color: #171717; /* neutral-900 */
+  font-size: 1rem;
+}
+
+.about-values span {
+  color: #525252; /* neutral-600 */
+  line-height: 1.55;
+}
+
+.dark .about-values strong {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.dark .about-values span {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.about-cta {
+  border-radius: 0.5rem;
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  background: linear-gradient(135deg, #ffffff, #f5f5f5);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  text-align: center;
+}
+
+.dark .about-cta {
+  border-color: #404040; /* neutral-700 */
+  background: linear-gradient(135deg, #171717, #262626);
+}
+
+.about-cta h2,
+.about-cta p {
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.about-cta p {
+  max-width: 42rem;
+  margin-top: 1rem;
+}
+
+.about-socials {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem 1rem;
+  margin-top: 1.5rem;
+}
+
+.about-socials a {
+  color: #525252; /* neutral-600 */
+  font-size: 0.9rem;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.about-socials a:hover {
+  color: rgba(var(--color-primary-700), 1);
+  text-decoration: underline;
+  text-underline-offset: 0.16rem;
+}
+
+.dark .about-socials a {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.dark .about-socials a:hover {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+@media (min-width: 700px) {
+  .about-hero h1 {
+    font-size: 4rem;
+  }
+
+  .about-section h2,
+  .about-cta h2 {
+    font-size: 2.55rem;
+  }
+
+  .about-feature-grid,
+  .about-statement-grid,
+  .about-values {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .about-presenter {
+    grid-template-columns: minmax(12rem, 0.75fr) minmax(0, 1.25fr);
+    padding: 1.25rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .about-page {
+    gap: 5rem;
+  }
+
+  .about-hero h1 {
+    font-size: 5.25rem;
+  }
+
+  .about-section h2,
+  .about-cta h2 {
+    font-size: 3.2rem;
+  }
+
+  .about-hero {
+    grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.82fr);
+    gap: 3rem;
+  }
+
+  .about-section,
+  .about-split {
+    grid-template-columns: minmax(18rem, 0.78fr) minmax(0, 1fr);
+    align-items: start;
+    gap: 3rem;
+  }
+
+  .about-feature-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -1,25 +1,16 @@
 ---
 title: 'About'
-description: 'A curated music show and archive from Haddington, Scotland'
+description: 'Sundown Sessions is an adventurous music show and archive from Haddington, East Lothian, Scotland, built around discovery, passionate presenters, and songs worth sharing.'
 menu:
   main:
     title: 'Go to the About page'
     weight: 3
+showDate: false
+showReadingTime: false
+showPagination: false
+showAuthor: false
+showHero: false
+showBreadcrumbs: true
+showTaxonomies: false
+sharingLinks: []
 ---
-{{< figure src="about-sundown-sessions.png" title="Colin Gourlay in Studio 2" >}}
-
-The _Sundown Sessions_ is a curated music show and archive from Haddington, Scotland — part late-evening mixtape, part conversation, and part home for the songs, artists, and stories that deserve a little longer in the light.
-
-The purpose and aims of the show include:
-
-- **Community Engagement:** Engaging with and serving the local community by providing relevant programming and information.
-
-- **Local News and Information:** Sharing local news, events, and information to keep listeners informed about what's happening in the area.
-
-- **Diverse Programming:** Providing a diverse range of music spanning different genres and interviews discussing local issues.
-
-- **Promotion of Local Talent:** Providing a platform for local musicians, artists, and other talents to showcase their work and connect with the community.
-
-- **Community Development:** Contributing to the development and well-being of the local community by promoting local initiatives, charities, and organisations.
-
-- **Entertainment:** Entertaining the community with engaging and enjoyable content, including music, interviews, and interactive segments.

--- a/src/layouts/about/single.html
+++ b/src/layouts/about/single.html
@@ -1,0 +1,181 @@
+{{ define "main" }}
+  {{ .Scratch.Set "scope" "single" }}
+  {{ $image := .Resources.GetMatch "about-sundown-sessions.png" }}
+  {{ if not $image }}{{ $image = .Resources.GetMatch "about-sundown-sessions.jpeg" }}{{ end }}
+
+  {{ $sameAs := slice }}
+  {{ range site.Params.Author.links }}
+    {{ range $service, $url := . }}
+      {{ with $url }}{{ $sameAs = $sameAs | append . }}{{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{ $jsonLD := dict
+    "@context" "https://schema.org"
+    "@type" "Organization"
+    "name" site.Title
+    "url" site.BaseURL
+    "description" .Description
+    "location" (dict "@type" "Place" "name" "Haddington, East Lothian, Scotland")
+    "sameAs" $sameAs
+  }}
+  <script type="application/ld+json">{{ $jsonLD | jsonify | safeJS }}</script>
+
+  <article class="about-page">
+    <header class="about-hero" aria-labelledby="about-heading">
+      <div class="about-hero__copy">
+        {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
+          {{ partial "breadcrumbs.html" . }}
+        {{ end }}
+        <p class="about-kicker">Broadcasting from Scotland</p>
+        <h1 id="about-heading">More than just another music archive.</h1>
+        <p class="about-hero__lede">
+          Sundown Sessions is an adventurous music show and living archive from Haddington, East Lothian, built for curious listeners who still believe discovery is the best part of radio.
+        </p>
+        <div class="about-actions" aria-label="Primary About page actions">
+          <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
+          <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
+        </div>
+      </div>
+      {{ with $image }}
+        <figure class="about-hero__media">
+          <img
+            src="{{ .RelPermalink }}"
+            alt="Colin Gourlay in the Sundown Sessions studio"
+            loading="eager"
+            decoding="async"
+            fetchpriority="high">
+        </figure>
+      {{ end }}
+    </header>
+
+    <section class="about-section about-section--intro" aria-labelledby="about-identity-heading">
+      <div class="about-section__header">
+        <p class="about-kicker">The station spirit</p>
+        <h2 id="about-identity-heading">A home for songs, stories, and late-night curiosity.</h2>
+      </div>
+      <div class="about-prose">
+        <p>
+          Part mixtape, part conversation, and part record shelf with the interesting corners left intact, Sundown Sessions champions music that deserves a little longer in the light.
+        </p>
+        <p>
+          The show grew from a love of eclectic radio: alternative cuts, indie discoveries, post-punk edges, overlooked classics, local voices, guest moments, and the joy of hearing something you were not expecting.
+        </p>
+      </div>
+    </section>
+
+    <section class="about-section" aria-labelledby="about-hear-heading">
+      <div class="about-section__header">
+        <p class="about-kicker">What you'll hear</p>
+        <h2 id="about-hear-heading">Programming for listeners who like to follow a thread.</h2>
+      </div>
+      <div class="about-feature-grid">
+        <section class="about-feature" aria-labelledby="about-music-heading">
+          <h3 id="about-music-heading">Music Programming</h3>
+          <p>Alternative, indie, post-punk, new discoveries, forgotten classics, specialist selections, and carefully sequenced detours.</p>
+        </section>
+        <section class="about-feature" aria-labelledby="about-talk-heading">
+          <h3 id="about-talk-heading">Talk Programming</h3>
+          <p>Guest conversations, interviews, technical discussions, behind-the-scenes notes, and podcast-style formats as the station grows.</p>
+        </section>
+        <section class="about-feature" aria-labelledby="about-specials-heading">
+          <h3 id="about-specials-heading">Special Programming</h3>
+          <p>Guest sessions, first plays, charity broadcasts, festival coverage, anniversary specials, and milestone shows.</p>
+        </section>
+      </div>
+    </section>
+
+    <section class="about-split about-section" aria-labelledby="about-roots-heading">
+      <div class="about-section__header">
+        <p class="about-kicker">Our roots</p>
+        <h2 id="about-roots-heading">Based in Haddington, East Lothian.</h2>
+      </div>
+      <div class="about-prose">
+        <p>
+          Sundown Sessions comes from Scotland's east coast, shaped by community radio values and the simple belief that good music deserves careful attention.
+        </p>
+        <p>
+          What began as a broadcast has become an archive of shows, playlists, featured artists, releases, notes, and musical paths worth revisiting.
+        </p>
+      </div>
+    </section>
+
+    <section class="about-section" aria-labelledby="about-people-heading">
+      <div class="about-section__header">
+        <p class="about-kicker">Behind the microphone</p>
+        <h2 id="about-people-heading">Presented with genuine musical obsession.</h2>
+      </div>
+      <div class="about-presenter">
+        {{ with $image }}
+          <img
+            src="{{ .RelPermalink }}"
+            alt="Colin Gourlay presenting Sundown Sessions"
+            loading="lazy"
+            decoding="async">
+        {{ end }}
+        <div>
+          <h3>Colin Gourlay</h3>
+          <p class="about-presenter__role">Presenter and curator, Sundown Sessions</p>
+          <p>
+            Colin brings together adventurous playlists, guest features, local connections, and the kind of music conversation that rewards close listening.
+          </p>
+          <div class="about-actions">
+            <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Meet the shows</a>
+            <a class="about-button about-button--text" href="{{ "/contact/" | relURL }}">Contact Sundown Sessions</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="about-section" aria-labelledby="about-purpose-heading">
+      <div class="about-section__header">
+        <p class="about-kicker">Purpose</p>
+        <h2 id="about-purpose-heading">Why Sundown Sessions exists.</h2>
+      </div>
+      <div class="about-statement-grid">
+        <section class="about-statement" aria-labelledby="about-mission-heading">
+          <h3 id="about-mission-heading">Our Mission</h3>
+          <p>To champion great music, celebrate passionate voices, and create a welcoming home for listeners who believe discovery is one of life's great pleasures.</p>
+        </section>
+        <section class="about-statement" aria-labelledby="about-vision-heading">
+          <h3 id="about-vision-heading">Our Vision</h3>
+          <p>To become a trusted destination for adventurous listeners, connecting communities through exceptional programming, authentic personality, and a shared love of music.</p>
+        </section>
+      </div>
+    </section>
+
+    <section class="about-section" aria-labelledby="about-values-heading">
+      <div class="about-section__header">
+        <p class="about-kicker">Values</p>
+        <h2 id="about-values-heading">The notes we keep returning to.</h2>
+      </div>
+      <ul class="about-values" aria-label="Sundown Sessions values">
+        <li><strong>Discovery</strong><span>Finding music worth sharing.</span></li>
+        <li><strong>Authenticity</strong><span>Real people with genuine passion.</span></li>
+        <li><strong>Community</strong><span>Building meaningful connections.</span></li>
+        <li><strong>Curiosity</strong><span>Following the unexpected path.</span></li>
+        <li><strong>Inclusivity</strong><span>Welcoming anyone who wants to listen.</span></li>
+      </ul>
+    </section>
+
+    <section class="about-cta" aria-labelledby="about-involved-heading">
+      <p class="about-kicker">Get involved</p>
+      <h2 id="about-involved-heading">Become part of the story.</h2>
+      <p>Listen live, explore the archive, send a note, or follow Sundown Sessions wherever you like to keep up with new music.</p>
+      <div class="about-actions about-actions--center">
+        <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
+        <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
+        <a class="about-button about-button--secondary" href="{{ "/contact/" | relURL }}">Contact Us</a>
+      </div>
+      {{ if $sameAs }}
+        <nav class="about-socials" aria-label="Sundown Sessions social links">
+          {{ range site.Params.Author.links }}
+            {{ range $service, $url := . }}
+              <a href="{{ $url }}" rel="me noopener" target="_blank">{{ title $service }}</a>
+            {{ end }}
+          {{ end }}
+        </nav>
+      {{ end }}
+    </section>
+  </article>
+{{ end }}


### PR DESCRIPTION
## Summary
- Replaces the default prose About page with a custom, story-led Hugo layout
- Adds sections for identity, programming, roots, presenter, mission, vision, values, CTAs, social links, and JSON-LD
- Updates About page metadata and scoped responsive styling

## Validation
- Passed: `hugo --source src --environment production --printPathWarnings` using Hugo 0.146.5
- Passed: `git diff --check`
- Not run: local markdownlint, because `markdownlint-cli2` and `npx` were unavailable

Closes #468