### PR TITLE
feat(src): add listen live status label

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1,13 +1,43 @@
 /* Listen Live page: native player sizing inside article prose. */
 
 .listen-live-player {
-  margin: 2rem 0 1.25rem;
+  margin: 0.75rem 0 1.25rem;
 }
 
 .listen-live-player audio {
   display: block;
   width: 100%;
   max-width: 42rem;
+}
+
+.listen-live-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: fit-content;
+  margin: 1.75rem 0 0;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.72);
+  padding: 0.35rem 0.75rem;
+  color: #404040; /* neutral-700 */
+  font-size: 0.9rem;
+  font-weight: 750;
+  line-height: 1.3;
+}
+
+.dark .listen-live-status {
+  border-color: #404040; /* neutral-700 */
+  background: rgb(23 23 23 / 0.72);
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.listen-live-status__dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(var(--color-primary-500), 0.85);
+  box-shadow: 0 0 0 0.18rem rgba(var(--color-primary-500), 0.12);
 }
 
 /* 404 page: branded recovery route for missing pages. */

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -11,6 +11,11 @@ Tune in to Sundown Sessions live.
 
 Alternative music, exclusive tracks, artist interviews and carefully curated playlists from across the independent music landscape.
 
+<div class="listen-live-status" aria-label="Live stream status">
+  <span class="listen-live-status__dot" aria-hidden="true"></span>
+  <span>Sundown Sessions Live</span>
+</div>
+
 {{< listen-live-player >}}
 
 If the player doesn't load, you can [listen directly using the NuCast player](https://betelgeuse.nucast.co.uk/public/8062).


### PR DESCRIPTION
## Summary
- Adds a static "Sundown Sessions Live" status label above the Listen Live audio player.
- Uses a subtle dot treatment and scoped CSS consistent with the existing Blowfish styling.
- Leaves the audio player unchanged and does not add dynamic stream-status logic.

## Testing
- Confirmed the change is limited to the Listen Live content and scoped CSS.
- `hugo --environment production` could not be run locally because `hugo` is not installed/on PATH in this shell.
