### PR TITLE
Make Listen Live intro schedule aware

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -140,6 +140,32 @@
   color: rgba(var(--color-neutral-200), 1);
 }
 
+.listen-live-broadcast-cue {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0.2rem 0 0;
+  color: var(--ss-color-muted);
+  font-size: 0.92rem;
+  font-weight: 780;
+  line-height: 1.45;
+}
+
+.listen-live-broadcast-cue[data-broadcast-state="live"] {
+  color: var(--listen-live-editorial-accent);
+}
+
+.listen-live-broadcast-cue__dot {
+  width: 0.52rem;
+  height: 0.52rem;
+  flex: 0 0 auto;
+  margin-right: 0.48rem;
+  border-radius: 999px;
+  background: var(--ss-color-live);
+  box-shadow: 0 0 0 0.16rem color-mix(in srgb, var(--ss-color-live) 18%, transparent);
+}
+
 .listen-live-intro .listen-live-strapline {
   margin: 0;
   color: var(--listen-live-editorial-accent);
@@ -384,6 +410,17 @@
   background: var(--ss-color-live);
   box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--ss-color-live) 24%, transparent);
   animation: listen-live-pulse 2.6s ease-out infinite;
+}
+
+.listen-live-status[data-broadcast-state="off-air"] {
+  border-color: color-mix(in srgb, var(--ss-color-border) 74%, transparent);
+  background: color-mix(in srgb, var(--ss-color-surface) 76%, transparent);
+}
+
+.listen-live-status[data-broadcast-state="off-air"] .listen-live-status__dot {
+  background: var(--ss-color-muted);
+  box-shadow: none;
+  animation: none;
 }
 
 .listen-live-status__microcopy {

--- a/src/assets/js/listen-live-schedule.js
+++ b/src/assets/js/listen-live-schedule.js
@@ -1,0 +1,93 @@
+(function () {
+  "use strict";
+
+  var REFRESH_INTERVAL_MS = 60000;
+  var UK_TIME_ZONE = "Europe/London";
+  var BROADCAST_DAY = "Tue";
+  var BROADCAST_START_MINUTES = 20 * 60;
+  var BROADCAST_END_MINUTES = 22 * 60;
+
+  var status = document.querySelector("[data-live-status]");
+  var standfirst = document.querySelector("[data-live-standfirst]");
+  var playerBadge = document.querySelector("[data-live-player-badge]");
+  var playerBadgeLabel = document.querySelector("[data-live-player-badge-label]");
+  var playerBadgeNote = document.querySelector("[data-live-player-badge-note]");
+
+  if (!status || !standfirst || !window.Intl || !window.Intl.DateTimeFormat) {
+    return;
+  }
+
+  // Keep this tied to UK civil time so daylight saving changes are handled by the browser.
+  var formatter = new Intl.DateTimeFormat("en-GB", {
+    timeZone: UK_TIME_ZONE,
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23"
+  });
+
+  function getUkTimeParts(date) {
+    var parts = formatter.formatToParts(date || new Date());
+    var values = {};
+
+    parts.forEach(function (part) {
+      if (part.type !== "literal") {
+        values[part.type] = part.value;
+      }
+    });
+
+    var hour = parseInt(values.hour, 10);
+    var minute = parseInt(values.minute, 10);
+
+    if (Number.isNaN(hour) || Number.isNaN(minute)) {
+      return {
+        weekday: "",
+        minutes: -1
+      };
+    }
+
+    return {
+      weekday: values.weekday,
+      minutes: (hour * 60) + minute
+    };
+  }
+
+  function isLiveNow(date) {
+    var ukTime = getUkTimeParts(date);
+
+    return ukTime.weekday === BROADCAST_DAY &&
+      ukTime.minutes >= BROADCAST_START_MINUTES &&
+      ukTime.minutes < BROADCAST_END_MINUTES;
+  }
+
+  function setPlayerBadge(live) {
+    if (!playerBadge || !playerBadgeLabel || !playerBadgeNote) {
+      return;
+    }
+
+    playerBadge.setAttribute("data-broadcast-state", live ? "live" : "off-air");
+    playerBadge.setAttribute("aria-label", live ? "Live stream status: live now" : "Live stream status: station stream available");
+    playerBadgeLabel.textContent = live ? "LIVE NOW" : "Station Stream";
+    playerBadgeNote.textContent = live ? "Broadcasting live until 10pm" : "Live Tuesdays, 8pm\u201310pm UK time";
+  }
+
+  function render() {
+    var live = isLiveNow();
+    var archiveUrl = standfirst.getAttribute("data-archive-url") || "/shows/";
+
+    status.setAttribute("data-broadcast-state", live ? "live" : "off-air");
+
+    if (live) {
+      status.innerHTML = "<span class=\"listen-live-broadcast-cue__dot\" aria-hidden=\"true\"></span>On Air Now &mdash; Broadcasting live until 10pm.";
+      standfirst.textContent = "No two broadcasts are ever quite the same. Join Sundown Sessions live for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Press play, settle in and discover what's drifting through Sundown Sessions tonight.";
+    } else {
+      status.textContent = "Next live broadcast: Tuesday, 8pm\u201310pm (UK time).";
+      standfirst.innerHTML = "Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Join us for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Between broadcasts, explore the <a href=\"" + archiveUrl + "\">archive</a> or enjoy the station stream.";
+    }
+
+    setPlayerBadge(live);
+  }
+
+  render();
+  window.setInterval(render, REFRESH_INTERVAL_MS);
+}());

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -8,12 +8,12 @@ showTableOfContents: false
 sharingLinks: false
 ---
 
-No two broadcasts are ever quite the same. Join Sundown Sessions live for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Press play, settle in and discover what&rsquo;s drifting through Sundown Sessions tonight.
+Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Join us for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Between broadcasts, explore the [archive](/shows/) or enjoy the station stream.
 
 ## Broadcast Schedule
 
-Live broadcasts are scheduled around the show. Outside live programmes, the [archive](/shows/) is always open.
+Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Outside live programmes, the [archive](/shows/) is always open.
 
-- Live broadcasts: Schedule to be confirmed
+- Live broadcasts: Tuesday, 8pm&ndash;10pm
 - Time zone: UK time
 - Listen again: Available anytime

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -28,14 +28,15 @@
           <div class="listen-live-page">
             <header class="listen-live-intro">
               <p class="listen-live-strapline">Alternative Music After Dark</p>
-              <p class="listen-live-standfirst">No two broadcasts are ever quite the same. Join Sundown Sessions live for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Press play, settle in and discover what&rsquo;s drifting through Sundown Sessions tonight.</p>
+              <p class="listen-live-broadcast-cue" data-live-status>Next live broadcast: Tuesday, 8pm&ndash;10pm (UK time).</p>
+              <p class="listen-live-standfirst" data-live-standfirst data-archive-url="{{ "/shows/" | relURL }}">Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Join us for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Between broadcasts, explore the <a href="{{ "/shows/" | relURL }}">archive</a> or enjoy the station stream.</p>
             </header>
 
             <section class="listen-live-live" aria-labelledby="listen-live-player-heading">
-              <p class="listen-live-status" aria-label="Live stream status">
+              <p class="listen-live-status" data-live-player-badge data-broadcast-state="off-air" aria-label="Live stream status">
                 <span class="listen-live-status__dot" aria-hidden="true"></span>
-                <span id="listen-live-player-heading">Live Now</span>
-                <span class="listen-live-status__microcopy">Alternative Music After Dark</span>
+                <span id="listen-live-player-heading" data-live-player-badge-label>Station Stream</span>
+                <span class="listen-live-status__microcopy" data-live-player-badge-note>Live Tuesdays, 8pm&ndash;10pm UK time</span>
               </p>
 
               <div
@@ -85,12 +86,12 @@
 
             <section class="listen-live-section listen-live-schedule" aria-labelledby="broadcast-schedule-heading">
               <h2 id="broadcast-schedule-heading">Broadcast Schedule</h2>
-              <p>Live broadcasts are scheduled around the show. Outside live programmes, the <a href="{{ "/shows/" | relURL }}">archive</a> is always open.</p>
+              <p>Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Outside live programmes, the <a href="{{ "/shows/" | relURL }}">archive</a> is always open.</p>
 
               <dl class="listen-live-detail-grid" aria-label="Broadcast details">
                 <div>
                   <dt>Live broadcasts</dt>
-                  <dd>Schedule to be confirmed</dd>
+                  <dd>Tuesday, 8pm&ndash;10pm</dd>
                 </div>
                 <div>
                   <dt>Time zone</dt>
@@ -132,5 +133,12 @@
       defer
       src="{{ $nowPlayingJS.RelPermalink }}"
       integrity="{{ $nowPlayingJS.Data.Integrity }}"></script>
+  {{ end }}
+  {{ with resources.Get "js/listen-live-schedule.js" }}
+    {{ $scheduleJS := . | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
+    <script
+      defer
+      src="{{ $scheduleJS.RelPermalink }}"
+      integrity="{{ $scheduleJS.Data.Integrity }}"></script>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- add accurate off-air fallback copy for the Listen Live intro and confirmed Tuesday broadcast schedule
- add a lightweight client-side schedule script using Europe/London time to switch live/off-air copy
- update the player badge styling/copy to align with the current schedule state

## Testing
- git diff --check
- Not run: hugo --environment production (hugo is not installed/on PATH in this environment)
- Not run: Node boundary check (node is not installed/on PATH in this environment)