### PR TITLE
Refine shows archive layout

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -734,14 +734,11 @@
 /* Shows archive page: editorial gateway above the broadcast list. */
 
 .shows-archive-intro {
-  display: grid;
-  gap: clamp(1.25rem, 3vw, 2rem);
-  align-items: start;
-  margin: 0 0 clamp(2rem, 5vw, 3rem);
+  margin: 0 0 clamp(1.75rem, 4vw, 2.5rem);
 }
 
 .shows-archive-intro__copy {
-  max-width: 47rem;
+  max-width: 55rem;
 }
 
 .shows-archive-kicker {
@@ -785,12 +782,24 @@
   line-height: 1.2;
 }
 
+.shows-archive-list-heading p:not(.shows-archive-kicker) {
+  max-width: 38rem;
+  margin: 0.35rem 0 0;
+  color: #525252; /* neutral-600 */
+  font-size: 0.98rem;
+  line-height: 1.55;
+}
+
+.dark .shows-archive-list-heading p:not(.shows-archive-kicker) {
+  color: #a3a3a3; /* neutral-400 */
+}
+
 .shows-archive-prose {
   max-width: 46rem;
-  margin-top: 1.15rem;
+  margin-top: 1rem;
   color: #404040; /* neutral-700 */
   font-size: 1.04rem;
-  line-height: 1.78;
+  line-height: 1.68;
 }
 
 .shows-archive-prose p {
@@ -805,154 +814,8 @@
   color: #d4d4d4; /* neutral-300 */
 }
 
