### PR TITLE
feat(src): add listen live supporting content

### DIFF
--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -19,3 +19,11 @@ Alternative music, exclusive tracks, artist interviews and carefully curated pla
 {{< listen-live-player >}}
 
 If the player doesn't load, you can [listen directly using the NuCast player](https://betelgeuse.nucast.co.uk/public/8062).
+
+## What You'll Hear
+
+Expect alternative music after dark, new discoveries, independent artists, exclusive first plays, interviews, deep cuts and carefully chosen tracks from across the musical landscape.
+
+## When to Listen
+
+Sundown Sessions broadcasts live when a show is scheduled. Outside live broadcasts, you can explore [past shows](/shows/) and [listen again](https://www.mixcloud.com/sundownsessions/) through the archive.


### PR DESCRIPTION
## Summary
- add compact supporting sections beneath the Listen Live player
- link visitors to past shows and the Mixcloud listen-again archive
- keep the existing player implementation and page layout unchanged

## Testing
- Not run: Hugo is not installed/on PATH in this environment