### PR TITLE
Add Sundown Sessions design tokens

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1,3 +1,108 @@
+/* Sundown Sessions brand tokens and Blowfish primary bridge. */
+
+:root {
+  --ss-color-midnight: #1e2438;
+  --ss-color-twilight: #6a3fb5;
+  --ss-color-sunset: #f47c3c;
+  --ss-color-golden-hour: #f8b04e;
+  --ss-color-cream: #fcfbf8;
+  --ss-color-surface: #ffffff;
+  --ss-color-muted: #7a746e;
+  --ss-color-border: rgba(30, 36, 56, 0.14);
+  --ss-color-link: var(--ss-color-twilight);
+  --ss-color-link-hover: #b64624;
+  --ss-color-primary-action: var(--ss-color-twilight);
+  --ss-color-primary-action-hover: #5a329d;
+  --ss-color-live: var(--ss-color-sunset);
+  --ss-color-focus: var(--ss-color-sunset);
+  --ss-color-shadow: rgb(30 36 56 / 0.12);
+  --ss-color-surface-warm: linear-gradient(135deg, #ffffff 0%, #fff6ef 58%, #fcfbf8 100%);
+  --ss-color-artwork-surface: linear-gradient(135deg, #fff6ef 0%, #fcfbf8 58%, #f4ede8 100%);
+
+  --color-primary-50: 252, 251, 248;
+  --color-primary-100: 255, 246, 239;
+  --color-primary-200: 253, 219, 197;
+  --color-primary-300: 248, 176, 78;
+  --color-primary-400: 244, 124, 60;
+  --color-primary-500: 244, 124, 60;
+  --color-primary-600: 106, 63, 181;
+  --color-primary-700: 86, 51, 146;
+  --color-primary-800: 30, 36, 56;
+  --color-primary-900: 16, 19, 31;
+}
+
+.dark {
+  --ss-color-midnight: #10131f;
+  --ss-color-twilight: #a98cff;
+  --ss-color-sunset: #ff8a4c;
+  --ss-color-golden-hour: #ffc46d;
+  --ss-color-cream: #181c2a;
+  --ss-color-surface: #181c2a;
+  --ss-color-muted: #b9b0a6;
+  --ss-color-border: rgba(246, 241, 234, 0.16);
+  --ss-color-link: var(--ss-color-twilight);
+  --ss-color-link-hover: var(--ss-color-sunset);
+  --ss-color-primary-action: #a98cff;
+  --ss-color-primary-action-hover: #ff8a4c;
+  --ss-color-live: var(--ss-color-sunset);
+  --ss-color-focus: var(--ss-color-sunset);
+  --ss-color-shadow: rgb(0 0 0 / 0.36);
+  --ss-color-surface-warm: linear-gradient(135deg, #181c2a 0%, #211d28 58%, #10131f 100%);
+  --ss-color-artwork-surface: linear-gradient(135deg, #211d28 0%, #181c2a 60%, #10131f 100%);
+
+  --color-primary-50: 246, 241, 234;
+  --color-primary-100: 233, 226, 216;
+  --color-primary-200: 207, 196, 186;
+  --color-primary-300: 255, 138, 76;
+  --color-primary-400: 169, 140, 255;
+  --color-primary-500: 255, 138, 76;
+  --color-primary-600: 106, 63, 181;
+  --color-primary-700: 74, 46, 126;
+  --color-primary-800: 24, 28, 42;
+  --color-primary-900: 16, 19, 31;
+}
+
+.prose a,
+.article-content a {
+  color: var(--ss-color-link);
+  text-decoration-color: color-mix(in srgb, var(--ss-color-link) 44%, transparent);
+}
+
+.prose a:hover,
+.article-content a:hover {
+  color: var(--ss-color-link-hover);
+  text-decoration-color: currentColor;
+}
+
+.prose a:focus-visible,
+.article-content a:focus-visible,
+.ss-primary-action:focus-visible {
+  outline: 2px solid var(--ss-color-focus);
+  outline-offset: 0.18rem;
+}
+
+.ss-primary-action {
+  background: var(--ss-color-primary-action);
+  color: #ffffff;
+  box-shadow: 0 0.55rem 1.5rem rgb(30 36 56 / 0.16);
+}
+
+.ss-primary-action:hover,
+.ss-primary-action:focus-visible {
+  background: var(--ss-color-primary-action-hover);
+  color: #ffffff;
+}
+
+.dark .ss-primary-action {
+  color: #10131f;
+  box-shadow: 0 0.55rem 1.5rem rgb(0 0 0 / 0.34);
+}
+
+.dark .ss-primary-action:hover,
+.dark .ss-primary-action:focus-visible {
+  color: #10131f;
+}
+
 /* Listen Live page: scoped editorial listening layout. */
 
 .listen-live-page {
@@ -16,17 +121,17 @@
 
 .listen-live-intro p {
   margin: 0;
-  color: #404040; /* neutral-700 */
+  color: var(--ss-color-muted);
   font-size: 1.05rem;
   line-height: 1.75;
 }
 
 .dark .listen-live-intro p {
-  color: #d4d4d4; /* neutral-300 */
+  color: var(--ss-color-muted);
 }
 
 .listen-live-intro .listen-live-strapline {
-  color: rgba(var(--color-primary-700), 1);
+  color: var(--ss-color-sunset);
   font-size: 0.8rem;
   font-weight: 800;
   line-height: 1.4;
@@ -34,28 +139,30 @@
 }
 
 .dark .listen-live-intro .listen-live-strapline {
-  color: rgba(var(--color-primary-300), 1);
+  color: var(--ss-color-sunset);
 }
 
 .listen-live-live {
   display: grid;
   gap: clamp(1.25rem, 3vw, 2rem);
   overflow: hidden;
-  border: 1px solid rgba(var(--color-primary-500), 0.25);
+  border: 1px solid var(--ss-color-border);
   border-radius: 0.5rem;
   background:
-    radial-gradient(circle at 10% 5%, rgba(var(--color-primary-500), 0.16), transparent 32%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(245, 245, 245, 0.74));
-  box-shadow: 0 20px 48px rgb(0 0 0 / 0.1);
+    radial-gradient(circle at 12% 6%, rgb(244 124 60 / 0.14), transparent 34%),
+    radial-gradient(circle at 94% 8%, rgb(106 63 181 / 0.1), transparent 28%),
+    var(--ss-color-surface-warm);
+  box-shadow: 0 20px 48px var(--ss-color-shadow);
   padding: clamp(1.25rem, 4vw, 2rem);
 }
 
 .dark .listen-live-live {
-  border-color: rgba(var(--color-primary-400), 0.3);
+  border-color: var(--ss-color-border);
   background:
-    radial-gradient(circle at 10% 5%, rgba(var(--color-primary-400), 0.2), transparent 34%),
-    linear-gradient(135deg, rgba(38, 38, 38, 0.88), rgba(23, 23, 23, 0.78));
-  box-shadow: 0 22px 56px rgb(0 0 0 / 0.32);
+    radial-gradient(circle at 12% 6%, rgb(255 138 76 / 0.16), transparent 34%),
+    radial-gradient(circle at 94% 8%, rgb(169 140 255 / 0.14), transparent 28%),
+    var(--ss-color-surface-warm);
+  box-shadow: 0 22px 56px var(--ss-color-shadow);
 }
 
 .listen-live-section {
@@ -67,7 +174,7 @@
 .listen-live-now-playing h2,
 .listen-live-section h2 {
   margin: 0;
-  color: #262626; /* neutral-800 */
+  color: var(--ss-color-midnight);
   font-size: 1.25rem;
   font-weight: 800;
   line-height: 1.35;
@@ -87,20 +194,20 @@
 .listen-live-player__note,
 .listen-live-more__card small {
   margin: 0;
-  color: #525252; /* neutral-600 */
+  color: var(--ss-color-muted);
   line-height: 1.65;
 }
 
 .dark .listen-live-section p,
 .dark .listen-live-player__note,
 .dark .listen-live-more__card small {
-  color: #d4d4d4; /* neutral-300 */
+  color: var(--ss-color-muted);
 }
 
 .listen-live-section a,
 .listen-live-player__note a,
 .listen-live-more__card span {
-  color: rgba(var(--color-primary-700), 1);
+  color: var(--ss-color-link);
   font-weight: 750;
   text-decoration: underline;
   text-underline-offset: 0.16rem;
@@ -109,13 +216,13 @@
 .dark .listen-live-section a,
 .dark .listen-live-player__note a,
 .dark .listen-live-more__card span {
-  color: rgba(var(--color-primary-300), 1);
+  color: var(--ss-color-link);
 }
 
 .listen-live-live a:focus-visible,
 .listen-live-section a:focus-visible,
 .listen-live-more__card:focus-visible {
-  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline: 2px solid var(--ss-color-focus);
   outline-offset: 0.18rem;
 }
 
@@ -147,23 +254,23 @@
   align-items: center;
   justify-items: center;
   overflow: hidden;
-  border: 1px solid rgba(var(--color-primary-500), 0.24);
+  border: 1px solid var(--ss-color-border);
   border-radius: 0.5rem;
   background:
-    radial-gradient(circle at 26% 20%, rgba(var(--color-primary-500), 0.18), transparent 34%),
-    linear-gradient(135deg, rgba(var(--color-primary-500), 0.14), transparent 52%),
-    #f5f5f5; /* neutral-100 */
-  color: rgba(var(--color-primary-700), 1);
-  box-shadow: 0 14px 32px rgb(0 0 0 / 0.12);
+    radial-gradient(circle at 24% 20%, rgb(244 124 60 / 0.12), transparent 34%),
+    radial-gradient(circle at 76% 16%, rgb(106 63 181 / 0.1), transparent 30%),
+    var(--ss-color-artwork-surface);
+  color: var(--ss-color-twilight);
+  box-shadow: 0 14px 32px var(--ss-color-shadow);
 }
 
 .dark .listen-live-now-playing__artwork {
-  border-color: rgba(var(--color-primary-400), 0.3);
+  border-color: var(--ss-color-border);
   background:
-    radial-gradient(circle at 26% 20%, rgba(var(--color-primary-400), 0.2), transparent 36%),
-    linear-gradient(135deg, rgba(var(--color-primary-400), 0.18), transparent 52%),
-    #262626; /* neutral-800 */
-  color: rgba(var(--color-primary-300), 1);
+    radial-gradient(circle at 24% 20%, rgb(255 138 76 / 0.14), transparent 36%),
+    radial-gradient(circle at 76% 16%, rgb(169 140 255 / 0.16), transparent 30%),
+    var(--ss-color-artwork-surface);
+  color: var(--ss-color-twilight);
 }
 
 .listen-live-now-playing__artwork img,
@@ -197,22 +304,22 @@
 .listen-live-artwork-placeholder::before {
   width: 78%;
   height: 78%;
-  border: 1px solid rgba(var(--color-primary-500), 0.34);
+  border: 1px solid color-mix(in srgb, var(--ss-color-twilight) 34%, transparent);
 }
 
 .listen-live-artwork-placeholder::after {
   width: 42%;
   height: 42%;
-  border: 0.7rem solid rgba(var(--color-primary-500), 0.12);
+  border: 0.7rem solid color-mix(in srgb, var(--ss-color-sunset) 18%, transparent);
   background: rgb(255 255 255 / 0.48);
 }
 
 .dark .listen-live-artwork-placeholder::before {
-  border-color: rgba(var(--color-primary-300), 0.34);
+  border-color: color-mix(in srgb, var(--ss-color-twilight) 34%, transparent);
 }
 
 .dark .listen-live-artwork-placeholder::after {
-  border-color: rgba(var(--color-primary-300), 0.14);
+  border-color: color-mix(in srgb, var(--ss-color-sunset) 18%, transparent);
   background: rgb(0 0 0 / 0.18);
 }
 
@@ -255,28 +362,28 @@
   gap: 0.5rem;
   width: fit-content;
   margin: 0;
-  border: 1px solid rgba(var(--color-primary-500), 0.28);
+  border: 1px solid color-mix(in srgb, var(--ss-color-live) 38%, transparent);
   border-radius: 999px;
-  background: rgb(255 255 255 / 0.72);
+  background: color-mix(in srgb, var(--ss-color-live) 10%, var(--ss-color-surface));
   padding: 0.35rem 0.75rem;
-  color: #404040; /* neutral-700 */
+  color: var(--ss-color-midnight);
   font-size: 0.9rem;
   font-weight: 750;
   line-height: 1.3;
 }
 
 .dark .listen-live-status {
-  border-color: rgba(var(--color-primary-400), 0.34);
-  background: rgb(23 23 23 / 0.72);
-  color: #d4d4d4; /* neutral-300 */
+  border-color: color-mix(in srgb, var(--ss-color-live) 42%, transparent);
+  background: color-mix(in srgb, var(--ss-color-live) 14%, var(--ss-color-surface));
+  color: #f6f1ea;
 }
 
 .listen-live-status__dot {
   width: 0.55rem;
   height: 0.55rem;
   border-radius: 999px;
-  background: rgba(var(--color-primary-500), 0.85);
-  box-shadow: 0 0 0 0.18rem rgba(var(--color-primary-500), 0.12);
+  background: var(--ss-color-live);
+  box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--ss-color-live) 24%, transparent);
 }
 
 .listen-live-player__note {

--- a/src/config/_default/params.toml
+++ b/src/config/_default/params.toml
@@ -92,7 +92,7 @@ headerAvatar = "/images/sundown-sessions-logo.jpg"
   icon48 = "favicon-48x48.png"
   appleTouchIcon = "apple-touch-icon.png"
   manifest = "site.webmanifest"
-  themeColor = "#081a3a"
+  themeColor = "#1E2438"
 
 [header]
   layout = "basic"

--- a/src/layouts/partials/head.html
+++ b/src/layouts/partials/head.html
@@ -5,7 +5,7 @@
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <meta name="theme-color" content="{{ .Site.Params.favicon.themeColor | default "#081a3a" }}">
+  <meta name="theme-color" content="{{ .Site.Params.favicon.themeColor | default "#1E2438" }}">
 
   {{/* Title */}}
   {{ if .IsHome }}

--- a/src/layouts/partials/header/components/desktop-menu.html
+++ b/src/layouts/partials/header/components/desktop-menu.html
@@ -37,7 +37,7 @@
     data-analytics-event="listen_live_click"
     data-analytics-provider="listen-live-page"
     aria-label="Listen Live"
-    class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary-600 text-neutral-50 hover:bg-primary-500 transition-colors font-medium text-sm">
+    class="ss-primary-action inline-flex items-center gap-2 px-4 py-2 rounded-full transition-colors font-medium text-sm">
     <span class="flex items-center justify-center h-3 w-3">
       {{ partial "icon.html" "play" }}
     </span>

--- a/src/layouts/partials/header/components/mobile-menu.html
+++ b/src/layouts/partials/header/components/mobile-menu.html
@@ -144,7 +144,7 @@
       data-analytics-event="listen_live_click"
       data-analytics-provider="listen-live-page"
       aria-label="Listen Live"
-      class="inline-flex items-center gap-3 px-6 py-3 rounded-full bg-primary-600 text-neutral-50 hover:bg-primary-500 transition-colors font-medium">
+      class="ss-primary-action inline-flex items-center gap-3 px-6 py-3 rounded-full transition-colors font-medium">
       <span class="flex items-center justify-center h-5 w-5">
         {{ partial "icon.html" "play" }}
       </span>


### PR DESCRIPTION
## Summary
- add Sundown Sessions brand colour tokens with light/dark values and a Blowfish primary bridge
- update global/prose links, focus rings, and Listen Live surfaces to use brand-led colours
- replace Listen Live nav button colour utilities with a semantic primary action class
- align browser theme colour with Deep Midnight

## Testing
- `hugo --environment githubPages --minify --baseURL http://localhost:1313/`
- local route checks for home, Listen Live, shows list/detail, artists list/detail, releases list/detail, track, search, and contact
- contrast checks for light/dark links, hover links, buttons, and badge text
- `git diff --check`