### PR TITLE
Improve release details spacing

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -299,6 +299,23 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: rgba(var(--color-primary-400), 1);
 }
 
+/* Release details: subtle row breathing room for individual release pages. */
+
+.release-details__row {
+  padding-top: 1rem;
+  padding-bottom: 0.25rem;
+}
+
+.release-details__row:first-child {
+  padding-top: 0;
+}
+
+@media (min-width: 640px) {
+  .release-details__row:first-child {
+    padding-top: 1rem;
+  }
+}
+
 /* Release hero: optional artwork-derived accent for individual release pages.
    The CSS variable is only emitted when front matter provides a colour. */
 

--- a/src/layouts/partials/release/metadata-card.html
+++ b/src/layouts/partials/release/metadata-card.html
@@ -159,7 +159,7 @@
 
 {{- if gt (len $fields) 0 -}}
   <section
-    class="mb-10 max-w-prose rounded-lg border border-neutral-200 bg-neutral-50/70 p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/60"
+    class="release-details mb-10 max-w-prose rounded-lg border border-neutral-200 bg-neutral-50/70 p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/60"
     role="region"
     aria-labelledby="release-details-heading">
     <h2
@@ -169,7 +169,7 @@
     </h2>
     <dl class="m-0 grid gap-x-6 gap-y-3 sm:grid-cols-2">
       {{- range $fields }}
-        <div class="min-w-0 border-t border-neutral-200 pt-3 first:border-t-0 first:pt-0 sm:first:border-t sm:first:pt-3 dark:border-neutral-700">
+        <div class="release-details__row min-w-0 border-t border-neutral-200 pt-3 first:border-t-0 first:pt-0 sm:first:border-t sm:first:pt-3 dark:border-neutral-700">
           <dt class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
             {{ .term }}
           </dt>


### PR DESCRIPTION
## Summary
- add scoped Release Details row classes to the release metadata card
- increase vertical row padding via release-specific custom CSS
- preserve the existing two-column layout, dividers, and typography

## Verification
- Ran git diff --check successfully; only Windows line-ending warnings were reported.
- Hugo build not run locally because hugo is not installed on PATH.