### PR TITLE
Refine Listen Live editorial layout

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1,17 +1,17 @@
-/* Listen Live page: scoped editorial cards built on the site's card language. */
+/* Listen Live page: scoped editorial listening layout. */
 
 .listen-live-page {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  max-width: 48rem;
-  margin: 0 0 4rem;
+  gap: clamp(2rem, 5vw, 3.5rem);
+  max-width: 60rem;
+  margin: 0 0 5rem;
 }
 
 .listen-live-intro {
   display: grid;
   gap: 0.85rem;
-  margin-bottom: 0.5rem;
+  max-width: 46rem;
 }
 
 .listen-live-intro p {
@@ -37,70 +37,68 @@
   color: rgba(var(--color-primary-300), 1);
 }
 
-.listen-live-card,
-.listen-live-more__card {
-  border: 1px solid #e5e5e5; /* neutral-200 */
-  border-radius: 0.75rem;
-  background-color: rgba(250, 250, 250, 0.72); /* neutral-50/72 */
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-}
-
-.dark .listen-live-card,
-.dark .listen-live-more__card {
-  border-color: #404040; /* neutral-700 */
-  background-color: rgba(23, 23, 23, 0.66); /* neutral-900/66 */
-}
-
-.listen-live-card {
+.listen-live-live {
   display: grid;
-  gap: 0.85rem;
-  padding: clamp(1.1rem, 3vw, 1.5rem);
-}
-
-.listen-live-card--player {
-  gap: 1rem;
-  border-color: rgba(var(--color-primary-500), 0.28);
+  gap: clamp(1.25rem, 3vw, 2rem);
+  overflow: hidden;
+  border: 1px solid rgba(var(--color-primary-500), 0.25);
+  border-radius: 0.5rem;
   background:
-    linear-gradient(135deg, rgba(var(--color-primary-500), 0.08), transparent 45%),
-    rgba(250, 250, 250, 0.82);
+    radial-gradient(circle at 10% 5%, rgba(var(--color-primary-500), 0.16), transparent 32%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(245, 245, 245, 0.74));
+  box-shadow: 0 20px 48px rgb(0 0 0 / 0.1);
+  padding: clamp(1.25rem, 4vw, 2rem);
 }
 
-.dark .listen-live-card--player {
+.dark .listen-live-live {
   border-color: rgba(var(--color-primary-400), 0.3);
   background:
-    linear-gradient(135deg, rgba(var(--color-primary-400), 0.12), transparent 45%),
-    rgba(23, 23, 23, 0.76);
+    radial-gradient(circle at 10% 5%, rgba(var(--color-primary-400), 0.2), transparent 34%),
+    linear-gradient(135deg, rgba(38, 38, 38, 0.88), rgba(23, 23, 23, 0.78));
+  box-shadow: 0 22px 56px rgb(0 0 0 / 0.32);
 }
 
-.listen-live-card h2,
-.listen-live-more h2 {
+.listen-live-section {
+  display: grid;
+  gap: 1rem;
+  max-width: 54rem;
+}
+
+.listen-live-now-playing h2,
+.listen-live-section h2 {
   margin: 0;
   color: #262626; /* neutral-800 */
   font-size: 1.25rem;
-  font-weight: 750;
+  font-weight: 800;
   line-height: 1.35;
 }
 
-.dark .listen-live-card h2,
-.dark .listen-live-more h2 {
+.listen-live-now-playing h2 {
+  font-size: clamp(1.6rem, 4vw, 2.25rem);
+  line-height: 1.08;
+}
+
+.dark .listen-live-now-playing h2,
+.dark .listen-live-section h2 {
   color: #f5f5f5; /* neutral-100 */
 }
 
-.listen-live-card p,
-.listen-live-card dd,
+.listen-live-section p,
+.listen-live-player__note,
 .listen-live-more__card small {
   margin: 0;
   color: #525252; /* neutral-600 */
   line-height: 1.65;
 }
 
-.dark .listen-live-card p,
-.dark .listen-live-card dd,
+.dark .listen-live-section p,
+.dark .listen-live-player__note,
 .dark .listen-live-more__card small {
   color: #d4d4d4; /* neutral-300 */
 }
 
-.listen-live-card a,
+.listen-live-section a,
+.listen-live-player__note a,
 .listen-live-more__card span {
   color: rgba(var(--color-primary-700), 1);
   font-weight: 750;
@@ -108,19 +106,21 @@
   text-underline-offset: 0.16rem;
 }
 
-.dark .listen-live-card a,
+.dark .listen-live-section a,
+.dark .listen-live-player__note a,
 .dark .listen-live-more__card span {
   color: rgba(var(--color-primary-300), 1);
 }
 
-.listen-live-card a:focus-visible,
+.listen-live-live a:focus-visible,
+.listen-live-section a:focus-visible,
 .listen-live-more__card:focus-visible {
   outline: 2px solid rgba(var(--color-primary-500), 0.75);
   outline-offset: 0.18rem;
 }
 
 .listen-live-player {
-  margin: 0.1rem 0;
+  margin: 0.25rem 0 0;
 }
 
 .listen-live-player audio {
@@ -130,19 +130,19 @@
 
 .listen-live-player-shell {
   display: grid;
-  gap: 1rem;
+  gap: clamp(1rem, 3vw, 1.75rem);
   align-items: start;
 }
 
 .listen-live-player-shell__main {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
   min-width: 0;
 }
 
 .listen-live-now-playing__artwork {
   display: grid;
-  width: min(100%, 9rem);
+  width: min(100%, 16rem);
   aspect-ratio: 1 / 1;
   align-items: center;
   justify-items: center;
@@ -150,15 +150,18 @@
   border: 1px solid rgba(var(--color-primary-500), 0.24);
   border-radius: 0.5rem;
   background:
-    linear-gradient(135deg, rgba(var(--color-primary-500), 0.14), transparent 46%),
+    radial-gradient(circle at 26% 20%, rgba(var(--color-primary-500), 0.18), transparent 34%),
+    linear-gradient(135deg, rgba(var(--color-primary-500), 0.14), transparent 52%),
     #f5f5f5; /* neutral-100 */
   color: rgba(var(--color-primary-700), 1);
+  box-shadow: 0 14px 32px rgb(0 0 0 / 0.12);
 }
 
 .dark .listen-live-now-playing__artwork {
   border-color: rgba(var(--color-primary-400), 0.3);
   background:
-    linear-gradient(135deg, rgba(var(--color-primary-400), 0.18), transparent 46%),
+    radial-gradient(circle at 26% 20%, rgba(var(--color-primary-400), 0.2), transparent 36%),
+    linear-gradient(135deg, rgba(var(--color-primary-400), 0.18), transparent 52%),
     #262626; /* neutral-800 */
   color: rgba(var(--color-primary-300), 1);
 }
@@ -175,10 +178,70 @@
   object-fit: cover;
 }
 
-.listen-live-now-playing__artwork span {
-  font-size: 1.4rem;
-  font-weight: 850;
-  line-height: 1;
+.listen-live-artwork-placeholder {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-items: center;
+  padding: 14%;
+}
+
+.listen-live-artwork-placeholder::before,
+.listen-live-artwork-placeholder::after {
+  content: "";
+  grid-area: 1 / 1;
+  border-radius: 999px;
+}
+
+.listen-live-artwork-placeholder::before {
+  width: 78%;
+  height: 78%;
+  border: 1px solid rgba(var(--color-primary-500), 0.34);
+}
+
+.listen-live-artwork-placeholder::after {
+  width: 42%;
+  height: 42%;
+  border: 0.7rem solid rgba(var(--color-primary-500), 0.12);
+  background: rgb(255 255 255 / 0.48);
+}
+
+.dark .listen-live-artwork-placeholder::before {
+  border-color: rgba(var(--color-primary-300), 0.34);
+}
+
+.dark .listen-live-artwork-placeholder::after {
+  border-color: rgba(var(--color-primary-300), 0.14);
+  background: rgb(0 0 0 / 0.18);
+}
+
+.listen-live-artwork-placeholder img {
+  grid-area: 1 / 1;
+  z-index: 1;
+  width: 52%;
+  height: auto;
+  max-height: 52%;
+  object-fit: contain;
+}
+
+.listen-live-artwork-placeholder span {
+  grid-area: 1 / 1;
+  align-self: end;
+  z-index: 1;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.78);
+  padding: 0.22rem 0.6rem;
+  color: #404040; /* neutral-700 */
+  font-size: 0.74rem;
+  font-weight: 800;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.dark .listen-live-artwork-placeholder span {
+  background: rgb(23 23 23 / 0.72);
+  color: #e5e5e5; /* neutral-200 */
 }
 
 .listen-live-now-playing [hidden],
@@ -192,9 +255,9 @@
   gap: 0.5rem;
   width: fit-content;
   margin: 0;
-  border: 1px solid #e5e5e5; /* neutral-200 */
+  border: 1px solid rgba(var(--color-primary-500), 0.28);
   border-radius: 999px;
-  background: rgb(255 255 255 / 0.76);
+  background: rgb(255 255 255 / 0.72);
   padding: 0.35rem 0.75rem;
   color: #404040; /* neutral-700 */
   font-size: 0.9rem;
@@ -203,7 +266,7 @@
 }
 
 .dark .listen-live-status {
-  border-color: #404040; /* neutral-700 */
+  border-color: rgba(var(--color-primary-400), 0.34);
   background: rgb(23 23 23 / 0.72);
   color: #d4d4d4; /* neutral-300 */
 }
@@ -216,8 +279,13 @@
   box-shadow: 0 0 0 0.18rem rgba(var(--color-primary-500), 0.12);
 }
 
-.listen-live-card__note {
+.listen-live-player__note {
   font-size: 0.95rem;
+}
+
+.listen-live-now-playing {
+  display: grid;
+  gap: 0.6rem;
 }
 
 .listen-live-now-playing__body {
@@ -227,7 +295,7 @@
 
 .listen-live-now-playing__details {
   display: grid;
-  gap: 0.55rem;
+  gap: 0.75rem;
   margin: 0;
 }
 
@@ -253,7 +321,7 @@
   min-width: 0;
   overflow-wrap: anywhere;
   color: #262626; /* neutral-800 */
-  font-size: 1rem;
+  font-size: 1.05rem;
   font-weight: 700;
   line-height: 1.35;
 }
@@ -262,8 +330,7 @@
   color: #f5f5f5; /* neutral-100 */
 }
 
-.listen-live-now-playing a,
-.listen-live-actions a {
+.listen-live-now-playing a {
   width: fit-content;
   max-width: 100%;
   overflow-wrap: anywhere;
@@ -271,28 +338,18 @@
 
 .listen-live-detail-grid {
   display: grid;
-  gap: 0;
-  margin: 0.25rem 0 0;
-  overflow: hidden;
-  border: 1px solid #e5e5e5; /* neutral-200 */
-  border-radius: 0.5rem;
-}
-
-.dark .listen-live-detail-grid {
-  border-color: #404040; /* neutral-700 */
+  gap: 0.35rem;
+  margin: 0.15rem 0 0;
 }
 
 .listen-live-detail-grid div {
   display: grid;
   gap: 0.25rem;
-  padding: 0.9rem 1rem;
-}
-
-.listen-live-detail-grid div + div {
   border-top: 1px solid #e5e5e5; /* neutral-200 */
+  padding: 0.8rem 0 0;
 }
 
-.dark .listen-live-detail-grid div + div {
+.dark .listen-live-detail-grid div {
   border-top-color: #404040; /* neutral-700 */
 }
 
@@ -308,39 +365,51 @@
   color: #a3a3a3; /* neutral-400 */
 }
 
-.listen-live-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
+.listen-live-detail-grid dd {
+  margin: 0;
+  color: #262626; /* neutral-800 */
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.dark .listen-live-detail-grid dd {
+  color: #f5f5f5; /* neutral-100 */
 }
 
 .listen-live-more {
   display: grid;
   gap: 1rem;
-  margin-top: 0.5rem;
 }
 
 .listen-live-more__grid {
   display: grid;
-  gap: 0.85rem;
+  gap: 0;
+  border-top: 1px solid #e5e5e5; /* neutral-200 */
+}
+
+.dark .listen-live-more__grid {
+  border-top-color: #404040; /* neutral-700 */
 }
 
 .listen-live-more__card {
   display: grid;
   gap: 0.35rem;
-  padding: 1rem;
+  border-bottom: 1px solid #e5e5e5; /* neutral-200 */
+  padding: 0.95rem 0;
   color: inherit;
   text-decoration: none;
-  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  transition: color 0.15s ease, padding-left 0.15s ease;
+}
+
+.dark .listen-live-more__card {
+  border-bottom-color: #404040; /* neutral-700 */
 }
 
 .listen-live-more__card:hover,
 .listen-live-more__card:focus-visible {
-  border-color: rgba(var(--color-primary-500), 0.45);
-  box-shadow: 0 10px 18px rgb(0 0 0 / 0.08);
   color: inherit;
   text-decoration: none;
-  transform: translateY(-0.0625rem);
+  padding-left: 0.35rem;
 }
 
 .listen-live-more__card span {
@@ -354,21 +423,36 @@
 
 @media (min-width: 700px) {
   .listen-live-player-shell {
-    grid-template-columns: 9rem minmax(0, 1fr);
+    grid-template-columns: minmax(12rem, 0.42fr) minmax(0, 1fr);
+    align-items: center;
   }
 
-  .listen-live-detail-grid,
+  .listen-live-detail-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem;
+  }
+
+  .listen-live-detail-grid div {
+    border-top: 1px solid #e5e5e5; /* neutral-200 */
+  }
+
+  .dark .listen-live-detail-grid div {
+    border-top-color: #404040; /* neutral-700 */
+  }
+
   .listen-live-more__grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .listen-live-detail-grid div + div {
+    gap: 1.25rem;
     border-top: 0;
-    border-left: 1px solid #e5e5e5; /* neutral-200 */
   }
 
-  .dark .listen-live-detail-grid div + div {
-    border-left-color: #404040; /* neutral-700 */
+  .listen-live-more__card {
+    border-top: 1px solid #e5e5e5; /* neutral-200 */
+    border-bottom: 0;
+  }
+
+  .dark .listen-live-more__card {
+    border-top-color: #404040; /* neutral-700 */
   }
 }
 
@@ -379,7 +463,7 @@
 
   .listen-live-more__card:hover,
   .listen-live-more__card:focus-visible {
-    transform: none;
+    padding-left: 0;
   }
 }
 

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -10,34 +10,12 @@ sharingLinks: false
 
 Join Sundown Sessions live for alternative music after dark, exclusive first plays, artist interviews and carefully curated selections from across the independent music landscape.
 
-Press play, settle in, and discover what is drifting through the Sundown Sessions tonight.
-
-<div class="listen-live-status" aria-label="Live stream status">
-  <span class="listen-live-status__dot" aria-hidden="true"></span>
-  <span>Sundown Sessions Live</span>
-</div>
-
-{{< listen-live-player >}}
-
-Having trouble with the player? You can also [listen directly using the NuCast player](https://betelgeuse.nucast.co.uk/public/8062).
-
-<section class="listen-live-now-playing" aria-labelledby="now-playing-heading">
-  <h2 id="now-playing-heading">Now Playing</h2>
-  <div class="listen-live-now-playing__body" data-now-playing-state="fallback">
-    <p data-now-playing-fallback>Live track information is not available just yet. Press play to hear what's currently drifting through Sundown Sessions.</p>
-    <a href="/shows/" data-now-playing-archive>Explore past shows</a>
-  </div>
-</section>
+No two broadcasts are ever quite the same. Press play, settle in, and discover what is drifting through Sundown Sessions tonight.
 
 ## Broadcast Schedule
 
 Sundown Sessions broadcasts live when a show is scheduled. Outside live broadcasts, explore the [show archive](/shows/) and [listen again](https://www.mixcloud.com/sundownsessions/) whenever the mood takes you.
 
-> **Live broadcasts**  
-> Schedule to be confirmed
-
-## What You'll Hear
-
-Expect alternative music after dark, new discoveries, independent artists, exclusive first plays, interviews, deep cuts and carefully chosen tracks from across the musical landscape.
-
-{{< social-follow >}}
+- Live broadcasts: Schedule to be confirmed
+- Time zone: UK time
+- Listen again: Available anytime

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -27,18 +27,18 @@
 
     <section class="flex flex-col max-w-full mt-0 lg:flex-row">
       <div class="min-w-0 min-h-0 max-w-fit">
-        <div class="article-content max-w-prose mb-20">
+        <div class="article-content max-w-none mb-20">
           <div class="listen-live-page">
             <header class="listen-live-intro">
               <p class="listen-live-strapline">Alternative Music After Dark</p>
               <p>Join Sundown Sessions live for alternative music after dark, exclusive first plays, artist interviews and carefully curated selections from across the independent music landscape.</p>
-              <p>Press play, settle in, and discover what is drifting through the Sundown Sessions tonight.</p>
+              <p>No two broadcasts are ever quite the same. Press play, settle in, and discover what is drifting through Sundown Sessions tonight.</p>
             </header>
 
-            <section class="listen-live-card listen-live-card--player" aria-labelledby="listen-live-player-heading">
+            <section class="listen-live-live" aria-labelledby="listen-live-player-heading">
               <p class="listen-live-status" aria-label="Live stream status">
                 <span class="listen-live-status__dot" aria-hidden="true"></span>
-                <span id="listen-live-player-heading">Live Stream</span>
+                <span id="listen-live-player-heading">Live Now</span>
               </p>
 
               <div
@@ -49,12 +49,13 @@
                 data-now-playing-stream="https://betelgeuse.nucast.co.uk:8062/stream">
                 <div class="listen-live-now-playing__artwork" data-now-playing-artwork-wrap aria-hidden="true">
                   <img data-now-playing-artwork alt="" hidden>
-                  <span data-now-playing-artwork-placeholder aria-hidden="true">SS</span>
+                  <span class="listen-live-artwork-placeholder" data-now-playing-artwork-placeholder aria-hidden="true">
+                    <img src="{{ "/images/sundown-sessions-logo.jpg" | relURL }}" alt="" loading="lazy" decoding="async">
+                    <span>On air</span>
+                  </span>
                 </div>
 
                 <div class="listen-live-player-shell__main">
-                  {{ partial "listen-live/player.html" (dict "src" "" "type" "") }}
-
                   <section class="listen-live-now-playing" aria-labelledby="now-playing-heading">
                     <h2 id="now-playing-heading">Now Playing</h2>
                     <div class="listen-live-now-playing__body" data-now-playing-state="fallback">
@@ -75,15 +76,17 @@
                       </dl>
                     </div>
                   </section>
+
+                  {{ partial "listen-live/player.html" (dict "src" "" "type" "") }}
+
+                  <p class="listen-live-player__note">Having trouble with the player? You can also <a href="https://betelgeuse.nucast.co.uk/public/8062">listen directly using the NuCast player</a>.</p>
                 </div>
               </div>
-
-              <p class="listen-live-card__note">Having trouble with the player? You can also <a href="https://betelgeuse.nucast.co.uk/public/8062">listen directly using the NuCast player</a>.</p>
             </section>
 
-            <section class="listen-live-card" aria-labelledby="broadcast-schedule-heading">
+            <section class="listen-live-section listen-live-schedule" aria-labelledby="broadcast-schedule-heading">
               <h2 id="broadcast-schedule-heading">Broadcast Schedule</h2>
-              <p>Sundown Sessions broadcasts live when a show is scheduled. Outside live broadcasts, explore the <a href="{{ "/shows/" | relURL }}">show archive</a> and <a href="{{ "/shows/" | relURL }}">listen again</a> whenever the mood takes you.</p>
+              <p>Sundown Sessions broadcasts live when a show is scheduled. Outside live broadcasts, explore the <a href="{{ "/shows/" | relURL }}">show archive</a> and listen again whenever the mood takes you.</p>
 
               <dl class="listen-live-detail-grid" aria-label="Broadcast details">
                 <div>
@@ -101,22 +104,8 @@
               </dl>
             </section>
 
-            <section class="listen-live-card" aria-labelledby="why-listen-live-heading">
-              <h2 id="why-listen-live-heading">Why Listen Live?</h2>
-              <p>No two broadcasts are ever quite the same. Each show blends new discoveries, independent artists, exclusive first plays, interviews, deep cuts and music chosen for after-dark listening.</p>
-            </section>
-
-            <section class="listen-live-card" aria-labelledby="stay-connected-heading">
-              <h2 id="stay-connected-heading">Stay Connected</h2>
-              <p>Follow along for broadcast updates, featured tracks and music worth staying up for.</p>
-              <div class="listen-live-actions" aria-label="Sundown Sessions contact links">
-                <a href="https://www.instagram.com/sundownsessionsshow">Follow on Instagram</a>
-                <a href="{{ "/contact/" | relURL }}">Contact Sundown Sessions</a>
-              </div>
-            </section>
-
-            <section class="listen-live-more" aria-labelledby="explore-more-heading">
-              <h2 id="explore-more-heading">Explore More</h2>
+            <section class="listen-live-section listen-live-more" aria-labelledby="continue-exploring-heading">
+              <h2 id="continue-exploring-heading">Continue Exploring</h2>
               <div class="listen-live-more__grid">
                 <a class="listen-live-more__card" href="{{ "/shows/" | relURL }}">
                   <span>Browse Shows</span>


### PR DESCRIPTION
## Summary
- Reworks Listen Live around one dominant live player and now-playing section
- Removes dashboard-like standalone cards for Why Listen Live and Stay Connected
- Simplifies Broadcast Schedule and renames Explore More to Continue Exploring
- Adds a branded artwork fallback using existing Sundown Sessions imagery

## Verification
- git diff --check
- Hugo build not run locally because hugo is not available on PATH in this shell