### PR TITLE
Refine release hero artist links

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -513,6 +513,36 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   margin: 0;
 }
 
+.release-hero__artist-link {
+  color: rgba(var(--color-primary-600), 1);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: rgba(var(--color-primary-500), 0.45);
+  text-underline-offset: 0.16rem;
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+.release-hero__artist-link:hover,
+.release-hero__artist-link:focus-visible {
+  color: rgba(var(--color-primary-700), 1);
+  text-decoration-color: currentColor;
+}
+
+.release-hero__artist-link:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 0.2rem;
+}
+
+.dark .release-hero__artist-link {
+  color: rgba(var(--color-primary-400), 1);
+  text-decoration-color: rgba(var(--color-primary-400), 0.5);
+}
+
+.dark .release-hero__artist-link:hover,
+.dark .release-hero__artist-link:focus-visible {
+  color: rgba(var(--color-primary-300), 1);
+}
+
 .release-hero__metadata {
   display: grid;
   gap: 0.9rem;
@@ -707,26 +737,6 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 
 .dark .release-artists__summary {
   color: #a3a3a3; /* neutral-400 */
-}
-
-.release-artists__profile-link {
-  display: inline-flex;
-  margin-top: 0.65rem;
-  color: rgba(var(--color-primary-600), 1);
-  font-size: 0.88rem;
-  font-weight: 700;
-  line-height: 1.4;
-  text-decoration: none;
-}
-
-.release-artists__profile-link:hover,
-.release-artists__profile-link:focus-visible {
-  text-decoration: underline;
-  text-underline-offset: 0.125rem;
-}
-
-.dark .release-artists__profile-link {
-  color: rgba(var(--color-primary-400), 1);
 }
 
 /* Release tracklist: scoped card/list-group treatment for structured release

--- a/src/layouts/partials/release/artists.html
+++ b/src/layouts/partials/release/artists.html
@@ -1,145 +1,26 @@
-{{- $artistItems := slice -}}
-
-{{- with .Params.artists -}}
-  {{- if reflect.IsSlice . -}}
-    {{- $artistItems = . -}}
-  {{- else -}}
-    {{- $artistItems = slice . -}}
+{{- $artists := partial "release/resolve-artists.html" . -}}
+{{- $artistCards := slice -}}
+{{- range $artists -}}
+  {{- $artist := . -}}
+  {{- $summary := "" -}}
+  {{- with .page -}}
+    {{- $summary = .Summary | plainify | strings.TrimSpace -}}
   {{- end -}}
-{{- else -}}
-  {{- with .Params.artist -}}
-    {{- if reflect.IsSlice . -}}
-      {{- $artistItems = . -}}
-    {{- else -}}
-      {{- $artistItems = slice . -}}
-    {{- end -}}
+  {{- with $summary -}}
+    {{- $artistCards = $artistCards | append (merge $artist (dict "summary" $summary)) -}}
   {{- end -}}
 {{- end -}}
 
-{{- $artists := slice -}}
-{{- $artistSection := site.GetPage "artists" -}}
-{{- $artistPages := slice -}}
-{{- with $artistSection -}}
-  {{- $artistPages = .RegularPagesRecursive -}}
-{{- else -}}
-  {{- $artistPages = where site.RegularPages "Section" "artists" -}}
-{{- end -}}
-
-{{- range $artistItems -}}
-  {{- $name := "" -}}
-  {{- $pageRef := "" -}}
-  {{- $slug := "" -}}
-  {{- $artistPage := false -}}
-
-  {{- if reflect.IsMap . -}}
-    {{- $name = index . "title" | default (index . "name") | default (index . "artist") -}}
-    {{- $pageRef = index . "page" | default (index . "url") -}}
-    {{- $slug = index . "slug" | default (index . "artist_slug") -}}
-  {{- else -}}
-    {{- $name = printf "%v" . -}}
-    {{- $slug = $.Params.artist_slug -}}
-  {{- end -}}
-
-  {{- if $name -}}
-    {{- $name = printf "%v" $name | strings.TrimSpace -}}
-  {{- else -}}
-    {{- $name = "" -}}
-  {{- end -}}
-  {{- if $pageRef -}}
-    {{- $pageRef = printf "%v" $pageRef | strings.TrimSpace -}}
-  {{- else -}}
-    {{- $pageRef = "" -}}
-  {{- end -}}
-  {{- if $slug -}}
-    {{- $slug = printf "%v" $slug | strings.TrimSpace -}}
-  {{- else -}}
-    {{- $slug = "" -}}
-  {{- end -}}
-
-  {{- if and (not $slug) $name -}}
-    {{- $slug = urlize $name -}}
-  {{- end -}}
-
-  {{- with $pageRef -}}
-    {{- $cleanRef := strings.TrimSuffix "/" (strings.TrimPrefix "/" .) -}}
-    {{- $lookupRefs := slice . $cleanRef (printf "/%s/" $cleanRef) -}}
-    {{- range $lookupRefs -}}
-      {{- if not $artistPage -}}
-        {{- with site.GetPage . -}}
-          {{- if eq .Section "artists" -}}
-            {{- $artistPage = . -}}
-          {{- end -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{- if and (not $artistPage) $slug -}}
-    {{- $slugPath := strings.TrimSuffix "/" (strings.TrimPrefix "/" $slug) -}}
-    {{- $slugBase := path.Base $slugPath -}}
-    {{- if $slugBase -}}
-      {{- $firstChar := substr $slugBase 0 1 | lower -}}
-      {{- $lookupRefs := slice
-        (printf "artists/%s" $slugPath)
-        (printf "artists/%s/%s" $firstChar $slugBase)
-        (printf "/artists/%s/" $slugPath)
-        (printf "/artists/%s/%s/" $firstChar $slugBase)
-      -}}
-      {{- range $lookupRefs -}}
-        {{- if not $artistPage -}}
-          {{- with site.GetPage . -}}
-            {{- if eq .Section "artists" -}}
-              {{- $artistPage = . -}}
-            {{- end -}}
-          {{- end -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{- if and (not $artistPage) (or $slug $name) -}}
-    {{- $slugCandidate := $slug | default (urlize $name) -}}
-    {{- $nameCandidate := urlize $name -}}
-    {{- range $artistPages -}}
-      {{- if not $artistPage -}}
-        {{- $pageSlug := .Slug | default (path.Base .RelPermalink) | urlize -}}
-        {{- $fileSlug := "" -}}
-        {{- with .File -}}
-          {{- $fileSlug = path.Base (strings.TrimSuffix "/" .Dir) | urlize -}}
-        {{- end -}}
-        {{- $titleSlug := .Title | urlize -}}
-        {{- if or
-          (and $slugCandidate (or (eq $slugCandidate $pageSlug) (eq $slugCandidate $fileSlug) (eq $slugCandidate $titleSlug)))
-          (and $nameCandidate (eq $nameCandidate $titleSlug))
-        -}}
-          {{- $artistPage = . -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{- if or $name $artistPage -}}
-    {{- if and (not $name) $artistPage -}}
-      {{- $name = $artistPage.Title -}}
-    {{- end -}}
-    {{- $artists = $artists | append (dict "name" $name "page" $artistPage) -}}
-  {{- end -}}
-{{- end -}}
-
-{{- if gt (len $artists) 0 -}}
-  {{- $heading := cond (eq (len $artists) 1) "Artist" "Artists" -}}
+{{- if gt (len $artistCards) 0 -}}
+  {{- $heading := cond (eq (len $artistCards) 1) "Artist" "Artists" -}}
   <section
     class="release-artists"
     role="region"
     aria-labelledby="release-artists-heading">
     <h2 id="release-artists-heading" class="release-artists__heading">{{ $heading }}</h2>
     <div class="release-artists__list" role="list">
-      {{- range $artists }}
+      {{- range $artistCards }}
         {{- $artistPage := .page -}}
-        {{- $summary := "" -}}
-        {{- with $artistPage -}}
-          {{- $summary = .Summary | plainify | strings.TrimSpace -}}
-        {{- end -}}
         <article class="release-artists__item" role="listitem">
           <div class="release-artists__body">
             <h3 class="release-artists__name">
@@ -149,11 +30,8 @@
                 {{ .name | emojify }}
               {{- end -}}
             </h3>
-            {{- with $summary }}
+            {{- with .summary }}
               <p class="release-artists__summary">{{ . }}</p>
-            {{- end }}
-            {{- with $artistPage }}
-              <a class="release-artists__profile-link" href="{{ .RelPermalink }}">View Artist Profile &rarr;</a>
             {{- end }}
           </div>
         </article>

--- a/src/layouts/partials/release/hero.html
+++ b/src/layouts/partials/release/hero.html
@@ -165,26 +165,7 @@
   {{ end }}
 {{ end }}
 
-{{ $artist := "" }}
-{{ with $artistNames }}
-  {{ $artist = delimit . ", " }}
-{{ end }}
-
-{{ $releaseDate := .Params.releaseDate | default .Params.release_date | default .Params.date }}
-{{ if and (not $releaseDate) (not .Date.IsZero) }}
-  {{ $releaseDate = .Date }}
-{{ end }}
-{{ $releaseDateText := "" }}
-{{ with $releaseDate }}
-  {{ if reflect.IsMap . }}
-  {{ else if reflect.IsSlice . }}
-  {{ else }}
-    {{ $releaseDateText = printf "%v" . }}
-    {{ if or (in $releaseDateText "UTC") (in $releaseDateText "+0000") }}
-      {{ $releaseDateText = time.Format (site.Params.dateFormat | default "2 January 2006") . }}
-    {{ end }}
-  {{ end }}
-{{ end }}
+{{ $artists := partial "release/resolve-artists.html" . }}
 {{ $releaseType := .Params.releaseType | default .Params.release_type | default .Params.type }}
 {{ $accentColor := "" }}
 {{ with .Params.artworkAccent }}
@@ -228,27 +209,26 @@
           class="mt-0 text-3xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral sm:text-4xl lg:text-5xl">
           {{ .Title | emojify }}
         </h1>
-        {{ with $artist }}
+        {{ with $artists }}
           <p class="release-hero__artist text-lg font-medium text-neutral-700 dark:text-neutral-300">
-            {{ . }}
+            {{- range $index, $artist := . -}}
+              {{- if gt $index 0 }}, {{ end -}}
+              {{- with $artist.page -}}
+                <a class="release-hero__artist-link" href="{{ .RelPermalink }}">{{ $artist.name | emojify }}</a>
+              {{- else -}}
+                <span>{{ $artist.name | emojify }}</span>
+              {{- end -}}
+            {{- end -}}
           </p>
         {{ end }}
       </div>
 
-      {{ if or $releaseDateText $releaseType }}
+      {{ with $releaseType }}
         <dl class="release-hero__metadata">
-          {{ with $releaseDateText }}
-            <div>
-              <dt>Released</dt>
-              <dd>{{ . }}</dd>
-            </div>
-          {{ end }}
-          {{ with $releaseType }}
-            <div>
-              <dt>Type</dt>
-              <dd>{{ . }}</dd>
-            </div>
-          {{ end }}
+          <div>
+            <dt>Type</dt>
+            <dd>{{ . }}</dd>
+          </div>
         </dl>
       {{ end }}
     </div>

--- a/src/layouts/partials/release/resolve-artists.html
+++ b/src/layouts/partials/release/resolve-artists.html
@@ -1,0 +1,133 @@
+{{- $artistItems := slice -}}
+
+{{- with .Params.artists -}}
+  {{- if reflect.IsSlice . -}}
+    {{- $artistItems = . -}}
+  {{- else -}}
+    {{- $artistItems = slice . -}}
+  {{- end -}}
+{{- else -}}
+  {{- with .Params.artist -}}
+    {{- if reflect.IsSlice . -}}
+      {{- $artistItems = . -}}
+    {{- else -}}
+      {{- $artistItems = slice . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $artists := slice -}}
+{{- $artistSection := site.GetPage "artists" -}}
+{{- $artistPages := slice -}}
+{{- with $artistSection -}}
+  {{- $artistPages = .RegularPagesRecursive -}}
+{{- else -}}
+  {{- $artistPages = where site.RegularPages "Section" "artists" -}}
+{{- end -}}
+
+{{- range $artistItems -}}
+  {{- $name := "" -}}
+  {{- $pageRef := "" -}}
+  {{- $slug := "" -}}
+  {{- $artistPage := false -}}
+
+  {{- if reflect.IsMap . -}}
+    {{- $name = index . "title" | default (index . "name") | default (index . "artist") | default (index . "slug") -}}
+    {{- $pageRef = index . "page" | default (index . "url") -}}
+    {{- $slug = index . "slug" | default (index . "artist_slug") -}}
+  {{- else -}}
+    {{- $name = printf "%v" . -}}
+    {{- $slug = $.Params.artist_slug -}}
+  {{- end -}}
+
+  {{- if $name -}}
+    {{- $name = printf "%v" $name | strings.TrimSpace -}}
+  {{- else -}}
+    {{- $name = "" -}}
+  {{- end -}}
+  {{- if $pageRef -}}
+    {{- $pageRef = printf "%v" $pageRef | strings.TrimSpace -}}
+  {{- else -}}
+    {{- $pageRef = "" -}}
+  {{- end -}}
+  {{- if $slug -}}
+    {{- $slug = printf "%v" $slug | strings.TrimSpace -}}
+  {{- else -}}
+    {{- $slug = "" -}}
+  {{- end -}}
+
+  {{- if and (not $slug) $name -}}
+    {{- $slug = urlize $name -}}
+  {{- end -}}
+
+  {{- with $pageRef -}}
+    {{- if not (or (strings.HasPrefix . "http://") (strings.HasPrefix . "https://")) -}}
+      {{- $cleanRef := strings.TrimSuffix "/" (strings.TrimPrefix "/" .) -}}
+      {{- $cleanRef = strings.TrimSuffix "/index.md" $cleanRef -}}
+      {{- $cleanRef = strings.TrimSuffix "/_index.md" $cleanRef -}}
+      {{- $lookupRefs := slice . $cleanRef (printf "/%s/" $cleanRef) -}}
+      {{- range $lookupRefs -}}
+        {{- if not $artistPage -}}
+          {{- with site.GetPage . -}}
+            {{- if eq .Section "artists" -}}
+              {{- $artistPage = . -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if and (not $artistPage) $slug -}}
+    {{- $slugPath := strings.TrimSuffix "/" (strings.TrimPrefix "/" $slug) -}}
+    {{- $slugBase := path.Base $slugPath -}}
+    {{- if $slugBase -}}
+      {{- $firstChar := substr $slugBase 0 1 | lower -}}
+      {{- $lookupRefs := slice
+        (printf "artists/%s" $slugPath)
+        (printf "artists/%s/%s" $firstChar $slugBase)
+        (printf "/artists/%s/" $slugPath)
+        (printf "/artists/%s/%s/" $firstChar $slugBase)
+      -}}
+      {{- range $lookupRefs -}}
+        {{- if not $artistPage -}}
+          {{- with site.GetPage . -}}
+            {{- if eq .Section "artists" -}}
+              {{- $artistPage = . -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if and (not $artistPage) (or $slug $name) -}}
+    {{- $slugCandidate := $slug | default (urlize $name) -}}
+    {{- $nameCandidate := urlize $name -}}
+    {{- range $artistPages -}}
+      {{- if not $artistPage -}}
+        {{- $pageSlug := .Slug | default (path.Base .RelPermalink) | urlize -}}
+        {{- $fileSlug := "" -}}
+        {{- with .File -}}
+          {{- $fileSlug = path.Base (strings.TrimSuffix "/" .Dir) | urlize -}}
+        {{- end -}}
+        {{- $titleSlug := .Title | urlize -}}
+        {{- if or
+          (and $slugCandidate (or (eq $slugCandidate $pageSlug) (eq $slugCandidate $fileSlug) (eq $slugCandidate $titleSlug)))
+          (and $nameCandidate (eq $nameCandidate $titleSlug))
+        -}}
+          {{- $artistPage = . -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if or $name $artistPage -}}
+    {{- if and (not $name) $artistPage -}}
+      {{- $name = $artistPage.Title -}}
+    {{- end -}}
+    {{- $artists = $artists | append (dict "name" $name "page" $artistPage) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $artists -}}


### PR DESCRIPTION
## Summary
- simplify individual release heroes to artwork, title, artist, and release type
- resolve release artists through a shared helper so hero artist names link only when a real Artist page exists
- remove the duplicate Artist card profile CTA and keep the card only when it has editorial summary content
- add scoped accessible styling for release hero artist links

## Testing
- `hugo --environment production` using Hugo Extended 0.157.0
- spot-checked `public/releases/q/queens-of-the-stone-age/villains/index.html`