### PR TITLE
feat: refine Listen Live intro

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1,40 +1,45 @@
 /* Listen Live page: scoped editorial listening layout. */
 
 .listen-live-page {
+  --listen-live-editorial-accent: #8a5a30;
+
   display: flex;
   flex-direction: column;
-  gap: clamp(2rem, 5vw, 3.5rem);
+  gap: clamp(1.75rem, 4vw, 3rem);
   max-width: 60rem;
   margin: 0 0 5rem;
 }
 
+.dark .listen-live-page {
+  --listen-live-editorial-accent: #d6a36c;
+}
+
 .listen-live-intro {
   display: grid;
-  gap: 0.85rem;
-  max-width: 46rem;
+  gap: 0.65rem;
+  max-width: 66ch;
+  margin-bottom: clamp(0.15rem, 1vw, 0.5rem);
 }
 
-.listen-live-intro p {
+.listen-live-intro .listen-live-standfirst {
   margin: 0;
-  color: #404040; /* neutral-700 */
-  font-size: 1.05rem;
-  line-height: 1.75;
+  color: #262626; /* neutral-800 */
+  font-size: clamp(1.08rem, 1.4vw, 1.22rem);
+  font-weight: 450;
+  line-height: 1.72;
 }
 
-.dark .listen-live-intro p {
-  color: #d4d4d4; /* neutral-300 */
+.dark .listen-live-intro .listen-live-standfirst {
+  color: #e5e5e5; /* neutral-200 */
 }
 
 .listen-live-intro .listen-live-strapline {
-  color: rgba(var(--color-primary-700), 1);
-  font-size: 0.8rem;
-  font-weight: 800;
-  line-height: 1.4;
-  text-transform: uppercase;
-}
-
-.dark .listen-live-intro .listen-live-strapline {
-  color: rgba(var(--color-primary-300), 1);
+  margin: 0;
+  color: var(--listen-live-editorial-accent);
+  font-size: clamp(1.05rem, 1.8vw, 1.24rem);
+  font-style: italic;
+  font-weight: 650;
+  line-height: 1.35;
 }
 
 .listen-live-live {

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -8,9 +8,7 @@ showTableOfContents: false
 sharingLinks: false
 ---
 
-Join Sundown Sessions live for alternative music after dark, exclusive first plays, artist interviews and carefully curated selections from across the independent music landscape.
-
-No two broadcasts are ever quite the same. Press play, settle in, and discover what is drifting through Sundown Sessions tonight.
+No two broadcasts are ever quite the same. Join Sundown Sessions live for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Press play, settle in and discover what&rsquo;s drifting through Sundown Sessions tonight.
 
 ## Broadcast Schedule
 

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -20,9 +20,6 @@
       <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
         {{ .Title | emojify }}
       </h1>
-      <div class="mt-1 mb-6 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
-        {{ partial "article-meta/basic.html" (dict "context" . "scope" "single") }}
-      </div>
     </header>
 
     <section class="flex flex-col max-w-full mt-0 lg:flex-row">
@@ -31,8 +28,7 @@
           <div class="listen-live-page">
             <header class="listen-live-intro">
               <p class="listen-live-strapline">Alternative Music After Dark</p>
-              <p>Join Sundown Sessions live for alternative music after dark, exclusive first plays, artist interviews and carefully curated selections from across the independent music landscape.</p>
-              <p>No two broadcasts are ever quite the same. Press play, settle in, and discover what is drifting through Sundown Sessions tonight.</p>
+              <p class="listen-live-standfirst">No two broadcasts are ever quite the same. Join Sundown Sessions live for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Press play, settle in and discover what&rsquo;s drifting through Sundown Sessions tonight.</p>
             </header>
 
             <section class="listen-live-live" aria-labelledby="listen-live-player-heading">


### PR DESCRIPTION
## Summary
- Replace the Listen Live intro paragraphs with a single editorial standfirst
- Restyle the strapline as a warmer title-case subtitle
- Tighten intro spacing so it leads more naturally into the live player

## Testing
- git diff --check
- Not run: local Hugo build, because hugo is not available on PATH in this shell