### PR TITLE
Remove Listen Live on-air artwork badge

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -346,9 +346,8 @@
   display: grid;
   width: 100%;
   height: 100%;
-  align-content: center;
+  place-content: center;
   justify-items: center;
-  gap: 0.85rem;
   padding: 10%;
 }
 
@@ -374,22 +373,6 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-}
-
-.listen-live-artwork-badge {
-  border-radius: 999px;
-  background: rgb(255 255 255 / 0.78);
-  padding: 0.22rem 0.6rem;
-  color: #404040; /* neutral-700 */
-  font-size: 0.74rem;
-  font-weight: 800;
-  line-height: 1.3;
-  text-transform: uppercase;
-}
-
-.dark .listen-live-artwork-badge {
-  background: rgb(23 23 23 / 0.72);
-  color: #e5e5e5; /* neutral-200 */
 }
 
 .listen-live-now-playing [hidden],

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -50,7 +50,6 @@
                     <span class="listen-live-artwork-avatar">
                       <img src="{{ "/images/sundown-sessions-logo.jpg" | relURL }}" alt="Sundown Sessions" loading="lazy" decoding="async">
                     </span>
-                    <span class="listen-live-artwork-badge">On air</span>
                   </span>
                 </div>
 


### PR DESCRIPTION
## Summary
- remove the lower On air badge from the Listen Live artwork placeholder
- remove CSS used only by that badge
- keep the artwork placeholder centered after the badge removal

## Testing
- Searched for remaining lower badge references with rg
- Hugo build not run locally because hugo is not installed/on PATH in this environment