### PR TITLE
feat: add straplines to landing page heroes

### DIFF
--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -1,6 +1,8 @@
 ---
 title: 'About'
+strapline: 'The story behind Sundown Sessions.'
 description: 'Sundown Sessions is an adventurous music show and archive from Haddington, East Lothian, Scotland, built around discovery, passionate presenters, and songs worth sharing.'
+featured_image: 'about-sundown-sessions.png'
 menu:
   main:
     title: 'Go to the About page'

--- a/src/content/artists/_index.md
+++ b/src/content/artists/_index.md
@@ -1,0 +1,4 @@
+---
+title: Artists
+description: Discover the musicians behind the music.
+---

--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -1,5 +1,6 @@
 ---
 title: 'Contact'
+strapline: 'Get in touch with the show.'
 description: 'If you want to get in touch - this is the place!'
 menu:
   main:

--- a/src/content/releases/_index.md
+++ b/src/content/releases/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Releases
-description: Release pages for albums and EPs featured on Sundown Sessions.
+description: Albums, EPs and singles featured on the show.
 ---

--- a/src/content/shows/_index.md
+++ b/src/content/shows/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Shows'
-description: 'Featuring: playlists, track details, show notes and more from each broadcast'
+description: 'Every broadcast, playlist and musical discovery.'
 menu:
   main:
     name: 'Shows'

--- a/src/content/tracks/_index.md
+++ b/src/content/tracks/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Tracks
-description: Track pages for songs featured on Sundown Sessions.
+description: Explore every song played on Sundown Sessions.
 ---

