### PR TITLE
feat(src): add Listen Live now playing fallback

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -40,6 +40,69 @@
   box-shadow: 0 0 0 0.18rem rgba(var(--color-primary-500), 0.12);
 }
 
+.listen-live-now-playing {
+  max-width: 42rem;
+  margin: 1.5rem 0 2.25rem;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.5rem;
+  background: rgb(255 255 255 / 0.74);
+  padding: 1.1rem 1.2rem;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+}
+
+.dark .listen-live-now-playing {
+  border-color: #404040; /* neutral-700 */
+  background: rgb(23 23 23 / 0.72);
+}
+
+.listen-live-now-playing h2 {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-size: 1.15rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.dark .listen-live-now-playing h2 {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.listen-live-now-playing__body {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.55rem;
+}
+
+.listen-live-now-playing p {
+  margin: 0;
+  color: #525252; /* neutral-600 */
+  line-height: 1.65;
+}
+
+.dark .listen-live-now-playing p {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.listen-live-now-playing a {
+  width: fit-content;
+  max-width: 100%;
+  color: rgba(var(--color-primary-700), 1);
+  font-weight: 750;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  text-decoration: underline;
+  text-underline-offset: 0.16rem;
+}
+
+.dark .listen-live-now-playing a {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.listen-live-now-playing a:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 0.18rem;
+}
+
 /* 404 page: branded recovery route for missing pages. */
 
 .not-found-page {

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -20,6 +20,14 @@ Press play, settle in, and discover what is drifting through the Sundown Session
 
 If the player doesn't load, you can [listen directly using the NuCast player](https://betelgeuse.nucast.co.uk/public/8062).
 
+<section class="listen-live-now-playing" aria-labelledby="now-playing-heading">
+  <h2 id="now-playing-heading">Now Playing</h2>
+  <div class="listen-live-now-playing__body" data-now-playing-state="fallback">
+    <p data-now-playing-fallback>Live track information is not available just yet. Press play to hear what's currently drifting through Sundown Sessions.</p>
+    <a href="/shows/" data-now-playing-archive>Explore past shows</a>
+  </div>
+</section>
+
 ## What You'll Hear
 
 Expect alternative music after dark, new discoveries, independent artists, exclusive first plays, interviews, deep cuts and carefully chosen tracks from across the musical landscape.


### PR DESCRIPTION
## Summary
- add a compact Now Playing fallback section below the live player and NuCast link
- style the section with scoped Listen Live CSS for light and dark mode
- include data hooks so future stream metadata can replace the fallback content

## Verification
- git diff --check
- attempted \hugo --environment production\, but Hugo is not installed or available in PATH on this machine