### PR TITLE
Refine Listen Live onward navigation

### DIFF
--- a/src/content/listen-live/index.md
+++ b/src/content/listen-live/index.md
@@ -14,4 +14,4 @@ Every broadcast is carefully curated, blending new discoveries, exclusive first 
 
 - Live broadcasts: Tuesday &bull; 8pm&ndash;10pm
 - Time zone: UK time
-- Listen again: Available anytime
+- Shows Archive: Available anytime

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -96,8 +96,8 @@
                   <dd>UK time</dd>
                 </div>
                 <div>
-                  <dt>Listen again</dt>
-                  <dd><a href="https://www.mixcloud.com/sundownsessions/">Available anytime</a></dd>
+                  <dt>Shows Archive</dt>
+                  <dd><a href="{{ "/shows/" | relURL }}">Available anytime</a></dd>
                 </div>
               </dl>
             </section>
@@ -108,10 +108,6 @@
                 <a class="listen-live-more__card" href="{{ "/shows/" | relURL }}">
                   <span class="listen-live-more__card-label">Browse Shows</span>
                   <small>Explore past Sundown Sessions broadcasts and track listings.</small>
-                </a>
-                <a class="listen-live-more__card" href="https://www.mixcloud.com/sundownsessions/">
-                  <span class="listen-live-more__card-label">Listen Again</span>
-                  <small>Catch up with previous shows whenever the mood takes you.</small>
                 </a>
                 <a class="listen-live-more__card" href="{{ "/artists/" | relURL }}">
                   <span class="listen-live-more__card-label">Featured Artists</span>


### PR DESCRIPTION
## Summary
- rename the Broadcast Information archive link to Shows Archive and point it to /shows/
- remove the duplicate Listen Again card from Continue Exploring
- leave Continue Exploring with Browse Shows and Featured Artists only

## Testing
- Searched the Listen Live layout/content for duplicate Listen Again wording
- Not run: Hugo build unavailable because hugo is not on PATH in this shell