--- a/src/layouts/_default/list.html
+++ b/src/layouts/_default/list.html
@@ -1,0 +1,122 @@
+{{ define "main" }}
+  {{ .Scratch.Set "scope" "list" }}
+  {{ $enableToc := .Params.showTableOfContents | default (site.Params.list.showTableOfContents | default false) }}
+  {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+
+  {{ partial "section-hero.html" . }}
+
+  {{/* Description (markdown content) */}}
+  {{ $tocMargin := cond $showToc "mt-12" "mt-0" }}
+  {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+  <section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row mb-10">
+    {{ if $showToc }}
+      <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
+        <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+          {{ partial "toc.html" . }}
+        </div>
+      </div>
+    {{ end }}
+    <div class="min-w-0 min-h-0 max-w-prose w-full">
+      {{ .Content }}
+    </div>
+  </section>
+
+  {{/* Article Grid */}}
+  {{ if gt .Pages 0 }}
+    {{ $cardView := .Params.cardView | default (site.Params.list.cardView | default false) }}
+    {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (site.Params.list.cardViewScreenWidth | default false) }}
+    {{ $groupByYear := .Params.groupByYear | default (site.Params.list.groupByYear | default false) }}
+    {{ $orderByWeight := .Params.orderByWeight | default (site.Params.list.orderByWeight | default false) }}
+    {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
+
+    {{ if not $cardView }}
+      <section class="space-y-10 w-full">
+        {{ if not $orderByWeight }}
+          {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+            {{ if $groupByYear }}
+              <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                {{ .Key }}
+              </h2>
+            {{ end }}
+            {{ range .Pages }}
+              {{ partial "article-link/simple.html" . }}
+            {{ end }}
+          {{ end }}
+        {{ else }}
+          {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+            {{ partial "article-link/simple.html" . }}
+          {{ end }}
+        {{ end }}
+      </section>
+    {{/* else: is cardView */}}
+    {{ else }}
+      {{ if $groupByYear }}
+        {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+          {{ if $cardViewScreenWidth }}
+            <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
+              <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+                {{ .Key }}
+              </h2>
+              <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+                {{ range .Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              </section>
+            </div>
+          {{ else }}
+            <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+              {{ .Key }}
+            </h2>
+            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+              {{ range .Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            </section>
+          {{ end }}
+        {{ end }}
+
+      {{/* else: not groupByYear */}}
+      {{ else }}
+        {{ if $cardViewScreenWidth }}
+          <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
+            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+              {{ if not $orderByWeight }}
+                {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+                  {{ range .Pages }}
+                    {{ partial "article-link/card.html" . }}
+                  {{ end }}
+                {{ end }}
+              {{ else }}
+                {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              {{ end }}
+            </section>
+          </div>
+        {{ else }}
+          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {{ if not $orderByWeight }}
+              {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+                {{ range .Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              {{ end }}
+            {{ else }}
+              {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            {{ end }}
+          </section>
+        {{ end }}{{/* End of cardViewScreenWidth */}}
+      {{ end }}{{/* End of groupByYear */}}
+    {{ end }}{{/* End of cardView */}}
+  {{/* else: .Pages not greater to zero */}}
+  {{ else }}
+    <section class="mt-10 prose dark:prose-invert">
+      <p class="py-8 border-t">
+        <em>{{ i18n "list.no_articles" | emojify }}</em>
+      </p>
+    </section>
+  {{ end }}
+  {{ partial "pagination.html" . }}
+{{ end }}

--- a/src/layouts/about/single.html
+++ b/src/layouts/about/single.html
@@ -22,32 +22,7 @@
   <script type="application/ld+json">{{ $jsonLD | jsonify | safeJS }}</script>
 
   <article class="about-page">
-    <header class="about-hero" aria-labelledby="about-heading">
-      <div class="about-hero__copy">
-        {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
-          {{ partial "breadcrumbs.html" . }}
-        {{ end }}
-        <p class="about-kicker">Broadcasting from Scotland</p>
-        <h1 id="about-heading">More than just another music archive.</h1>
-        <p class="about-hero__lede">
-          Sundown Sessions is an adventurous music show and living archive from Haddington, East Lothian, built for curious listeners who still believe discovery is the best part of radio.
-        </p>
-        <div class="about-actions" aria-label="Primary About page actions">
-          <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
-          <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
-        </div>
-      </div>
-      {{ with $image }}
-        <figure class="about-hero__media">
-          <img
-            src="{{ .RelPermalink }}"
-            alt="Colin Gourlay in the Sundown Sessions studio"
-            loading="eager"
-            decoding="async"
-            fetchpriority="high">
-        </figure>
-      {{ end }}
-    </header>
+    {{ partial "section-hero.html" . }}
 
     <section class="about-section about-section--intro" aria-labelledby="about-identity-heading">
       <div class="about-section__header">

--- a/src/layouts/contact/single.html
+++ b/src/layouts/contact/single.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+  {{ .Scratch.Set "scope" "single" }}
+
+  <article>
+    {{ partial "section-hero.html" . }}
+
+    <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
+      <div class="min-w-0 min-h-0 max-w-fit">
+        <div class="article-content max-w-prose mb-20">
+          {{ .Content }}
+        </div>
+      </div>
+    </section>
+  </article>
+{{ end }}

--- a/src/layouts/partials/section-hero.html
+++ b/src/layouts/partials/section-hero.html
@@ -1,0 +1,85 @@
+{{ $heroImageURL := "" }}
+{{ $heroOverlayBottomOffset := "7%" }}
+{{ $featureImage := .Params.featured_image | default .Params.featureimage }}
+
+{{ with $featureImage }}
+  {{ if or (strings.HasPrefix . "http://") (strings.HasPrefix . "https://") }}
+    {{ $heroImageURL = . }}
+  {{ else }}
+    {{ with $.Resources.GetMatch . }}
+      {{ $heroImageURL = .RelPermalink }}
+    {{ else }}
+      {{ with $.Resources.GetMatch (path.Base .) }}
+        {{ $heroImageURL = .RelPermalink }}
+      {{ else }}
+        {{ with resources.Get . }}
+          {{ $heroImageURL = .RelPermalink }}
+        {{ else }}
+          {{ $heroImageURL = . | relURL }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ if not $heroImageURL }}
+  {{ with .Site.Params.homepage.homepageImage | default .Site.Params.defaultBackgroundImage }}
+    {{ if or (strings.HasPrefix . "http://") (strings.HasPrefix . "https://") }}
+      {{ $heroImageURL = . }}
+    {{ else }}
+      {{ with resources.Get . }}
+        {{ $heroImageURL = .RelPermalink }}
+      {{ else }}
+        {{ $heroImageURL = . | relURL }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $strapline := .Params.strapline | default .Description }}
+{{ $headingID := printf "%s-hero-heading" (.Title | anchorize) }}
+
+{{ if $heroImageURL }}
+  <div class="space-y-6 mb-10">
+    <section
+      class="relative overflow-hidden rounded-2xl shadow-2xl"
+      role="region"
+      aria-labelledby="{{ $headingID }}">
+      <img
+        src="{{ $heroImageURL }}"
+        alt=""
+        role="presentation"
+        loading="eager"
+        decoding="async"
+        fetchpriority="high"
+        class="h-72 w-full object-cover sm:h-80 lg:h-96"
+        {{ with .Params.imagePosition | default .Site.Params.homepage.homepageImagePosition }}style="object-position: {{ . | safeCSS }};"{{ end }}>
+      <div
+        aria-hidden="true"
+        class="absolute inset-0 bg-gradient-to-t from-neutral-950/80 via-neutral-950/45 to-neutral-950/20"></div>
+      <div
+        aria-hidden="true"
+        class="absolute inset-0 hero-overlay"></div>
+      <div class="absolute inset-x-0 top-0 flex items-center justify-center px-4" style="{{ printf "bottom: %s;" $heroOverlayBottomOffset | safeCSS }}">
+        <div class="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
+          <h1 id="{{ $headingID }}" class="mt-0 text-4xl font-sans font-extrabold tracking-tight text-neutral-50 drop-shadow-2xl hero-text-shadow sm:text-5xl">
+            {{ .Title | emojify }}
+          </h1>
+          {{ with $strapline }}
+            <p class="mt-2 text-base font-semibold text-neutral-200 drop-shadow-lg hero-text-shadow sm:text-lg">{{ . }}</p>
+          {{ end }}
+        </div>
+      </div>
+    </section>
+  </div>
+{{ else }}
+  <header class="mb-10">
+    {{ if .Params.showBreadcrumbs | default (site.Params.list.showBreadcrumbs | default false) }}
+      {{ partial "breadcrumbs.html" . }}
+    {{ end }}
+    <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title | emojify }}</h1>
+    {{ with $strapline }}
+      <p class="mt-2 text-base text-neutral-500 dark:text-neutral-400">{{ . }}</p>
+    {{ end }}
+  </header>
+{{ end }}

--- a/src/layouts/shows/list.html
+++ b/src/layouts/shows/list.html
@@ -2,74 +2,7 @@
   {{ .Scratch.Set "scope" "list" }}
 
   {{/* Hero Banner */}}
-  {{ $heroImageURL := "" }}
-  {{ $featureImage := .Params.featured_image | default .Params.featureimage }}
-  {{ with $featureImage }}
-    {{ if or (strings.HasPrefix . "http://") (strings.HasPrefix . "https://") }}
-      {{ $heroImageURL = . }}
-    {{ else }}
-      {{ with resources.Get . }}
-        {{ $heroImageURL = .RelPermalink }}
-      {{ else }}
-        {{ $heroImageURL = . | relURL }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-  {{ if not $heroImageURL }}
-    {{ with .Site.Params.homepage.homepageImage | default .Site.Params.defaultBackgroundImage }}
-      {{ if or (strings.HasPrefix . "http://") (strings.HasPrefix . "https://") }}
-        {{ $heroImageURL = . }}
-      {{ else }}
-        {{ with resources.Get . }}
-          {{ $heroImageURL = .RelPermalink }}
-        {{ else }}
-          {{ $heroImageURL = . | relURL }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-
-  {{ if $heroImageURL }}
-    <div class="space-y-6 mb-10">
-      <section
-        class="relative overflow-hidden rounded-2xl shadow-2xl"
-        role="region"
-        aria-labelledby="shows-hero-heading">
-        <img
-          src="{{ $heroImageURL }}"
-          alt=""
-          role="presentation"
-          loading="eager"
-          decoding="async"
-          fetchpriority="high"
-          class="h-72 w-full object-cover sm:h-80 lg:h-96"
-          {{ with .Site.Params.homepage.homepageImagePosition }}style="object-position: {{ . | safeCSS }};"{{ end }}>
-        <div
-          aria-hidden="true"
-          class="absolute inset-0 bg-gradient-to-t from-neutral-950/80 via-neutral-950/45 to-neutral-950/20"></div>
-        <div class="absolute inset-0 flex items-center justify-center px-4">
-          <div class="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
-            <h1 id="shows-hero-heading" class="mt-0 text-4xl font-extrabold tracking-tight text-neutral-50 drop-shadow-2xl sm:text-5xl">
-              {{ .Title }}
-            </h1>
-          </div>
-        </div>
-      </section>
-      {{ with .Description }}
-        <p class="mx-auto max-w-2xl px-4 text-center text-base font-medium text-neutral-700 dark:text-neutral-300 sm:text-lg">{{ . }}</p>
-      {{ end }}
-    </div>
-  {{ else }}
-    <header class="mb-10">
-      {{ if .Params.showBreadcrumbs | default (site.Params.list.showBreadcrumbs | default false) }}
-        {{ partial "breadcrumbs.html" . }}
-      {{ end }}
-      <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
-      {{ with .Description }}
-        <p class="mt-2 text-base text-neutral-500 dark:text-neutral-400">{{ . }}</p>
-      {{ end }}
-    </header>
-  {{ end }}
+  {{ partial "section-hero.html" . }}
 
   {{/* Shows listing — horizontal show cards in a vertical stack */}}
   {{ $datedPages := where .Pages ".Date.IsZero" "ne" true }}


### PR DESCRIPTION
## Summary
- Add a shared landing-page hero partial with homepage-aligned title placement and optional strapline support
- Use the shared hero for Shows, default section lists, About, and Contact without changing the homepage hero
- Add concise landing straplines for Shows, Artists, Releases, Tracks, About, and Contact

## Verification
- `hugo v0.146.5 --source src --minify`
- Spot-checked generated homepage, Shows, About, Contact, Releases, Tracks, and Artists HTML