### PR TITLE
Improve release tracklist presentation

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -768,10 +768,10 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 .release-tracklist__row {
   display: grid;
   grid-template-columns: 2.5rem minmax(0, 1fr);
-  gap: 0.75rem;
+  gap: 0.5rem 1rem;
   align-items: baseline;
   border-top: 1px solid #e5e5e5; /* neutral-200 */
-  padding: 0.85rem 1.25rem;
+  padding: 0.7rem 1.25rem;
 }
 
 .dark .release-tracklist__row {
@@ -782,7 +782,7 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: #737373; /* neutral-500 */
   font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.05em;
+  font-variant-numeric: tabular-nums;
   line-height: 1.5;
 }
 
@@ -804,15 +804,24 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 
 .release-tracklist__title a {
   color: inherit;
-  text-decoration: none;
-}
-
-.release-tracklist__title a:hover {
-  color: rgba(var(--color-primary-600), 1);
   text-decoration: underline;
+  text-decoration-color: rgba(var(--color-primary-500), 0.45);
+  text-underline-offset: 0.16rem;
 }
 
-.dark .release-tracklist__title a:hover {
+.release-tracklist__title a:hover,
+.release-tracklist__title a:focus-visible {
+  color: rgba(var(--color-primary-600), 1);
+  text-decoration-color: currentColor;
+}
+
+.release-tracklist__title a:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 0.15rem;
+}
+
+.dark .release-tracklist__title a:hover,
+.dark .release-tracklist__title a:focus-visible {
   color: rgba(var(--color-primary-400), 1);
 }
 
@@ -821,6 +830,7 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: #737373; /* neutral-500 */
   font-size: 0.875rem;
   font-weight: 600;
+  font-variant-numeric: tabular-nums;
   line-height: 1.4;
 }
 
