### PR TITLE
Fix Listen Live logo avatar artwork

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -166,8 +166,8 @@
   color: rgba(var(--color-primary-300), 1);
 }
 
-.listen-live-now-playing__artwork img,
-.listen-live-now-playing__artwork span {
+.listen-live-now-playing__artwork > img,
+.listen-live-now-playing__artwork > span {
   grid-area: 1 / 1;
 }
 
@@ -182,53 +182,37 @@
   display: grid;
   width: 100%;
   height: 100%;
-  align-items: center;
+  align-content: center;
   justify-items: center;
-  padding: 14%;
+  gap: 0.85rem;
+  padding: 10%;
 }
 
-.listen-live-artwork-placeholder::before,
-.listen-live-artwork-placeholder::after {
-  content: "";
-  grid-area: 1 / 1;
-  border-radius: 999px;
-}
-
-.listen-live-artwork-placeholder::before {
-  width: 78%;
-  height: 78%;
+.listen-live-artwork-avatar {
+  display: block;
+  width: min(100%, 11.5rem);
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
   border: 1px solid rgba(var(--color-primary-500), 0.34);
+  border-radius: 50%;
+  background: #f5f5f5; /* neutral-100 */
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.14);
 }
 
-.listen-live-artwork-placeholder::after {
-  width: 42%;
-  height: 42%;
-  border: 0.7rem solid rgba(var(--color-primary-500), 0.12);
-  background: rgb(255 255 255 / 0.48);
-}
-
-.dark .listen-live-artwork-placeholder::before {
+.dark .listen-live-artwork-avatar {
   border-color: rgba(var(--color-primary-300), 0.34);
+  background: #171717; /* neutral-900 */
+  box-shadow: 0 14px 32px rgb(0 0 0 / 0.34);
 }
 
-.dark .listen-live-artwork-placeholder::after {
-  border-color: rgba(var(--color-primary-300), 0.14);
-  background: rgb(0 0 0 / 0.18);
+.listen-live-artwork-avatar img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
-.listen-live-artwork-placeholder img {
-  grid-area: 1 / 1;
-  z-index: 1;
-  width: 52%;
-  height: auto;
-  max-height: 52%;
-  object-fit: contain;
-}
-
-.listen-live-artwork-placeholder span {
-  grid-area: 1 / 1;
-  align-self: end;
-  z-index: 1;
+.listen-live-artwork-badge {
   border-radius: 999px;
   background: rgb(255 255 255 / 0.78);
   padding: 0.22rem 0.6rem;
@@ -239,7 +223,7 @@
   text-transform: uppercase;
 }
 
-.dark .listen-live-artwork-placeholder span {
+.dark .listen-live-artwork-badge {
   background: rgb(23 23 23 / 0.72);
   color: #e5e5e5; /* neutral-200 */
 }

--- a/src/assets/js/listen-live-now-playing.js
+++ b/src/assets/js/listen-live-now-playing.js
@@ -160,7 +160,7 @@
       elements.placeholder.hidden = false;
     }
     if (elements.artworkWrap) {
-      elements.artworkWrap.setAttribute("aria-hidden", "true");
+      elements.artworkWrap.removeAttribute("aria-hidden");
     }
   }
 
@@ -205,7 +205,7 @@
         elements.placeholder.hidden = false;
       }
       if (elements.artworkWrap) {
-        elements.artworkWrap.setAttribute("aria-hidden", "true");
+        elements.artworkWrap.removeAttribute("aria-hidden");
       }
     }
   }

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -47,11 +47,13 @@
                 data-now-playing-public-json="https://betelgeuse.nucast.co.uk/public-json/150"
                 data-now-playing-shoutcast="https://betelgeuse.nucast.co.uk:8062/7.html"
                 data-now-playing-stream="https://betelgeuse.nucast.co.uk:8062/stream">
-                <div class="listen-live-now-playing__artwork" data-now-playing-artwork-wrap aria-hidden="true">
+                <div class="listen-live-now-playing__artwork" data-now-playing-artwork-wrap>
                   <img data-now-playing-artwork alt="" hidden>
-                  <span class="listen-live-artwork-placeholder" data-now-playing-artwork-placeholder aria-hidden="true">
-                    <img src="{{ "/images/sundown-sessions-logo.jpg" | relURL }}" alt="" loading="lazy" decoding="async">
-                    <span>On air</span>
+                  <span class="listen-live-artwork-placeholder" data-now-playing-artwork-placeholder>
+                    <span class="listen-live-artwork-avatar">
+                      <img src="{{ "/images/sundown-sessions-logo.jpg" | relURL }}" alt="Sundown Sessions logo" loading="lazy" decoding="async">
+                    </span>
+                    <span class="listen-live-artwork-badge">On air</span>
                   </span>
                 </div>
 


### PR DESCRIPTION
## Summary
- display the existing Sundown Sessions logo as a circular avatar in the Listen Live artwork fallback
- keep the ON AIR badge below the avatar and preserve the NuCast fallback link/audio player behavior
- keep fallback artwork accessible with descriptive logo alt text

## Verification
- git diff --check

Hugo build was not run locally because the Hugo CLI is not installed on PATH in this environment.