### PR TITLE
feat(src): add branded 404 recovery page

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -10,6 +10,340 @@
   max-width: 42rem;
 }
 
+/* 404 page: branded recovery route for missing pages. */
+
+.not-found-page {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 4rem);
+  margin: 1.5rem 0 5rem;
+}
+
+.not-found-hero {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: center;
+}
+
+.not-found-hero__copy {
+  min-width: 0;
+}
+
+.not-found-kicker {
+  margin: 0 0 0.75rem;
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.dark .not-found-kicker {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.not-found-hero h1,
+.not-found-section h2 {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-weight: 850;
+  letter-spacing: 0;
+}
+
+.dark .not-found-hero h1,
+.dark .not-found-section h2 {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.not-found-hero h1 {
+  max-width: 11ch;
+  font-size: clamp(3rem, 12vw, 6rem);
+  line-height: 0.95;
+}
+
+.not-found-hero__message {
+  max-width: 38rem;
+  margin: 1.2rem 0 0;
+  color: #262626; /* neutral-800 */
+  font-size: clamp(1.15rem, 2.4vw, 1.45rem);
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.dark .not-found-hero__message {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.not-found-hero__recovery,
+.not-found-section__header p,
+.not-found-route__description,
+.not-found-show__summary {
+  color: #525252; /* neutral-600 */
+}
+
+.dark .not-found-hero__recovery,
+.dark .not-found-section__header p,
+.dark .not-found-route__description,
+.dark .not-found-show__summary {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.not-found-hero__recovery {
+  max-width: 42rem;
+  margin: 0.85rem 0 0;
+  font-size: 1.03rem;
+  line-height: 1.75;
+}
+
+.not-found-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.not-found-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  max-width: 100%;
+  border-radius: 0.5rem;
+  padding: 0.7rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 750;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.not-found-button:hover {
+  transform: translateY(-0.0625rem);
+}
+
+.not-found-button:focus-visible,
+.not-found-route:focus-visible,
+.not-found-show:focus-visible {
+  outline: 3px solid rgba(var(--color-primary-500), 0.6);
+  outline-offset: 3px;
+}
+
+.not-found-button--primary {
+  background: #171717; /* neutral-900 */
+  color: #ffffff;
+}
+
+.not-found-button--primary:hover {
+  background: rgba(var(--color-primary-700), 1);
+  color: #ffffff;
+}
+
+.dark .not-found-button--primary {
+  background: #f5f5f5; /* neutral-100 */
+  color: #171717; /* neutral-900 */
+}
+
+.dark .not-found-button--primary:hover {
+  background: rgba(var(--color-primary-300), 1);
+  color: #171717;
+}
+
+.not-found-button--secondary {
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  background: #ffffff;
+  color: #171717; /* neutral-900 */
+}
+
+.not-found-button--secondary:hover {
+  border-color: #737373; /* neutral-500 */
+  background: #f5f5f5; /* neutral-100 */
+  color: #171717;
+}
+
+.dark .not-found-button--secondary {
+  border-color: #525252; /* neutral-600 */
+  background: #262626; /* neutral-800 */
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.dark .not-found-button--secondary:hover {
+  border-color: #a3a3a3; /* neutral-400 */
+  background: #404040; /* neutral-700 */
+  color: #ffffff;
+}
+
+.not-found-hero__media {
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.5rem;
+  background: #fff7ed; /* orange-50 */
+  box-shadow: 0 18px 50px rgb(0 0 0 / 0.16);
+}
+
+.dark .not-found-hero__media {
+  border-color: #404040; /* neutral-700 */
+  background: #171717; /* neutral-900 */
+}
+
+.not-found-hero__media img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.not-found-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.not-found-section__header {
+  max-width: 44rem;
+}
+
+.not-found-section h2 {
+  font-size: clamp(1.75rem, 5vw, 2.45rem);
+  line-height: 1.05;
+}
+
+.not-found-section__header p {
+  margin: 0.55rem 0 0;
+  line-height: 1.7;
+}
+
+.not-found-link-grid,
+.not-found-latest {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.not-found-route,
+.not-found-show {
+  display: flex;
+  min-width: 0;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.5rem;
+  background: rgb(255 255 255 / 0.78);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+  color: inherit;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.dark .not-found-route,
+.dark .not-found-show {
+  border-color: #404040; /* neutral-700 */
+  background: rgb(23 23 23 / 0.72);
+}
+
+.not-found-route:hover,
+.not-found-show:hover {
+  border-color: rgba(var(--color-primary-500), 0.45);
+  box-shadow: 0 10px 18px rgb(0 0 0 / 0.08);
+  color: inherit;
+  text-decoration: none;
+  transform: translateY(-0.0625rem);
+}
+
+.not-found-route {
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.1rem;
+}
+
+.not-found-route__label,
+.not-found-show__title {
+  color: #171717; /* neutral-900 */
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.dark .not-found-route__label,
+.dark .not-found-show__title {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.not-found-route:hover .not-found-route__label,
+.not-found-route:focus-visible .not-found-route__label,
+.not-found-show:hover .not-found-show__title,
+.not-found-show:focus-visible .not-found-show__title {
+  color: rgba(var(--color-primary-700), 1);
+  text-decoration: underline;
+  text-underline-offset: 0.16rem;
+}
+
+.dark .not-found-route:hover .not-found-route__label,
+.dark .not-found-route:focus-visible .not-found-route__label,
+.dark .not-found-show:hover .not-found-show__title,
+.dark .not-found-show:focus-visible .not-found-show__title {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.not-found-route__description {
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.not-found-show {
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+}
+
+.not-found-show__meta {
+  color: rgba(var(--color-primary-700), 1);
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.dark .not-found-show__meta {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.not-found-show__summary {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+@media (min-width: 700px) {
+  .not-found-link-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .not-found-hero {
+    grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.78fr);
+  }
+
+  .not-found-latest {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .not-found-button,
+  .not-found-route,
+  .not-found-show {
+    transition: none;
+  }
+
+  .not-found-button:hover,
+  .not-found-route:hover,
+  .not-found-show:hover {
+    transform: none;
+  }
+}
+
 /* Contact form toast notifications. Scoped to the contact shortcode so other
    site forms keep their existing behaviour. */
 

--- a/src/config/_default/params.toml
+++ b/src/config/_default/params.toml
@@ -35,6 +35,54 @@ listen_live_stream_url = ""
 # Resolved as a static file path (e.g. /images/my-logo.jpg).
 headerAvatar = "/images/sundown-sessions-logo.jpg"
 
+[notFound]
+  eyebrow = "404 Not Found"
+  title = "Signal Lost"
+  message = "The page you're looking for seems to have drifted off air."
+  recovery = "There is still plenty worth listening to. Try one of these routes back into Sundown Sessions."
+  image = "/images/404.png"
+  imageAlt = "Illustration of headphones around a radio tower with a 404 not found message."
+
+  [notFound.primary]
+    label = "Listen Live"
+    url = "/listen-live/"
+    event = "listen_live_click"
+    provider = "404-primary"
+
+  [notFound.secondary]
+    label = "Back Home"
+    url = "/"
+    event = "not_found_recovery_click"
+    provider = "home"
+
+  [[notFound.links]]
+    label = "Browse Shows"
+    url = "/shows/"
+    description = "Find recent playlists and broadcasts."
+    event = "not_found_recovery_click"
+    provider = "shows"
+
+  [[notFound.links]]
+    label = "Search the Site"
+    url = "/search/"
+    description = "Look for artists, releases, tracks and shows."
+    event = "not_found_recovery_click"
+    provider = "search"
+
+  [[notFound.links]]
+    label = "Meet the Presenter"
+    url = "/about/"
+    description = "Learn more about the show and its story."
+    event = "not_found_recovery_click"
+    provider = "about"
+
+  [[notFound.links]]
+    label = "Contact Us"
+    url = "/contact/"
+    description = "Tell us about a broken link or send a request."
+    event = "not_found_recovery_click"
+    provider = "contact"
+
 [favicon]
   # Static favicon asset paths. Tenant-specific builds can override these values
   # without changing the Blowfish partial.

--- a/src/layouts/404.html
+++ b/src/layouts/404.html
@@ -1,0 +1,120 @@
+{{ define "main" }}
+  {{- $config := site.Params.notFound | default dict -}}
+  {{- $title := $config.title | default "Signal Lost" -}}
+  {{- $eyebrow := $config.eyebrow | default "404 Not Found" -}}
+  {{- $message := $config.message | default "The page you're looking for seems to have drifted off air." -}}
+  {{- $recovery := $config.recovery | default "There is still plenty worth listening to. Try one of these routes back into Sundown Sessions." -}}
+  {{- $image := $config.image | default "/images/404.png" -}}
+  {{- $imageAlt := $config.imageAlt | default "Illustration of headphones around a radio tower with a 404 not found message." -}}
+  {{- $primary := $config.primary | default (dict "label" "Listen Live" "url" "/listen-live/" "event" "listen_live_click" "provider" "404-primary") -}}
+  {{- $secondary := $config.secondary | default (dict "label" "Back Home" "url" "/" "event" "not_found_recovery_click" "provider" "home") -}}
+  {{- $links := $config.links | default (slice
+    (dict "label" "Browse Shows" "url" "/shows/" "description" "Find recent playlists and broadcasts." "event" "not_found_recovery_click" "provider" "shows")
+    (dict "label" "Search the Site" "url" "/search/" "description" "Look for artists, releases, tracks and shows." "event" "not_found_recovery_click" "provider" "search")
+    (dict "label" "Meet the Presenter" "url" "/about/" "description" "Learn more about the show and its story." "event" "not_found_recovery_click" "provider" "about")
+    (dict "label" "Contact Us" "url" "/contact/" "description" "Tell us about a broken link or send a request." "event" "not_found_recovery_click" "provider" "contact")
+  ) -}}
+  {{- $shows := where site.RegularPages "Section" "shows" -}}
+  {{- $datedShows := where $shows ".Date.IsZero" "ne" true -}}
+  {{- $latestShows := first 3 (sort $datedShows "Date" "desc") -}}
+
+  <article class="not-found-page" aria-labelledby="not-found-heading">
+    <section class="not-found-hero">
+      <div class="not-found-hero__copy">
+        <p class="not-found-kicker">{{ $eyebrow }}</p>
+        <h1 id="not-found-heading">{{ $title }}</h1>
+        <p class="not-found-hero__message">{{ $message }}</p>
+        <p class="not-found-hero__recovery">{{ $recovery }}</p>
+
+        <div class="not-found-actions" aria-label="404 recovery actions">
+          <a
+            class="not-found-button not-found-button--primary"
+            href="{{ default "/listen-live/" $primary.url | relURL }}"
+            data-analytics-event="{{ $primary.event | default "listen_live_click" }}"
+            data-analytics-provider="{{ $primary.provider | default "404-primary" }}">
+            {{ $primary.label | default "Listen Live" }}
+          </a>
+          <a
+            class="not-found-button not-found-button--secondary"
+            href="{{ default "/" $secondary.url | relURL }}"
+            data-analytics-event="{{ $secondary.event | default "not_found_recovery_click" }}"
+            data-analytics-provider="{{ $secondary.provider | default "home" }}">
+            {{ $secondary.label | default "Back Home" }}
+          </a>
+        </div>
+      </div>
+
+      <figure class="not-found-hero__media">
+        <img src="{{ $image | relURL }}" alt="{{ $imageAlt }}">
+      </figure>
+    </section>
+
+    <section class="not-found-section" aria-labelledby="not-found-routes-heading">
+      <div class="not-found-section__header">
+        <h2 id="not-found-routes-heading">Tune Back In</h2>
+        <p>Useful routes if the link was old, mistyped or moved during a reshuffle.</p>
+      </div>
+
+      <div class="not-found-link-grid">
+        {{- range $links }}
+          <a
+            class="not-found-route"
+            href="{{ .url | relURL }}"
+            data-analytics-event="{{ .event | default "not_found_recovery_click" }}"
+            data-analytics-provider="{{ .provider | default .label }}">
+            <span class="not-found-route__label">{{ .label }}</span>
+            {{- with .description }}
+              <span class="not-found-route__description">{{ . }}</span>
+            {{- end }}
+          </a>
+        {{- end }}
+      </div>
+    </section>
+
+    {{- if gt (len $latestShows) 0 }}
+      <section class="not-found-section" aria-labelledby="not-found-latest-heading">
+        <div class="not-found-section__header">
+          <h2 id="not-found-latest-heading">Latest Listen Again</h2>
+          <p>Recent Sundown Sessions broadcasts ready when you are.</p>
+        </div>
+
+        <div class="not-found-latest">
+          {{- range $latestShows }}
+            {{- $showLabel := "" -}}
+            {{- $showTitle := .Title | plainify -}}
+            {{- $titleParts := split .Title ": " -}}
+            {{- if gt (len $titleParts) 1 -}}
+              {{- $showLabel = index $titleParts 0 -}}
+              {{- $showTitle = strings.TrimPrefix (printf "%s: " $showLabel) .Title | plainify -}}
+            {{- end -}}
+            <a
+              class="not-found-show"
+              href="{{ .RelPermalink }}"
+              data-analytics-event="not_found_latest_show_click"
+              data-analytics-provider="latest-listen-again">
+              <span class="not-found-show__meta">
+                {{- with $showLabel }}{{ . }} &middot; {{ end -}}{{ .Date.Format "2 Jan 2006" }}
+              </span>
+              <span class="not-found-show__title">{{ $showTitle }}</span>
+              {{- with .Summary }}
+                <span class="not-found-show__summary">{{ . | plainify }}</span>
+              {{- end }}
+            </a>
+          {{- end }}
+        </div>
+      </section>
+    {{- end }}
+  </article>
+
+  <script>
+    window.addEventListener("DOMContentLoaded", function() {
+      if (!window.sundownAnalytics || typeof window.sundownAnalytics.track !== "function") return;
+      window.sundownAnalytics.track("not_found_view", {
+        requested_path: window.location.pathname,
+        requested_url: window.location.href,
+        referrer: document.referrer,
+        page_type: "404"
+      });
+    }, { once: true });
+  </script>
+{{ end }}


### PR DESCRIPTION
## Summary
- Replaces the default Blowfish 404 with a branded Sundown Sessions "Signal Lost" recovery page.
- Adds config-light `params.notFound` defaults for copy, imagery, and recovery links.
- Adds scoped responsive styles, recovery CTA analytics, latest-show discovery, and a `not_found_view` analytics event.

Closes #475.

## Testing
- Confirmed the new template/config/styles exist and the working tree was clean before opening the PR.
- `hugo --environment production` could not be run locally because `hugo` is not installed/on PATH in this shell.
