### PR TITLE
Refine Shows archive page content

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -731,6 +731,230 @@
   }
 }
 
+/* Shows archive page: editorial gateway above the broadcast list. */
+
+.shows-archive-intro {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  align-items: start;
+  margin: 0 0 clamp(2rem, 5vw, 3rem);
+}
+
+.shows-archive-intro__copy {
+  max-width: 47rem;
+}
+
+.shows-archive-kicker {
+  margin: 0 0 0.7rem;
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.dark .shows-archive-kicker {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.shows-archive-intro h2,
+.shows-archive-list-heading h2 {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-weight: 850;
+  letter-spacing: 0;
+}
+
+.dark .shows-archive-intro h2,
+.dark .shows-archive-list-heading h2 {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.shows-archive-intro h2 {
+  max-width: 16ch;
+  font-size: clamp(1.9rem, 4.4vw, 3rem);
+  line-height: 1.05;
+}
+
+.shows-archive-list-heading {
+  margin: 0 0 1rem;
+}
+
+.shows-archive-list-heading h2 {
+  font-size: 1.65rem;
+  line-height: 1.2;
+}
+
+.shows-archive-prose {
+  max-width: 46rem;
+  margin-top: 1.15rem;
+  color: #404040; /* neutral-700 */
+  font-size: 1.04rem;
+  line-height: 1.78;
+}
+
+.shows-archive-prose p {
+  margin: 0;
+}
+
+.shows-archive-prose p + p {
+  margin-top: 1rem;
+}
+
+.dark .shows-archive-prose {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.shows-archive-panel {
+  display: grid;
+  gap: 1.15rem;
+  border: 1px solid color-mix(in srgb, var(--ss-color-border) 82%, transparent);
+  border-radius: 0.5rem;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--ss-color-sunset) 8%, transparent),
+      transparent 46%
+    ),
+    color-mix(in srgb, var(--ss-color-surface) 90%, white);
+  padding: clamp(1.15rem, 3vw, 1.5rem);
+  box-shadow: 0 1px 2px rgb(30 36 56 / 0.06);
+}
+
+.dark .shows-archive-panel {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--ss-color-golden-hour) 7%, transparent),
+      transparent 46%
+    ),
+    color-mix(in srgb, var(--ss-color-surface) 88%, #171717);
+  box-shadow: 0 14px 30px rgb(0 0 0 / 0.18);
+}
+
+.shows-archive-stats {
+  display: grid;
+  gap: 0.9rem;
+  margin: 0;
+}
+
+.shows-archive-stats div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.shows-archive-stats dt {
+  color: #737373; /* neutral-500 */
+  font-size: 0.76rem;
+  font-weight: 800;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.dark .shows-archive-stats dt {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.shows-archive-stats dd {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-size: 1.08rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.dark .shows-archive-stats dd {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.shows-archive-stats a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--ss-color-link) 42%, transparent);
+  text-underline-offset: 0.16rem;
+}
+
+.shows-archive-stats a:hover,
+.shows-archive-stats a:focus-visible {
+  color: var(--ss-color-link);
+  text-decoration-color: currentColor;
+}
+
+.shows-archive-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.shows-archive-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.7rem;
+  border-radius: 0.5rem;
+  padding: 0.68rem 1rem;
+  font-size: 0.94rem;
+  font-weight: 750;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.shows-archive-button:focus-visible,
+.shows-archive-stats a:focus-visible {
+  outline: 3px solid rgba(var(--color-primary-500), 0.6);
+  outline-offset: 3px;
+}
+
+.shows-archive-button--primary {
+  background: #171717; /* neutral-900 */
+  color: #ffffff;
+}
+
+.shows-archive-button--primary:hover {
+  background: rgba(var(--color-primary-700), 1);
+  color: #ffffff;
+}
+
+.dark .shows-archive-button--primary {
+  background: #f5f5f5; /* neutral-100 */
+  color: #171717; /* neutral-900 */
+}
+
+.dark .shows-archive-button--primary:hover {
+  background: rgba(var(--color-primary-300), 1);
+  color: #171717; /* neutral-900 */
+}
+
+.shows-archive-button--secondary {
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  background: #ffffff;
+  color: #171717; /* neutral-900 */
+}
+
+.shows-archive-button--secondary:hover {
+  border-color: #737373; /* neutral-500 */
+  background: #f5f5f5; /* neutral-100 */
+  color: #171717; /* neutral-900 */
+}
+
+.dark .shows-archive-button--secondary {
+  border-color: #525252; /* neutral-600 */
+  background: #262626; /* neutral-800 */
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.dark .shows-archive-button--secondary:hover {
+  border-color: #a3a3a3; /* neutral-400 */
+  background: #404040; /* neutral-700 */
+  color: #ffffff;
+}
+
+@media (min-width: 800px) {
+  .shows-archive-intro {
+    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.38fr);
+  }
+}
+
 .listen-live-follow {
   max-width: 42rem;
   margin: 2rem 0 0;

--- a/src/content/shows/_index.md
+++ b/src/content/shows/_index.md
@@ -1,9 +1,15 @@
 ---
-title: 'Shows'
-description: 'Every broadcast, playlist and musical discovery.'
+title: 'Shows Archive'
+description: 'Browse Sundown Sessions broadcasts, playlists, featured artists and music discoveries from the archive.'
+summary: 'Explore previous Sundown Sessions broadcasts, with playlists, featured artists, show notes and routes into the wider music archive.'
+strapline: 'Broadcasts, playlists and late-night discoveries from Sundown Sessions.'
 menu:
   main:
     name: 'Shows'
-    title: 'Go to the Shows page'
+    title: 'Browse the Sundown Sessions shows archive'
     weight: 1
 ---
+
+Every Sundown Sessions broadcast is a trail through the record shelves: new discoveries, overlooked favourites, guest moments, local voices, and songs that deserve another listen after the show has finished.
+
+Use the archive to revisit previous broadcasts, follow the artists that shaped each playlist, and find your way into related tracks and releases across the site.

--- a/src/layouts/partials/article-link/show-card.html
+++ b/src/layouts/partials/article-link/show-card.html
@@ -2,7 +2,7 @@
 {{ $page := .Page }}
 {{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
 
-{{/* Image resolution — mirrors the logic in card.html */}}
+{{/* Image resolution mirrors the logic in card.html */}}
 {{ $featured := "" }}
 {{ $featuredURL := "" }}
 {{ if not .Params.hideFeatureImage }}
@@ -55,8 +55,7 @@
   {{ $showTitle = strings.TrimPrefix (printf "%s: " $showLabel) .Title | emojify }}
 {{ end }}
 
-{{/* Derived values */}}
-{{ $trackCount := len .Params.tags }}
+{{ $featuredArtistCount := len .Params.tags }}
 {{ $durationStr := printf "%02d:00" .ReadingTime }}
 {{ $tags := .Params.tags }}
 {{ $maxVisibleTags := 4 }}
@@ -64,12 +63,11 @@
 {{ $overflowCount := sub (len $tags) $maxVisibleTags }}
 
 <article
-  class="article-link--show-card group relative flex flex-row items-start overflow-hidden rounded-xl border border-neutral-300 bg-white/80 shadow-sm transition hover:shadow-lg dark:border-neutral-700 dark:bg-neutral-900/80">
+  class="article-link--show-card group relative flex flex-col items-stretch overflow-hidden rounded-xl border border-neutral-300 bg-white/80 shadow-sm transition hover:shadow-lg dark:border-neutral-700 dark:bg-neutral-900/80 sm:flex-row sm:items-start">
 
-  {{/* Album art — fixed 192×192 (30% of 640×640 original), aspect ratio preserved */}}
   <a
     href="{{ $page.RelPermalink }}"
-    class="not-prose block flex-none shrink-0 overflow-hidden bg-neutral-100 dark:bg-neutral-800 w-80 h-80"
+    class="not-prose block h-48 w-full flex-none shrink-0 overflow-hidden bg-neutral-100 dark:bg-neutral-800 sm:h-80 sm:w-80"
     tabindex="-1"
     aria-hidden="true">
     {{ with $featuredURL }}
@@ -85,10 +83,7 @@
     {{ end }}
   </a>
 
-  {{/* Main content */}}
-  <div class="flex flex-1 flex-col gap-1.5 p-4 sm:p-5 min-w-0">
-
-    {{/* Show label with play icon */}}
+  <div class="flex min-w-0 flex-1 flex-col gap-1.5 p-4 sm:p-5">
     {{ if $showLabel }}
       <div class="flex items-center gap-1.5 text-sm font-semibold text-primary-600 dark:text-primary-400">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
@@ -99,7 +94,6 @@
       </div>
     {{ end }}
 
-    {{/* Broadcast title */}}
     <header>
       <a
         href="{{ $page.RelPermalink }}"
@@ -108,7 +102,6 @@
       </a>
     </header>
 
-    {{/* Metadata row: date · reading time · track count */}}
     <div class="flex flex-row flex-wrap items-center text-sm text-neutral-500 dark:text-neutral-400">
       {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
         <span class="flex items-center gap-1">
@@ -126,23 +119,21 @@
             class="h-3.5 w-3.5 flex-none opacity-70" aria-hidden="true">
             <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm.75-13a.75.75 0 0 0-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 0 0 0-1.5h-3.25V5Z" clip-rule="evenodd"/>
           </svg>
-          {{ partial "meta/reading-time.html" . }}
+          Show notes
         </span>
       {{ end }}
-      {{ if gt $trackCount 0 }}
+      {{ if gt $featuredArtistCount 0 }}
         <span class="px-2 text-primary-500">&middot;</span>
-        <span>{{ $trackCount }} {{ if eq $trackCount 1 }}track{{ else }}tracks{{ end }}</span>
+        <span>{{ $featuredArtistCount }} featured {{ if eq $featuredArtistCount 1 }}artist{{ else }}artists{{ end }}</span>
       {{ end }}
     </div>
 
-    {{/* Summary text */}}
     {{ with .Summary }}
       <p class="line-clamp-2 text-sm text-neutral-600 dark:text-neutral-300">{{ . | plainify }}</p>
     {{ end }}
 
-    {{/* Artist tags: first four visible, remainder shown as +N */}}
     {{ if $tags }}
-      <div class="flex flex-wrap items-center gap-1.5 mt-0.5">
+      <div class="mt-0.5 flex flex-wrap items-center gap-1.5">
         {{ range $visibleTags }}
           <span class="rounded-full border border-primary-400 px-2.5 py-0.5 text-xs text-primary-700 dark:border-primary-600 dark:text-primary-400">{{ . }}</span>
         {{ end }}
@@ -151,11 +142,9 @@
         {{ end }}
       </div>
     {{ end }}
-
   </div>
 
-  {{/* Right panel: play button + duration */}}
-  <div class="hidden sm:flex flex-none flex-col items-center justify-center gap-2 px-5 border-l border-neutral-200 dark:border-neutral-700">
+  <div class="hidden flex-none flex-col items-center justify-center gap-2 border-l border-neutral-200 px-5 dark:border-neutral-700 sm:flex">
     <a
       href="{{ $page.RelPermalink }}"
       aria-label="Go to {{ $showLabel | default .Title }}"
@@ -165,7 +154,6 @@
         <path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.84Z"/>
       </svg>
     </a>
-    <span class="text-xs font-mono text-neutral-500 dark:text-neutral-400">{{ $durationStr }}</span>
+    <span class="font-mono text-xs text-neutral-500 dark:text-neutral-400">{{ $durationStr }}</span>
   </div>
-
 </article>

--- a/src/layouts/shows/list.html
+++ b/src/layouts/shows/list.html
@@ -1,18 +1,61 @@
 {{ define "main" }}
   {{ .Scratch.Set "scope" "list" }}
 
-  {{/* Hero Banner */}}
   {{ partial "section-hero.html" . }}
 
-  {{/* Shows listing — horizontal show cards in a vertical stack */}}
   {{ $datedPages := where .Pages ".Date.IsZero" "ne" true }}
+  {{ $sortedPages := sort $datedPages "Date" "desc" }}
+  {{ $showCount := len $datedPages }}
+  {{ $latestShow := index $sortedPages 0 }}
+
+  {{ with .Content }}
+    <section class="shows-archive-intro" aria-labelledby="shows-archive-intro-heading">
+      <div class="shows-archive-intro__copy">
+        <p class="shows-archive-kicker">The archive</p>
+        <h2 id="shows-archive-intro-heading">Start with a broadcast, then follow the music wherever it leads.</h2>
+        <div class="shows-archive-prose">
+          {{ . }}
+        </div>
+      </div>
+      <aside class="shows-archive-panel" aria-label="Shows archive highlights">
+        <dl class="shows-archive-stats">
+          <div>
+            <dt>Published broadcasts</dt>
+            <dd>{{ $showCount }}</dd>
+          </div>
+          <div>
+            <dt>Latest show</dt>
+            <dd>
+              {{ with $latestShow }}
+                <a href="{{ .RelPermalink }}">{{ partial "release/show-card-title.html" . }}</a>
+              {{ else }}
+                Coming soon
+              {{ end }}
+            </dd>
+          </div>
+        </dl>
+        <div class="shows-archive-actions">
+          {{ with $latestShow }}
+            <a class="shows-archive-button shows-archive-button--primary" href="{{ .RelPermalink }}">Latest Broadcast</a>
+          {{ end }}
+          <a class="shows-archive-button shows-archive-button--secondary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
+        </div>
+      </aside>
+    </section>
+  {{ end }}
+
   {{ if $datedPages }}
+    <div class="shows-archive-list-heading">
+      <p class="shows-archive-kicker">Browse previous shows</p>
+      <h2>All Broadcasts</h2>
+    </div>
+
     {{ $orderByWeight := .Params.orderByWeight | default (site.Params.list.orderByWeight | default false) }}
     {{ $groupByYear := .Params.groupByYear | default (site.Params.list.groupByYear | default false) }}
     {{ $groupByYear = and (not $orderByWeight) $groupByYear }}
 
     {{ if $groupByYear }}
-      {{ range (.Paginate ($datedPages.GroupByDate "2006")).PageGroups }}
+      {{ range (.Paginate ($sortedPages.GroupByDate "2006")).PageGroups }}
         <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
           {{ .Key }}
         </h2>
@@ -25,7 +68,7 @@
     {{ else }}
       <section class="flex flex-col gap-4 w-full">
         {{ if not $orderByWeight }}
-          {{ range (.Paginate ($datedPages.GroupByDate "2006")).PageGroups }}
+          {{ range (.Paginate ($sortedPages.GroupByDate "2006")).PageGroups }}
             {{ range .Pages }}
               {{ partial "article-link/show-card.html" . }}
             {{ end }}


### PR DESCRIPTION
## Summary
- retitle and rewrite Shows archive metadata and intro copy
- add an editorial archive gateway with published-show stats, latest broadcast, and Listen Live CTA
- clarify show-card metadata as featured artists and improve mobile card stacking

## Validation
- Hugo v0.146.5 production validation passed: \hugo --source src --printPathWarnings --panicOnWarning --environment production --baseURL https://example.invalid/\`n- Checked generated Shows HTML for SEO metadata, archive intro, CTAs, and featured artist labels
- Playwright screenshot check not run because Node/npx are not installed locally

Closes #573