### PR TITLE
Polish Listen Live editorial layout

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -167,6 +167,15 @@
 .listen-live-broadcast-cue__time {
   color: var(--ss-color-midnight);
   font-weight: 820;
+  text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
+  text-decoration-thickness: 0.08rem;
+  text-underline-offset: 0.18rem;
+}
+
+.listen-live-broadcast-cue__time:hover,
+.listen-live-broadcast-cue__time:focus-visible {
+  color: var(--ss-color-link);
+  text-decoration-color: currentColor;
 }
 
 .dark .listen-live-broadcast-cue__time {
@@ -225,9 +234,33 @@
   max-width: 54rem;
 }
 
+.listen-live-lower {
+  display: grid;
+  gap: clamp(1.6rem, 3vw, 2.25rem);
+  margin-top: clamp(-0.2rem, -0.4vw, 0rem);
+  border-radius: 0.5rem;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--ss-color-sunset) 5%, transparent),
+      transparent 42%
+    );
+  padding: clamp(1rem, 2.8vw, 1.6rem);
+}
+
+.dark .listen-live-lower {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--ss-color-golden-hour) 6%, transparent),
+      transparent 46%
+    );
+}
+
 .listen-live-schedule {
   gap: 0.8rem;
   max-width: 48rem;
+  scroll-margin-top: 6rem;
 }
 
 .listen-live-now-playing h2,
@@ -277,6 +310,7 @@
 }
 
 .listen-live-live a:focus-visible,
+.listen-live-broadcast-cue a:focus-visible,
 .listen-live-section a:focus-visible,
 .listen-live-more__card:focus-visible {
   outline: 2px solid var(--ss-color-focus);
@@ -560,10 +594,9 @@
 
 .listen-live-detail-grid dt {
   color: #737373; /* neutral-500 */
-  font-size: 0.72rem;
-  font-weight: 800;
+  font-size: 0.78rem;
+  font-weight: 750;
   line-height: 1.35;
-  text-transform: uppercase;
 }
 
 .dark .listen-live-detail-grid dt {
@@ -598,16 +631,22 @@
   min-width: 0;
   min-height: 100%;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.55rem;
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--ss-color-border) 82%, transparent);
   border-radius: 0.5rem;
-  background: color-mix(in srgb, var(--ss-color-surface) 90%, white);
-  padding: 1.05rem 1.1rem;
+  background: color-mix(in srgb, var(--ss-color-surface) 88%, white);
+  padding: clamp(1.1rem, 2.5vw, 1.35rem);
   color: inherit;
   text-decoration: none;
-  box-shadow: 0 10px 24px rgb(30 36 56 / 0.05);
+  box-shadow: 0 1px 2px rgb(30 36 56 / 0.05);
   transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.listen-live-section .listen-live-more__card {
+  color: inherit;
+  font-weight: inherit;
+  text-decoration: none;
 }
 
 .dark .listen-live-more__card {
@@ -621,7 +660,7 @@
   border-color: color-mix(in srgb, var(--ss-color-sunset) 42%, var(--ss-color-border));
   color: inherit;
   text-decoration: none;
-  box-shadow: 0 14px 30px rgb(30 36 56 / 0.09);
+  box-shadow: 0 10px 18px rgb(30 36 56 / 0.08);
   transform: translateY(-0.08rem);
 }
 
@@ -663,7 +702,7 @@
   }
 
   .listen-live-more__grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1.25rem;
   }
 }

--- a/src/assets/js/listen-live-schedule.js
+++ b/src/assets/js/listen-live-schedule.js
@@ -78,7 +78,7 @@
       status.innerHTML = "<span class=\"listen-live-broadcast-cue__dot\" aria-hidden=\"true\"></span>On Air Now &mdash; Broadcasting live until 10pm.";
       standfirst.textContent = "No two broadcasts are ever quite the same. Press play, settle in and discover what's drifting through Sundown Sessions tonight.";
     } else {
-      status.innerHTML = "<span class=\"listen-live-broadcast-cue__label\">Next live broadcast:</span> <span class=\"listen-live-broadcast-cue__time\">Tuesday \u2022 8pm\u201310pm (UK)</span>";
+      status.innerHTML = "<span class=\"listen-live-broadcast-cue__label\">Next live broadcast:</span> <a class=\"listen-live-broadcast-cue__time\" href=\"#broadcast-details\">Tuesday \u2022 8pm\u201310pm (UK)</a>";
       standfirst.textContent = "Every broadcast is carefully curated, blending new discoveries, exclusive first plays, artist interviews and music chosen for after-dark listening.";
     }
 

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -28,7 +28,7 @@
           <div class="listen-live-page">
             <header class="listen-live-intro">
               <p class="listen-live-strapline">Alternative Music After Dark</p>
