### PR TITLE
Refine Listen Live editorial hierarchy

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -391,9 +391,8 @@
   color: var(--ss-color-midnight);
   font-size: 0.84rem;
   font-weight: 850;
-  letter-spacing: 0.04em;
+  letter-spacing: 0;
   line-height: 1.3;
-  text-transform: uppercase;
 }
 
 .dark .listen-live-status {

--- a/src/assets/js/listen-live-schedule.js
+++ b/src/assets/js/listen-live-schedule.js
@@ -11,7 +11,6 @@
   var standfirst = document.querySelector("[data-live-standfirst]");
   var playerBadge = document.querySelector("[data-live-player-badge]");
   var playerBadgeLabel = document.querySelector("[data-live-player-badge-label]");
-  var playerBadgeNote = document.querySelector("[data-live-player-badge-note]");
 
   if (!status || !standfirst || !window.Intl || !window.Intl.DateTimeFormat) {
     return;
@@ -61,28 +60,26 @@
   }
 
   function setPlayerBadge(live) {
-    if (!playerBadge || !playerBadgeLabel || !playerBadgeNote) {
+    if (!playerBadge || !playerBadgeLabel) {
       return;
     }
 
     playerBadge.setAttribute("data-broadcast-state", live ? "live" : "off-air");
     playerBadge.setAttribute("aria-label", live ? "Live stream status: live now" : "Live stream status: station stream available");
-    playerBadgeLabel.textContent = live ? "LIVE NOW" : "Station Stream";
-    playerBadgeNote.textContent = live ? "Broadcasting live until 10pm" : "Live Tuesdays, 8pm\u201310pm UK time";
+    playerBadgeLabel.textContent = live ? "Live Now" : "Station Stream";
   }
 
   function render() {
     var live = isLiveNow();
-    var archiveUrl = standfirst.getAttribute("data-archive-url") || "/shows/";
 
     status.setAttribute("data-broadcast-state", live ? "live" : "off-air");
 
     if (live) {
       status.innerHTML = "<span class=\"listen-live-broadcast-cue__dot\" aria-hidden=\"true\"></span>On Air Now &mdash; Broadcasting live until 10pm.";
-      standfirst.textContent = "No two broadcasts are ever quite the same. Join Sundown Sessions live for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Press play, settle in and discover what's drifting through Sundown Sessions tonight.";
+      standfirst.textContent = "No two broadcasts are ever quite the same. Press play, settle in and discover what's drifting through Sundown Sessions tonight.";
     } else {
-      status.textContent = "Next live broadcast: Tuesday, 8pm\u201310pm (UK time).";
-      standfirst.innerHTML = "Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Join us for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Between broadcasts, explore the <a href=\"" + archiveUrl + "\">archive</a> or enjoy the station stream.";
+      status.textContent = "Next live broadcast: Tuesday \u2022 8pm\u201310pm (UK)";
+      standfirst.textContent = "Every broadcast is carefully curated, blending new discoveries, exclusive first plays, artist interviews and music chosen for after-dark listening.";
     }
 
     setPlayerBadge(live);

--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -8,12 +8,10 @@ showTableOfContents: false
 sharingLinks: false
 ---
 
-Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Join us for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Between broadcasts, explore the [archive](/shows/) or enjoy the station stream.
+Every broadcast is carefully curated, blending new discoveries, exclusive first plays, artist interviews and music chosen for after-dark listening.
 
 ## Broadcast Schedule
 
-Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Outside live programmes, the [archive](/shows/) is always open.
-
-- Live broadcasts: Tuesday, 8pm&ndash;10pm
+- Live broadcasts: Tuesday &bull; 8pm&ndash;10pm
 - Time zone: UK time
 - Listen again: Available anytime

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -28,15 +28,14 @@
           <div class="listen-live-page">
             <header class="listen-live-intro">
               <p class="listen-live-strapline">Alternative Music After Dark</p>
-              <p class="listen-live-broadcast-cue" data-live-status>Next live broadcast: Tuesday, 8pm&ndash;10pm (UK time).</p>
-              <p class="listen-live-standfirst" data-live-standfirst data-archive-url="{{ "/shows/" | relURL }}">Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Join us for carefully curated alternative music, exclusive first plays, artist interviews and unexpected discoveries. Between broadcasts, explore the <a href="{{ "/shows/" | relURL }}">archive</a> or enjoy the station stream.</p>
+              <p class="listen-live-broadcast-cue" data-live-status>Next live broadcast: Tuesday &bull; 8pm&ndash;10pm (UK)</p>
+              <p class="listen-live-standfirst" data-live-standfirst>Every broadcast is carefully curated, blending new discoveries, exclusive first plays, artist interviews and music chosen for after-dark listening.</p>
             </header>
 
             <section class="listen-live-live" aria-labelledby="listen-live-player-heading">
               <p class="listen-live-status" data-live-player-badge data-broadcast-state="off-air" aria-label="Live stream status">
                 <span class="listen-live-status__dot" aria-hidden="true"></span>
                 <span id="listen-live-player-heading" data-live-player-badge-label>Station Stream</span>
-                <span class="listen-live-status__microcopy" data-live-player-badge-note>Live Tuesdays, 8pm&ndash;10pm UK time</span>
               </p>
 
               <div
@@ -86,12 +85,11 @@
 
             <section class="listen-live-section listen-live-schedule" aria-labelledby="broadcast-schedule-heading">
               <h2 id="broadcast-schedule-heading">Broadcast Schedule</h2>
-              <p>Sundown Sessions broadcasts live every Tuesday from 8pm to 10pm (UK time). Outside live programmes, the <a href="{{ "/shows/" | relURL }}">archive</a> is always open.</p>
 
               <dl class="listen-live-detail-grid" aria-label="Broadcast details">
                 <div>
                   <dt>Live broadcasts</dt>
-                  <dd>Tuesday, 8pm&ndash;10pm</dd>
+                  <dd>Tuesday &bull; 8pm&ndash;10pm</dd>
                 </div>
                 <div>
                   <dt>Time zone</dt>


### PR DESCRIPTION
## Summary
- remove repeated schedule messaging from the Listen Live intro, player badge, and schedule section
- update live/off-air dynamic copy so each section has a clearer job
- keep the player state badge concise and naturally cased

## Testing
- git diff --check
- rg check for removed repeated Listen Live schedule copy
- Not run: hugo server (hugo is not available on PATH in this shell)