-.shows-archive-panel {
-  display: grid;
-  gap: 1.15rem;
-  border: 1px solid color-mix(in srgb, var(--ss-color-border) 82%, transparent);
-  border-radius: 0.5rem;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--ss-color-sunset) 8%, transparent),
-      transparent 46%
-    ),
-    color-mix(in srgb, var(--ss-color-surface) 90%, white);
-  padding: clamp(1.15rem, 3vw, 1.5rem);
-  box-shadow: 0 1px 2px rgb(30 36 56 / 0.06);
-}
-
-.dark .shows-archive-panel {
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--ss-color-golden-hour) 7%, transparent),
-      transparent 46%
-    ),
-    color-mix(in srgb, var(--ss-color-surface) 88%, #171717);
-  box-shadow: 0 14px 30px rgb(0 0 0 / 0.18);
-}
-
-.shows-archive-stats {
-  display: grid;
-  gap: 0.9rem;
-  margin: 0;
-}
-
-.shows-archive-stats div {
-  display: grid;
-  gap: 0.2rem;
-}
-
-.shows-archive-stats dt {
-  color: #737373; /* neutral-500 */
-  font-size: 0.76rem;
-  font-weight: 800;
-  line-height: 1.35;
-  text-transform: uppercase;
-}
-
-.dark .shows-archive-stats dt {
-  color: #a3a3a3; /* neutral-400 */
-}
-
-.shows-archive-stats dd {
-  margin: 0;
-  color: #171717; /* neutral-900 */
-  font-size: 1.08rem;
-  font-weight: 800;
-  line-height: 1.35;
-}
-
-.dark .shows-archive-stats dd {
-  color: #f5f5f5; /* neutral-100 */
-}
-
-.shows-archive-stats a {
-  color: inherit;
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--ss-color-link) 42%, transparent);
-  text-underline-offset: 0.16rem;
-}
-
-.shows-archive-stats a:hover,
-.shows-archive-stats a:focus-visible {
-  color: var(--ss-color-link);
-  text-decoration-color: currentColor;
-}
-
-.shows-archive-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem;
-}
-
-.shows-archive-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.7rem;
-  border-radius: 0.5rem;
-  padding: 0.68rem 1rem;
-  font-size: 0.94rem;
-  font-weight: 750;
-  line-height: 1.2;
-  text-decoration: none;
-}
-
-.shows-archive-button:focus-visible,
-.shows-archive-stats a:focus-visible {
-  outline: 3px solid rgba(var(--color-primary-500), 0.6);
-  outline-offset: 3px;
-}
-
-.shows-archive-button--primary {
-  background: #171717; /* neutral-900 */
-  color: #ffffff;
-}
-
-.shows-archive-button--primary:hover {
-  background: rgba(var(--color-primary-700), 1);
-  color: #ffffff;
-}
-
-.dark .shows-archive-button--primary {
-  background: #f5f5f5; /* neutral-100 */
-  color: #171717; /* neutral-900 */
-}
-
-.dark .shows-archive-button--primary:hover {
-  background: rgba(var(--color-primary-300), 1);
-  color: #171717; /* neutral-900 */
-}
-
-.shows-archive-button--secondary {
-  border: 1px solid #d4d4d4; /* neutral-300 */
-  background: #ffffff;
-  color: #171717; /* neutral-900 */
-}
-
-.shows-archive-button--secondary:hover {
-  border-color: #737373; /* neutral-500 */
-  background: #f5f5f5; /* neutral-100 */
-  color: #171717; /* neutral-900 */
-}
-
-.dark .shows-archive-button--secondary {
-  border-color: #525252; /* neutral-600 */
-  background: #262626; /* neutral-800 */
-  color: #f5f5f5; /* neutral-100 */
-}
-
-.dark .shows-archive-button--secondary:hover {
-  border-color: #a3a3a3; /* neutral-400 */
-  background: #404040; /* neutral-700 */
-  color: #ffffff;
-}
-
-@media (min-width: 800px) {
-  .shows-archive-intro {
-    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.38fr);
-  }
+.shows-archive-list {
+  gap: 0.85rem;
 }
 
 .listen-live-follow {

--- a/src/content/shows/_index.md
+++ b/src/content/shows/_index.md
@@ -10,6 +10,4 @@ menu:
     weight: 1
 ---
 
-Every Sundown Sessions broadcast is a trail through the record shelves: new discoveries, overlooked favourites, guest moments, local voices, and songs that deserve another listen after the show has finished.
-
-Use the archive to revisit previous broadcasts, follow the artists that shaped each playlist, and find your way into related tracks and releases across the site.
+Every Sundown Sessions broadcast is a trail through the world of alternative music. Browse complete playlists, discover the artists and releases behind every track, and follow the connections wherever they lead.

--- a/src/layouts/partials/article-link/show-card.html
+++ b/src/layouts/partials/article-link/show-card.html
@@ -63,11 +63,11 @@
 {{ $overflowCount := sub (len $tags) $maxVisibleTags }}
 
 <article
-  class="article-link--show-card group relative flex flex-col items-stretch overflow-hidden rounded-xl border border-neutral-300 bg-white/80 shadow-sm transition hover:shadow-lg dark:border-neutral-700 dark:bg-neutral-900/80 sm:flex-row sm:items-start">
+  class="article-link--show-card group relative flex flex-col items-stretch overflow-hidden rounded-xl border border-neutral-300 bg-white/80 shadow-sm transition hover:shadow-lg dark:border-neutral-700 dark:bg-neutral-900/80 sm:flex-row sm:items-stretch">
 
   <a
     href="{{ $page.RelPermalink }}"
-    class="not-prose block h-48 w-full flex-none shrink-0 overflow-hidden bg-neutral-100 dark:bg-neutral-800 sm:h-80 sm:w-80"
+    class="not-prose block h-48 w-full flex-none shrink-0 overflow-hidden bg-neutral-100 dark:bg-neutral-800 sm:h-44 sm:w-44"
     tabindex="-1"
     aria-hidden="true">
     {{ with $featuredURL }}
@@ -83,7 +83,7 @@
     {{ end }}
   </a>
 
-  <div class="flex min-w-0 flex-1 flex-col gap-1.5 p-4 sm:p-5">
+  <div class="flex min-w-0 flex-1 flex-col justify-center gap-1.5 p-4 sm:p-5">
     {{ if $showLabel }}
       <div class="flex items-center gap-1.5 text-sm font-semibold text-primary-600 dark:text-primary-400">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"

--- a/src/layouts/shows/list.html
+++ b/src/layouts/shows/list.html
@@ -5,8 +5,6 @@
 
   {{ $datedPages := where .Pages ".Date.IsZero" "ne" true }}
   {{ $sortedPages := sort $datedPages "Date" "desc" }}
-  {{ $showCount := len $datedPages }}
-  {{ $latestShow := index $sortedPages 0 }}
 
   {{ with .Content }}
     <section class="shows-archive-intro" aria-labelledby="shows-archive-intro-heading">
@@ -17,30 +15,6 @@
           {{ . }}
         </div>
       </div>
-      <aside class="shows-archive-panel" aria-label="Shows archive highlights">
-        <dl class="shows-archive-stats">
-          <div>
-            <dt>Published broadcasts</dt>
-            <dd>{{ $showCount }}</dd>
-          </div>
-          <div>
-            <dt>Latest show</dt>
-            <dd>
-              {{ with $latestShow }}
-                <a href="{{ .RelPermalink }}">{{ partial "release/show-card-title.html" . }}</a>
-              {{ else }}
-                Coming soon
-              {{ end }}
-            </dd>
-          </div>
-        </dl>
-        <div class="shows-archive-actions">
-          {{ with $latestShow }}
-            <a class="shows-archive-button shows-archive-button--primary" href="{{ .RelPermalink }}">Latest Broadcast</a>
-          {{ end }}
-          <a class="shows-archive-button shows-archive-button--secondary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
-        </div>
-      </aside>
     </section>
   {{ end }}
 
@@ -48,6 +22,7 @@
     <div class="shows-archive-list-heading">
       <p class="shows-archive-kicker">Browse previous shows</p>
       <h2>All Broadcasts</h2>
+      <p>Browse every Sundown Sessions programme in chronological order.</p>
     </div>
 
     {{ $orderByWeight := .Params.orderByWeight | default (site.Params.list.orderByWeight | default false) }}
@@ -59,14 +34,14 @@
         <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
           {{ .Key }}
         </h2>
-        <section class="flex flex-col gap-4 w-full">
+        <section class="shows-archive-list flex flex-col w-full">
           {{ range .Pages }}
             {{ partial "article-link/show-card.html" . }}
           {{ end }}
         </section>
       {{ end }}
     {{ else }}
-      <section class="flex flex-col gap-4 w-full">
+      <section class="shows-archive-list flex flex-col w-full">
         {{ if not $orderByWeight }}
           {{ range (.Paginate ($sortedPages.GroupByDate "2006")).PageGroups }}
             {{ range .Pages }}


### PR DESCRIPTION
## Summary
- fix oversized Shows archive cards by reducing the desktop artwork block
- remove the weak archive sidebar so the intro reads as a full-width editorial lead-in
- tighten Shows intro copy, add All Broadcasts context, and reduce archive card spacing

## Testing
- Not run: Hugo is not installed or not available on PATH in this shell.