@@ -1060,7 +1070,8 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 
 @media (min-width: 640px) {
   .release-tracklist__row {
-    grid-template-columns: 2.5rem minmax(0, 1fr) auto;
+    grid-template-columns: 3rem minmax(0, 1fr) auto;
+    padding-block: 0.6rem;
   }
 
   .release-tracklist__duration {

--- a/src/layouts/partials/release/tracklist.html
+++ b/src/layouts/partials/release/tracklist.html
@@ -1,45 +1,131 @@
-{{- $tracks := .Params.tracks -}}
-{{- if and $tracks (reflect.IsSlice $tracks) (gt (len $tracks) 0) -}}
+{{- $page := . -}}
+{{- $tracks := slice -}}
+{{- $frontMatterTracks := .Params.tracks -}}
+{{- $hasFrontMatterTracks := and $frontMatterTracks (reflect.IsSlice $frontMatterTracks) (gt (len $frontMatterTracks) 0) -}}
+
+{{- if $hasFrontMatterTracks -}}
+  {{- range $index, $track := $frontMatterTracks -}}
+    {{- $title := "" -}}
+    {{- $duration := "" -}}
+    {{- $number := add $index 1 -}}
+    {{- $candidate := "" -}}
+
+    {{- if reflect.IsMap $track -}}
+      {{- $title = index $track "title" | default (index $track "name") | default "" -}}
+      {{- $duration = index $track "duration" | default (index $track "length") | default "" -}}
+      {{- $number = index $track "trackNumber" | default (index $track "tracknumber") | default (index $track "track_number") | default (index $track "number") | default $number -}}
+      {{- $candidate = index $track "url" | default (index $track "page") | default (index $track "slug") | default "" -}}
+    {{- else -}}
+      {{- $title = $track -}}
+    {{- end -}}
+
+    {{- $title = printf "%v" $title | strings.TrimSpace -}}
+    {{- if $title -}}
+      {{- $tracks = $tracks | append (dict
+        "title" $title
+        "duration" (printf "%v" $duration | strings.TrimSpace)
+        "number" (printf "%v" $number | strings.TrimSpace)
+        "candidate" (printf "%v" $candidate | strings.TrimSpace)
+      ) -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- $rawTracklist := "" -}}
+  {{- if in .RawContent "## Tracklist" -}}
+    {{- $rawTracklist = replaceRE `(?ims)^.*?^##\s*Tracklist\s*$\s*(.*?)(?:^##\s+.*|\z)` "$1" .RawContent | strings.TrimSpace -}}
+  {{- end -}}
+  {{- range split $rawTracklist "\n" -}}
+    {{- $line := . | strings.TrimSpace -}}
+    {{- if findRE `^\d+[\.)]\s+` $line -}}
+      {{- $number := replaceRE `^(\d+)[\.)]\s+.*$` "$1" $line -}}
+      {{- $rest := replaceRE `^\d+[\.)]\s+` "" $line | strings.TrimSpace -}}
+      {{- $duration := "" -}}
+      {{- $durationMatch := findRE `\([0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?\)\s*$` $rest -}}
+      {{- with $durationMatch -}}
+        {{- $duration = index . 0 | strings.TrimPrefix "(" | strings.TrimSuffix ")" | strings.TrimSpace -}}
+        {{- $rest = replaceRE `\s*\([0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?\)\s*$` "" $rest | strings.TrimSpace -}}
+      {{- end -}}
+      {{- $title := $rest -}}
+      {{- $candidate := "" -}}
+      {{- if findRE `^\[[^\]]+\]\([^)]+\)` $rest -}}
+        {{- $title = replaceRE `^\[([^\]]+)\]\([^)]+\).*$` "$1" $rest | strings.TrimSpace -}}
+        {{- $candidate = replaceRE `^\[[^\]]+\]\(([^)]+)\).*$` "$1" $rest | strings.TrimSpace -}}
+      {{- end -}}
+      {{- if $title -}}
+        {{- $tracks = $tracks | append (dict
+          "title" $title
+          "duration" $duration
+          "number" $number
+          "candidate" $candidate
+        ) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if gt (len $tracks) 0 -}}
   <section class="release-tracklist not-prose" role="region" aria-labelledby="tracklist">
     <h2 id="tracklist" class="release-tracklist__heading">Tracklist</h2>
     <ol class="release-tracklist__list">
       {{- range $index, $track := $tracks -}}
-        {{- $title := "" -}}
-        {{- $duration := "" -}}
-        {{- $number := add $index 1 -}}
-        {{- $link := "" -}}
+        {{- $title := $track.title -}}
+        {{- $duration := $track.duration -}}
+        {{- $number := $track.number | default (add $index 1) -}}
+        {{- $candidate := $track.candidate -}}
+        {{- $href := "" -}}
+        {{- $trackPage := false -}}
+        {{- $titleKey := lower (urlize $title) -}}
+        {{- $artistKey := lower (urlize (printf "%v" ($page.Params.artist | default ""))) -}}
+        {{- $releaseKey := lower (urlize $page.Title) -}}
 
-        {{- if reflect.IsMap $track -}}
-          {{- $title = index $track "title" | default (index $track "name") | default "" -}}
-          {{- $duration = index $track "duration" | default (index $track "length") | default "" -}}
-          {{- $number = index $track "trackNumber" | default (index $track "tracknumber") | default (index $track "track_number") | default (index $track "number") | default $number -}}
-          {{- $link = index $track "url" | default (index $track "page") | default (index $track "slug") | default "" -}}
-        {{- else -}}
-          {{- $title = $track -}}
-        {{- end -}}
-
-        {{- $title = printf "%v" $title | strings.TrimSpace -}}
-        {{- $duration = printf "%v" $duration | strings.TrimSpace -}}
-        {{- $link = printf "%v" $link | strings.TrimSpace -}}
-        {{- if and $link (not (or (strings.HasPrefix $link "http://") (strings.HasPrefix $link "https://") (strings.HasPrefix $link "/"))) -}}
-          {{- $link = printf "/%s" $link -}}
-        {{- end -}}
-
-        {{- if $title -}}
-          <li class="release-tracklist__row">
-            <span class="release-tracklist__number">{{ printf "%02d" (int $number) }}</span>
-            <span class="release-tracklist__title">
-              {{- if $link -}}
-                <a href="{{ $link | relURL }}">{{ $title }}</a>
-              {{- else -}}
-                {{ $title }}
+        {{- if $candidate -}}
+          {{- if or (strings.HasPrefix $candidate "http://") (strings.HasPrefix $candidate "https://") -}}
+            {{- $href = $candidate -}}
+          {{- else -}}
+            {{- $candidatePath := $candidate | strings.TrimPrefix "/" | strings.TrimSuffix "/" -}}
+            {{- $candidateKey := lower (urlize (path.Base $candidatePath)) -}}
+            {{- with site.GetPage $candidatePath -}}
+              {{- $trackPage = . -}}
+            {{- else -}}
+              {{- range where site.RegularPages "Section" "tracks" -}}
+                {{- $pagePath := .RelPermalink | strings.TrimPrefix "/" | strings.TrimSuffix "/" -}}
+                {{- $pageKey := lower (urlize .Title) -}}
+                {{- if or (eq $pagePath $candidatePath) (eq $pageKey $candidateKey) -}}
+                  {{- $trackPage = . -}}
+                {{- end -}}
               {{- end -}}
-            </span>
-            {{- with $duration -}}
-              <span class="release-tracklist__duration">{{ . }}</span>
             {{- end -}}
-          </li>
+          {{- end -}}
         {{- end -}}
+
+        {{- if and (not $href) (not $trackPage) -}}
+          {{- range where site.RegularPages "Section" "tracks" -}}
+            {{- $sameTitle := eq (lower (urlize .Title)) $titleKey -}}
+            {{- $sameArtist := or (not $artistKey) (eq (lower (urlize (printf "%v" (.Params.artist | default "")))) $artistKey) -}}
+            {{- $sameRelease := or (not .Params.release) (eq (lower (urlize (printf "%v" (.Params.release | default "")))) $releaseKey) -}}
+            {{- if and $sameTitle $sameArtist $sameRelease -}}
+              {{- $trackPage = . -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+
+        {{- with $trackPage -}}
+          {{- $href = .RelPermalink -}}
+        {{- end -}}
+
+        <li class="release-tracklist__row">
+          <span class="release-tracklist__number">{{ printf "%02d" (int $number) }}</span>
+          <span class="release-tracklist__title">
+            {{- if $href -}}
+              <a href="{{ $href }}">{{ $title }}</a>
+            {{- else -}}
+              {{ $title }}
+            {{- end -}}
+          </span>
+          {{- with $duration -}}
+            <span class="release-tracklist__duration">{{ . }}</span>
+          {{- end -}}
+        </li>
       {{- end -}}
     </ol>
   </section>

--- a/src/layouts/releases/single.html
+++ b/src/layouts/releases/single.html
@@ -36,12 +36,14 @@
             {{ $releaseContent = delimit (after 1 (split $releaseContent `</h2>`)) `</h2>` | strings.TrimSpace }}
           {{ end }}
           {{ $hasStructuredTracks := and .Params.tracks (reflect.IsSlice .Params.tracks) (gt (len .Params.tracks) 0) }}
-          {{ if $hasStructuredTracks }}
+          {{ $hasMarkdownTracks := in .RawContent "## Tracklist" }}
+          {{ $hasTracklist := or $hasStructuredTracks $hasMarkdownTracks }}
+          {{ if $hasTracklist }}
             {{ $releaseContent = replaceRE `(?is)<h2\b[^>]*>\s*Tracklist.*?</h2>\s*.*?(<h2\b[^>]*>|$)` "$1" $releaseContent | strings.TrimSpace }}
           {{ end }}
           {{ $releaseAboutContent := $releaseContent }}
           {{ $releaseAfterAboutContent := "" }}
-          {{ if and $hasStructuredTracks (in $releaseContent "<h2") }}
+          {{ if and $hasTracklist (in $releaseContent "<h2") }}
             {{ $releaseContentParts := split $releaseContent "<h2" }}
             {{ $releaseAboutContent = index $releaseContentParts 0 | strings.TrimSpace }}
             {{ $releaseAfterAboutContent = printf "<h2%s" (delimit (after 1 $releaseContentParts) "<h2") | strings.TrimSpace }}
@@ -60,7 +62,7 @@
             {{ end }}
           </h2>
           {{ $releaseAboutContent | safeHTML }}
-          {{ if $hasStructuredTracks }}
+          {{ if $hasTracklist }}
             {{ partial "release/tracklist.html" . }}
           {{ end }}
           {{ partial "release/featured-shows.html" . }}


### PR DESCRIPTION
## Summary
- render release tracklists in a scoped card/list-group component
- support structured front matter tracks and legacy Markdown tracklists
- resolve track links only when matching pages exist and suppress duplicate Markdown tracklists

## Verification
- Built successfully with temporary Hugo Extended v0.157.0
- Checked rendered Villains output for one Tracklist card, two-digit numbers, duration rows, and the existing Feet Don't Fail Me track link