### PR TITLE
Add Listen Live now playing metadata

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -128,6 +128,64 @@
   width: 100%;
 }
 
+.listen-live-player-shell {
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+}
+
+.listen-live-player-shell__main {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.listen-live-now-playing__artwork {
+  display: grid;
+  width: min(100%, 9rem);
+  aspect-ratio: 1 / 1;
+  align-items: center;
+  justify-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(var(--color-primary-500), 0.24);
+  border-radius: 0.5rem;
+  background:
+    linear-gradient(135deg, rgba(var(--color-primary-500), 0.14), transparent 46%),
+    #f5f5f5; /* neutral-100 */
+  color: rgba(var(--color-primary-700), 1);
+}
+
+.dark .listen-live-now-playing__artwork {
+  border-color: rgba(var(--color-primary-400), 0.3);
+  background:
+    linear-gradient(135deg, rgba(var(--color-primary-400), 0.18), transparent 46%),
+    #262626; /* neutral-800 */
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.listen-live-now-playing__artwork img,
+.listen-live-now-playing__artwork span {
+  grid-area: 1 / 1;
+}
+
+.listen-live-now-playing__artwork img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.listen-live-now-playing__artwork span {
+  font-size: 1.4rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.listen-live-now-playing [hidden],
+.listen-live-now-playing__artwork [hidden] {
+  display: none !important;
+}
+
 .listen-live-status {
   display: inline-flex;
   align-items: center;
@@ -165,6 +223,43 @@
 .listen-live-now-playing__body {
   display: grid;
   gap: 0.65rem;
+}
+
+.listen-live-now-playing__details {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.listen-live-now-playing__details div {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.listen-live-now-playing__details dt {
+  color: #737373; /* neutral-500 */
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.dark .listen-live-now-playing__details dt {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.listen-live-now-playing__details dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: #262626; /* neutral-800 */
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.dark .listen-live-now-playing__details dd {
+  color: #f5f5f5; /* neutral-100 */
 }
 
 .listen-live-now-playing a,
@@ -258,6 +353,10 @@
 }
 
 @media (min-width: 700px) {
+  .listen-live-player-shell {
+    grid-template-columns: 9rem minmax(0, 1fr);
+  }
+
   .listen-live-detail-grid,
   .listen-live-more__grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/src/assets/js/listen-live-now-playing.js
+++ b/src/assets/js/listen-live-now-playing.js
@@ -1,0 +1,358 @@
+(function () {
+  "use strict";
+
+  var POLL_INTERVAL_MS = 45000;
+  var STREAM_TIMEOUT_MS = 10000;
+  var FALLBACK_COPY = "Live track information is not available just yet. Press play to hear what's currently drifting through Sundown Sessions.";
+
+  var root = document.querySelector("[data-now-playing]");
+  if (!root || !window.fetch) {
+    return;
+  }
+
+  var elements = {
+    body: root.querySelector("[data-now-playing-state]"),
+    fallback: root.querySelector("[data-now-playing-fallback]"),
+    details: root.querySelector("[data-now-playing-details]"),
+    artwork: root.querySelector("[data-now-playing-artwork]"),
+    artworkWrap: root.querySelector("[data-now-playing-artwork-wrap]"),
+    placeholder: root.querySelector("[data-now-playing-artwork-placeholder]"),
+    artistRow: root.querySelector("[data-now-playing-artist-row]"),
+    artist: root.querySelector("[data-now-playing-artist]"),
+    trackRow: root.querySelector("[data-now-playing-track-row]"),
+    track: root.querySelector("[data-now-playing-track]"),
+    albumRow: root.querySelector("[data-now-playing-album-row]"),
+    album: root.querySelector("[data-now-playing-album]")
+  };
+
+  var lastRendered = "";
+
+  function getEndpoint(name) {
+    return root.getAttribute(name) || "";
+  }
+
+  function clean(value) {
+    return typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+  }
+
+  function isUsefulUrl(value) {
+    if (!value) {
+      return false;
+    }
+
+    try {
+      var url = new URL(value, window.location.href);
+      return url.protocol === "https:" || url.protocol === "http:";
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function splitCombinedTitle(value) {
+    var title = clean(value);
+    if (!title) {
+      return null;
+    }
+
+    var separator = title.indexOf(" - ");
+    if (separator === -1) {
+      return {
+        artist: "",
+        track: title,
+        album: "",
+        artwork: ""
+      };
+    }
+
+    return {
+      artist: clean(title.slice(0, separator)),
+      track: clean(title.slice(separator + 3)),
+      album: "",
+      artwork: ""
+    };
+  }
+
+  function normalizeMetadata(source) {
+    if (!source) {
+      return null;
+    }
+
+    var combinedTitle = clean(source.title || source.nowplaying || source.songtitle || source.currentSong || source.text);
+    var metadata = {
+      artist: clean(source.artist || source.artistName),
+      track: clean(source.track || source.title || source.song || source.name),
+      album: clean(source.album || source.albumTitle),
+      artwork: clean(source.artwork || source.artworkUrl || source.cover || source.coverUrl || source.image)
+    };
+
+    if ((!metadata.artist || !metadata.track) && combinedTitle) {
+      var split = splitCombinedTitle(combinedTitle);
+      if (split) {
+        metadata.artist = metadata.artist || split.artist;
+        metadata.track = metadata.track || split.track;
+      }
+    }
+
+    if (!metadata.track && combinedTitle) {
+      metadata.track = combinedTitle;
+    }
+
+    if (!metadata.artist && !metadata.track && !metadata.album && !metadata.artwork) {
+      return null;
+    }
+
+    if (!isUsefulUrl(metadata.artwork)) {
+      metadata.artwork = "";
+    }
+
+    return metadata;
+  }
+
+  function parseShoutcastSevenHtml(html) {
+    var text = clean(html.replace(/<[^>]+>/g, " "));
+    var fields = text.split(",");
+    if (fields.length < 7) {
+      return null;
+    }
+
+    return normalizeMetadata({
+      title: fields.slice(6).join(",")
+    });
+  }
+
+  function parseIcyStreamTitle(value) {
+    var match = value.match(/StreamTitle='([^']*)'/i);
+    return match ? normalizeMetadata({ title: match[1] }) : null;
+  }
+
+  function setText(node, value) {
+    if (node) {
+      node.textContent = value;
+    }
+  }
+
+  function setRow(row, node, value) {
+    if (!row || !node) {
+      return;
+    }
+
+    row.hidden = !value;
+    setText(node, value);
+  }
+
+  function renderFallback() {
+    if (elements.body) {
+      elements.body.setAttribute("data-now-playing-state", "fallback");
+    }
+    if (elements.fallback) {
+      elements.fallback.hidden = false;
+      elements.fallback.textContent = FALLBACK_COPY;
+    }
+    if (elements.details) {
+      elements.details.hidden = true;
+    }
+    if (elements.artwork) {
+      elements.artwork.hidden = true;
+      elements.artwork.removeAttribute("src");
+      elements.artwork.alt = "";
+    }
+    if (elements.placeholder) {
+      elements.placeholder.hidden = false;
+    }
+    if (elements.artworkWrap) {
+      elements.artworkWrap.setAttribute("aria-hidden", "true");
+    }
+  }
+
+  function renderMetadata(metadata) {
+    var nextKey = JSON.stringify(metadata);
+    if (nextKey === lastRendered) {
+      return;
+    }
+    lastRendered = nextKey;
+
+    if (elements.body) {
+      elements.body.setAttribute("data-now-playing-state", "ready");
+    }
+    if (elements.fallback) {
+      elements.fallback.hidden = true;
+    }
+    if (elements.details) {
+      elements.details.hidden = false;
+    }
+
+    setRow(elements.artistRow, elements.artist, metadata.artist);
+    setRow(elements.trackRow, elements.track, metadata.track);
+    setRow(elements.albumRow, elements.album, metadata.album);
+
+    if (metadata.artwork && elements.artwork) {
+      elements.artwork.src = metadata.artwork;
+      elements.artwork.alt = "Album artwork for " + (metadata.track || "the current track") + (metadata.artist ? " by " + metadata.artist : "");
+      elements.artwork.hidden = false;
+      if (elements.placeholder) {
+        elements.placeholder.hidden = true;
+      }
+      if (elements.artworkWrap) {
+        elements.artworkWrap.removeAttribute("aria-hidden");
+      }
+    } else {
+      if (elements.artwork) {
+        elements.artwork.hidden = true;
+        elements.artwork.removeAttribute("src");
+        elements.artwork.alt = "";
+      }
+      if (elements.placeholder) {
+        elements.placeholder.hidden = false;
+      }
+      if (elements.artworkWrap) {
+        elements.artworkWrap.setAttribute("aria-hidden", "true");
+      }
+    }
+  }
+
+  function logQuietly(error) {
+    if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
+      console.debug("Listen Live metadata unavailable", error);
+    }
+  }
+
+  function fetchJsonEndpoint(url) {
+    if (!url) {
+      return Promise.resolve(null);
+    }
+
+    // NuCast currently exposes useful JSON here, but does not send CORS headers.
+    // Static hosting cannot proxy it, so production browsers may reject this request.
+    return fetch(url, { cache: "no-store", mode: "cors" })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error("Metadata JSON returned " + response.status);
+        }
+        return response.json();
+      })
+      .then(normalizeMetadata);
+  }
+
+  function fetchShoutcastEndpoint(url) {
+    if (!url) {
+      return Promise.resolve(null);
+    }
+
+    // Shoutcast /7.html returns a comma-delimited title, but it may also be
+    // blocked by CORS when requested from GitHub Pages.
+    return fetch(url, { cache: "no-store", mode: "cors" })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error("Shoutcast metadata returned " + response.status);
+        }
+        return response.text();
+      })
+      .then(parseShoutcastSevenHtml);
+  }
+
+  function fetchIcyStreamMetadata(url) {
+    if (!url || !window.ReadableStream || !window.TextDecoder) {
+      return Promise.resolve(null);
+    }
+
+    var controller = new AbortController();
+    var timeoutId = window.setTimeout(function () {
+      controller.abort();
+    }, STREAM_TIMEOUT_MS);
+
+    // This stream does send CORS headers, but reading ICY metadata needs the
+    // Icy-MetaData request header. Some browsers or servers will reject the
+    // resulting preflight, so this remains a best-effort fallback.
+    return fetch(url, {
+      cache: "no-store",
+      headers: {
+        "Icy-MetaData": "1"
+      },
+      mode: "cors",
+      signal: controller.signal
+    })
+      .then(function (response) {
+        var metaint = parseInt(response.headers.get("icy-metaint"), 10);
+        if (!response.ok || !response.body || !metaint) {
+          throw new Error("ICY stream metadata is not readable");
+        }
+
+        var reader = response.body.getReader();
+        var decoder = new TextDecoder("utf-8");
+        var bytesSeen = 0;
+        var metadataLength = null;
+        var metadataBytes = [];
+
+        function readChunk() {
+          return reader.read().then(function (result) {
+            if (result.done) {
+              return null;
+            }
+
+            for (var i = 0; i < result.value.length; i += 1) {
+              var byte = result.value[i];
+              if (bytesSeen < metaint) {
+                bytesSeen += 1;
+                continue;
+              }
+
+              if (metadataLength === null) {
+                metadataLength = byte * 16;
+                if (metadataLength === 0) {
+                  controller.abort();
+                  return null;
+                }
+                continue;
+              }
+
+              metadataBytes.push(byte);
+              if (metadataBytes.length >= metadataLength) {
+                controller.abort();
+                return parseIcyStreamTitle(decoder.decode(new Uint8Array(metadataBytes)));
+              }
+            }
+
+            return readChunk();
+          });
+        }
+
+        return readChunk();
+      })
+      .finally(function () {
+        window.clearTimeout(timeoutId);
+      });
+  }
+
+  function firstSuccessful(tasks) {
+    return tasks.reduce(function (promise, task) {
+      return promise.then(function (metadata) {
+        if (metadata) {
+          return metadata;
+        }
+
+        return task().catch(function (error) {
+          logQuietly(error);
+          return null;
+        });
+      });
+    }, Promise.resolve(null));
+  }
+
+  function refresh() {
+    return firstSuccessful([
+      function () { return fetchJsonEndpoint(getEndpoint("data-now-playing-public-json")); },
+      function () { return fetchShoutcastEndpoint(getEndpoint("data-now-playing-shoutcast")); },
+      function () { return fetchIcyStreamMetadata(getEndpoint("data-now-playing-stream")); }
+    ]).then(function (metadata) {
+      if (metadata) {
+        renderMetadata(metadata);
+      } else {
+        renderFallback();
+      }
+    });
+  }
+
+  renderFallback();
+  refresh();
+  window.setInterval(refresh, POLL_INTERVAL_MS);
+}());

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -41,17 +41,44 @@
                 <span id="listen-live-player-heading">Live Stream</span>
               </p>
 
-              {{ partial "listen-live/player.html" (dict "src" "" "type" "") }}
+              <div
+                class="listen-live-player-shell"
+                data-now-playing
+                data-now-playing-public-json="https://betelgeuse.nucast.co.uk/public-json/150"
+                data-now-playing-shoutcast="https://betelgeuse.nucast.co.uk:8062/7.html"
+                data-now-playing-stream="https://betelgeuse.nucast.co.uk:8062/stream">
+                <div class="listen-live-now-playing__artwork" data-now-playing-artwork-wrap aria-hidden="true">
+                  <img data-now-playing-artwork alt="" hidden>
+                  <span data-now-playing-artwork-placeholder aria-hidden="true">SS</span>
+                </div>
+
+                <div class="listen-live-player-shell__main">
+                  {{ partial "listen-live/player.html" (dict "src" "" "type" "") }}
+
+                  <section class="listen-live-now-playing" aria-labelledby="now-playing-heading">
+                    <h2 id="now-playing-heading">Now Playing</h2>
+                    <div class="listen-live-now-playing__body" data-now-playing-state="fallback">
+                      <p class="listen-live-now-playing__fallback" data-now-playing-fallback>Live track information is not available just yet. Press play to hear what's currently drifting through Sundown Sessions.</p>
+                      <dl class="listen-live-now-playing__details" data-now-playing-details hidden>
+                        <div data-now-playing-artist-row hidden>
+                          <dt>Artist</dt>
+                          <dd data-now-playing-artist></dd>
+                        </div>
+                        <div data-now-playing-track-row hidden>
+                          <dt>Track</dt>
+                          <dd data-now-playing-track></dd>
+                        </div>
+                        <div data-now-playing-album-row hidden>
+                          <dt>Album</dt>
+                          <dd data-now-playing-album></dd>
+                        </div>
+                      </dl>
+                    </div>
+                  </section>
+                </div>
+              </div>
 
               <p class="listen-live-card__note">Having trouble with the player? You can also <a href="https://betelgeuse.nucast.co.uk/public/8062">listen directly using the NuCast player</a>.</p>
-            </section>
-
-            <section class="listen-live-card listen-live-now-playing" aria-labelledby="now-playing-heading">
-              <h2 id="now-playing-heading">Now Playing</h2>
-              <div class="listen-live-now-playing__body" data-now-playing-state="fallback">
-                <p data-now-playing-fallback>Live track information is not available just yet. Press play to hear what's currently drifting through Sundown Sessions.</p>
-                <a href="{{ "/shows/" | relURL }}" data-now-playing-archive>Explore past shows</a>
-              </div>
             </section>
 
             <section class="listen-live-card" aria-labelledby="broadcast-schedule-heading">
@@ -110,4 +137,12 @@
       </div>
     </section>
   </article>
+
+  {{ with resources.Get "js/listen-live-now-playing.js" }}
+    {{ $nowPlayingJS := . | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
+    <script
+      defer
+      src="{{ $nowPlayingJS.RelPermalink }}"
+      integrity="{{ $nowPlayingJS.Data.Integrity }}"></script>
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- Add a Listen Live Now Playing panel inside the existing player card
- Poll NuCast/Shoutcast/ICY metadata endpoints defensively every 45 seconds
- Add responsive artwork placeholder and metadata styling for light/dark mode

## Notes
- Current live endpoint samples return `Various Artists - Ethereal Embrace`.
- NuCast JSON and Shoutcast `/7.html` respond with usable metadata but do not send browser CORS headers, so the static site keeps the graceful fallback if production fetches are blocked.

## Validation
- `git diff --check`
- Parsed the live NuCast JSON and `/7.html` responses locally
- Could not run local Hugo or Node validation because neither executable is available on PATH in this environment