-              <p class="listen-live-broadcast-cue" data-live-status><span class="listen-live-broadcast-cue__label">Next live broadcast:</span> <span class="listen-live-broadcast-cue__time">Tuesday &bull; 8pm&ndash;10pm (UK)</span></p>
+              <p class="listen-live-broadcast-cue" data-live-status><span class="listen-live-broadcast-cue__label">Next live broadcast:</span> <a class="listen-live-broadcast-cue__time" href="#broadcast-details">Tuesday &bull; 8pm&ndash;10pm (UK)</a></p>
               <p class="listen-live-standfirst" data-live-standfirst>Every broadcast is carefully curated, blending new discoveries, exclusive first plays, artist interviews and music chosen for after-dark listening.</p>
             </header>
 
@@ -83,38 +83,40 @@
               </div>
             </section>
 
-            <section class="listen-live-section listen-live-schedule" aria-labelledby="broadcast-information-heading">
-              <h2 id="broadcast-information-heading">Broadcast Information</h2>
+            <div class="listen-live-lower">
+              <section id="broadcast-details" class="listen-live-section listen-live-schedule" aria-labelledby="broadcast-details-heading">
+                <h2 id="broadcast-details-heading">Broadcast Details</h2>
 
-              <dl class="listen-live-detail-grid" aria-label="Broadcast details">
-                <div>
-                  <dt>Live broadcasts</dt>
-                  <dd>Tuesday &bull; 8pm&ndash;10pm</dd>
-                </div>
-                <div>
-                  <dt>Time zone</dt>
-                  <dd>UK time</dd>
-                </div>
-                <div>
-                  <dt>Shows Archive</dt>
-                  <dd><a href="{{ "/shows/" | relURL }}">Available anytime</a></dd>
-                </div>
-              </dl>
-            </section>
+                <dl class="listen-live-detail-grid" aria-label="Broadcast details">
+                  <div>
+                    <dt>Live broadcasts</dt>
+                    <dd>Tuesday &bull; 8pm&ndash;10pm</dd>
+                  </div>
+                  <div>
+                    <dt>Time zone</dt>
+                    <dd>UK time</dd>
+                  </div>
+                  <div>
+                    <dt>Shows archive</dt>
+                    <dd><a href="{{ "/shows/" | relURL }}">Available anytime</a></dd>
+                  </div>
+                </dl>
+              </section>
 
-            <section class="listen-live-section listen-live-more" aria-labelledby="continue-exploring-heading">
-              <h2 id="continue-exploring-heading">Continue Exploring</h2>
-              <div class="listen-live-more__grid">
-                <a class="listen-live-more__card" href="{{ "/shows/" | relURL }}">
-                  <span class="listen-live-more__card-label">Browse Shows</span>
-                  <small>Explore past Sundown Sessions broadcasts and track listings.</small>
-                </a>
-                <a class="listen-live-more__card" href="{{ "/artists/" | relURL }}">
-                  <span class="listen-live-more__card-label">Featured Artists</span>
-                  <small>Discover the artists featured across Sundown Sessions.</small>
-                </a>
-              </div>
-            </section>
+              <section class="listen-live-section listen-live-more" aria-labelledby="continue-exploring-heading">
+                <h2 id="continue-exploring-heading">Continue Exploring</h2>
+                <div class="listen-live-more__grid">
+                  <a class="listen-live-more__card" href="{{ "/shows/" | relURL }}">
+                    <span class="listen-live-more__card-label">Browse Shows</span>
+                    <small>Explore past Sundown Sessions broadcasts and track listings.</small>
+                  </a>
+                  <a class="listen-live-more__card" href="{{ "/artists/" | relURL }}">
+                    <span class="listen-live-more__card-label">Featured Artists</span>
+                    <small>Discover the artists featured across Sundown Sessions.</small>
+                  </a>
+                </div>
+              </section>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rename the lower broadcast section to Broadcast Details and link the top schedule text to it
- soften broadcast detail labels and add a subtle lower-page surface treatment
- refine the Continue Exploring cards into balanced editorial recommendation cards

## Verification
- git diff --check
- Not run: hugo server/build, because Hugo is not available on PATH in this shell
- Not run: JS syntax check, because Node is not available on PATH in this shell