### PR TITLE
Improve Listen Live social follow section

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -103,6 +103,42 @@
   outline-offset: 0.18rem;
 }
 
+.listen-live-follow {
+  max-width: 42rem;
+  margin: 2rem 0 0;
+}
+
+.listen-live-follow h2 {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-size: 1.15rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.dark .listen-live-follow h2 {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.listen-live-follow p {
+  margin: 0.45rem 0 0;
+  color: #525252; /* neutral-600 */
+  line-height: 1.65;
+}
+
+.dark .listen-live-follow p {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.listen-live-follow > div {
+  margin-top: 0.75rem;
+}
+
+.listen-live-follow a:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 0.18rem;
+}
+
 /* 404 page: branded recovery route for missing pages. */
 
 .not-found-page {

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -5,6 +5,7 @@ showDate: false
 showReadingTime: false
 showAuthor: false
 showTableOfContents: false
+sharingLinks: false
 ---
 
 Join Sundown Sessions live for alternative music after dark, exclusive first plays, artist interviews and carefully curated selections from across the independent music landscape.
@@ -38,3 +39,5 @@ Sundown Sessions broadcasts live when a show is scheduled. Outside live broadcas
 ## What You'll Hear
 
 Expect alternative music after dark, new discoveries, independent artists, exclusive first plays, interviews, deep cuts and carefully chosen tracks from across the musical landscape.
+
+{{< social-follow >}}

--- a/src/layouts/shortcodes/social-follow.html
+++ b/src/layouts/shortcodes/social-follow.html
@@ -1,0 +1,7 @@
+{{- with .Site.Params.Author.links -}}
+  <section class="listen-live-follow" aria-labelledby="listen-live-follow-heading">
+    <h2 id="listen-live-follow-heading">Follow Sundown Sessions</h2>
+    <p>Keep up with future broadcasts, featured artists, new discoveries and listen-again links.</p>
+    {{ partial "author-links.html" $ }}
+  </section>
+{{- end -}}


### PR DESCRIPTION
## Summary
- add a compact Follow Sundown Sessions section to the Listen Live page
- reuse the existing Blowfish author social links/icons via a shortcode
- disable the generic share bar on Listen Live so the page-specific follow section does not feel duplicated

## Verification
- Ran git diff --check successfully; Git reported line-ending conversion warnings only.
- Could not run hugo --minify because hugo is not installed/on PATH in this environment.