### PR TITLE
feat(src): refine shows archive cards

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -818,6 +818,237 @@
   gap: 0.85rem;
 }
 
+.article-link--show-card {
+  position: relative;
+  display: flex;
+  min-height: 11.75rem;
+  overflow: hidden;
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.article-link--show-card:hover,
+.article-link--show-card:focus-within {
+  border-color: rgba(var(--color-primary-500), 0.55);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.12);
+  transform: translateY(-1px);
+}
+
+.dark .article-link--show-card {
+  border-color: #404040; /* neutral-700 */
+  background: rgba(23, 23, 23, 0.84);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22);
+}
+
+.dark .article-link--show-card:hover,
+.dark .article-link--show-card:focus-within {
+  border-color: rgba(var(--color-primary-400), 0.5);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.32);
+}
+
+.show-card__image-link {
+  display: block;
+  flex: 0 0 clamp(10.5rem, 22vw, 13.5rem);
+  align-self: stretch;
+  overflow: hidden;
+  background: #f5f5f5; /* neutral-100 */
+}
+
+.dark .show-card__image-link {
+  background: #262626; /* neutral-800 */
+}
+
+.show-card__image,
+.show-card__image-placeholder {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 11.75rem;
+}
+
+.show-card__image {
+  object-fit: cover;
+  transition: transform 300ms ease;
+}
+
+.article-link--show-card:hover .show-card__image,
+.article-link--show-card:focus-within .show-card__image {
+  transform: scale(1.025);
+}
+
+.show-card__image-placeholder {
+  background: linear-gradient(135deg, #f5f5f5, #e5e5e5);
+}
+
+.dark .show-card__image-placeholder {
+  background: linear-gradient(135deg, #262626, #171717);
+}
+
+.show-card__content {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(1.15rem, 2.4vw, 1.55rem) clamp(1.2rem, 3vw, 1.85rem);
+}
+
+.show-card__number {
+  margin-bottom: 0.3rem;
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.dark .show-card__number {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.show-card__title-link {
+  color: #171717; /* neutral-900 */
+  text-decoration-color: rgba(var(--color-primary-500), 1);
+}
+
+.show-card__title-link::before {
+  position: absolute;
+  inset: 0;
+  content: "";
+}
+
+.show-card__title-link:hover,
+.show-card__title-link:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.show-card__title-link:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 1);
+  outline-offset: 3px;
+  border-radius: 0.25rem;
+}
+
+.dark .show-card__title-link {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.show-card__title {
+  margin: 0;
+  font-size: clamp(1.12rem, 2.1vw, 1.35rem);
+  font-weight: 850;
+  letter-spacing: 0;
+  line-height: 1.22;
+}
+
+.show-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.42rem 0.8rem;
+  margin-top: 0.72rem;
+  color: #525252; /* neutral-600 */
+  font-size: 0.88rem;
+  line-height: 1.35;
+}
+
+.dark .show-card__meta {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.show-card__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  white-space: nowrap;
+}
+
+.show-card__meta-icon {
+  width: 0.92rem;
+  height: 0.92rem;
+  flex: 0 0 auto;
+  color: rgba(var(--color-primary-500), 0.78);
+}
+
+.dark .show-card__meta-icon {
+  color: rgba(var(--color-primary-400), 0.82);
+}
+
+.show-card__summary {
+  display: -webkit-box;
+  margin: 0.8rem 0 0;
+  overflow: hidden;
+  color: #404040; /* neutral-700 */
+  font-size: 0.95rem;
+  line-height: 1.58;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.dark .show-card__summary {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .article-link--show-card,
+  .show-card__image {
+    transition: none;
+  }
+
+  .article-link--show-card:hover,
+  .article-link--show-card:focus-within,
+  .article-link--show-card:hover .show-card__image,
+  .article-link--show-card:focus-within .show-card__image {
+    transform: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .shows-archive-list {
+    gap: 1rem;
+  }
+
+  .article-link--show-card {
+    min-height: 0;
+    flex-direction: column;
+  }
+
+  .show-card__image-link {
+    flex: none;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+  }
+
+  .show-card__image,
+  .show-card__image-placeholder {
+    min-height: 0;
+  }
+
+  .show-card__content {
+    padding: 1.05rem 1rem 1.15rem;
+  }
+
+  .show-card__meta {
+    gap: 0.46rem 0.75rem;
+    margin-top: 0.65rem;
+  }
+
+  .show-card__meta-item {
+    white-space: normal;
+  }
+
+  .show-card__summary {
+    -webkit-line-clamp: 3;
+  }
+}
+
 .listen-live-follow {
   max-width: 42rem;
   margin: 2rem 0 0;

--- a/src/layouts/partials/article-link/show-card.html
+++ b/src/layouts/partials/article-link/show-card.html
@@ -57,17 +57,26 @@
 
 {{ $featuredArtistCount := len .Params.tags }}
 {{ $durationStr := printf "%02d:00" .ReadingTime }}
-{{ $tags := .Params.tags }}
-{{ $maxVisibleTags := 4 }}
-{{ $visibleTags := first $maxVisibleTags $tags }}
-{{ $overflowCount := sub (len $tags) $maxVisibleTags }}
+{{ $trackCount := 0 }}
+{{ with $page.File }}
+  {{ $showDir := path.Dir (replace .Path "\\" "/") }}
+  {{ $trackInfoPath := printf "content/%s/track-info.md" $showDir }}
+  {{ $playlistPath := printf "content/%s/playlist.md" $showDir }}
+  {{ if fileExists $trackInfoPath }}
+    {{ $trackRows := findRE `(?m)^\|\s*\d+\s*\|` (readFile $trackInfoPath) }}
+    {{ $trackCount = len $trackRows }}
+  {{ else if fileExists $playlistPath }}
+    {{ $playlistRows := findRE `(?m)^\d+\.\s+` (readFile $playlistPath) }}
+    {{ $trackCount = len $playlistRows }}
+  {{ end }}
+{{ end }}
 
 <article
-  class="article-link--show-card group relative flex flex-col items-stretch overflow-hidden rounded-xl border border-neutral-300 bg-white/80 shadow-sm transition hover:shadow-lg dark:border-neutral-700 dark:bg-neutral-900/80 sm:flex-row sm:items-stretch">
+  class="article-link--show-card group not-prose">
 
   <a
     href="{{ $page.RelPermalink }}"
-    class="not-prose block h-48 w-full flex-none shrink-0 overflow-hidden bg-neutral-100 dark:bg-neutral-800 sm:h-44 sm:w-44"
+    class="show-card__image-link"
     tabindex="-1"
     aria-hidden="true">
     {{ with $featuredURL }}
@@ -77,19 +86,15 @@
         role="presentation"
         loading="lazy"
         decoding="async"
-        class="not-prose h-full w-full object-cover transition duration-300 ease-out group-hover:scale-[1.02] motion-reduce:transform-none">
+        class="show-card__image">
     {{ else }}
-      <div class="h-full w-full bg-gradient-to-br from-neutral-100 to-neutral-200 dark:from-neutral-800 dark:to-neutral-900"></div>
+      <div class="show-card__image-placeholder"></div>
     {{ end }}
   </a>
 
-  <div class="flex min-w-0 flex-1 flex-col justify-center gap-1.5 p-4 sm:p-5">
+  <div class="show-card__content">
     {{ if $showLabel }}
-      <div class="flex items-center gap-1.5 text-sm font-semibold text-primary-600 dark:text-primary-400">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-          class="h-4 w-4 flex-none" aria-hidden="true">
-          <path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.84Z"/>
-        </svg>
+      <div class="show-card__number">
         {{ $showLabel }}
       </div>
     {{ end }}
@@ -97,63 +102,52 @@
     <header>
       <a
         href="{{ $page.RelPermalink }}"
-        class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-neutral-800 hover:underline hover:underline-offset-2">
-        <h2 class="mt-0 mb-0 text-xl font-bold leading-snug">{{ $showTitle }}</h2>
+        class="show-card__title-link">
+        <h2 class="show-card__title">{{ $showTitle }}</h2>
       </a>
     </header>
 
-    <div class="flex flex-row flex-wrap items-center text-sm text-neutral-500 dark:text-neutral-400">
+    <div class="show-card__meta">
       {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
-        <span class="flex items-center gap-1">
+        <span class="show-card__meta-item">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-            class="h-3.5 w-3.5 flex-none opacity-70" aria-hidden="true">
+            class="show-card__meta-icon" aria-hidden="true">
             <path fill-rule="evenodd" d="M5.75 2a.75.75 0 0 1 .75.75V4h7V2.75a.75.75 0 0 1 1.5 0V4h.25A2.75 2.75 0 0 1 18 6.75v8.5A2.75 2.75 0 0 1 15.25 18H4.75A2.75 2.75 0 0 1 2 15.25v-8.5A2.75 2.75 0 0 1 4.75 4H5V2.75A.75.75 0 0 1 5.75 2Zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75Z" clip-rule="evenodd"/>
           </svg>
           {{ partial "meta/date.html" .Date }}
         </span>
       {{ end }}
       {{ if and (.Params.showReadingTime | default (.Site.Params.article.showReadingTime | default true)) (ne .ReadingTime 0) }}
-        <span class="px-2 text-primary-500">&middot;</span>
-        <span class="flex items-center gap-1">
+        <span class="show-card__meta-item">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-            class="h-3.5 w-3.5 flex-none opacity-70" aria-hidden="true">
+            class="show-card__meta-icon" aria-hidden="true">
             <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm.75-13a.75.75 0 0 0-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 0 0 0-1.5h-3.25V5Z" clip-rule="evenodd"/>
           </svg>
-          Show notes
+          {{ $durationStr }}
+        </span>
+      {{ end }}
+      {{ if gt $trackCount 0 }}
+        <span class="show-card__meta-item">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+            class="show-card__meta-icon" aria-hidden="true">
+            <path fill-rule="evenodd" d="M4.5 3A1.5 1.5 0 0 0 3 4.5v11A1.5 1.5 0 0 0 4.5 17h11a1.5 1.5 0 0 0 1.5-1.5v-11A1.5 1.5 0 0 0 15.5 3h-11Zm2.25 3.5a.75.75 0 0 0 0 1.5h6.5a.75.75 0 0 0 0-1.5h-6.5Zm0 3a.75.75 0 0 0 0 1.5h6.5a.75.75 0 0 0 0-1.5h-6.5Zm0 3a.75.75 0 0 0 0 1.5h4.5a.75.75 0 0 0 0-1.5h-4.5Z" clip-rule="evenodd"/>
+          </svg>
+          {{ $trackCount }} {{ if eq $trackCount 1 }}track{{ else }}tracks{{ end }}
         </span>
       {{ end }}
       {{ if gt $featuredArtistCount 0 }}
-        <span class="px-2 text-primary-500">&middot;</span>
-        <span>{{ $featuredArtistCount }} featured {{ if eq $featuredArtistCount 1 }}artist{{ else }}artists{{ end }}</span>
+        <span class="show-card__meta-item">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+            class="show-card__meta-icon" aria-hidden="true">
+            <path d="M10 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM3.465 14.493a1.23 1.23 0 0 0 .41 1.412A9.96 9.96 0 0 0 10 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41A7.002 7.002 0 0 0 3.465 14.493Z"/>
+          </svg>
+          {{ $featuredArtistCount }} featured {{ if eq $featuredArtistCount 1 }}artist{{ else }}artists{{ end }}
+        </span>
       {{ end }}
     </div>
 
     {{ with .Summary }}
-      <p class="line-clamp-2 text-sm text-neutral-600 dark:text-neutral-300">{{ . | plainify }}</p>
+      <p class="show-card__summary">{{ . | plainify }}</p>
     {{ end }}
-
-    {{ if $tags }}
-      <div class="mt-0.5 flex flex-wrap items-center gap-1.5">
-        {{ range $visibleTags }}
-          <span class="rounded-full border border-primary-400 px-2.5 py-0.5 text-xs text-primary-700 dark:border-primary-600 dark:text-primary-400">{{ . }}</span>
-        {{ end }}
-        {{ if gt $overflowCount 0 }}
-          <span class="text-xs font-medium text-neutral-500 dark:text-neutral-400">+{{ $overflowCount }}</span>
-        {{ end }}
-      </div>
-    {{ end }}
-  </div>
-
-  <div class="hidden flex-none flex-col items-center justify-center gap-2 border-l border-neutral-200 px-5 dark:border-neutral-700 sm:flex">
-    <a
-      href="{{ $page.RelPermalink }}"
-      aria-label="Go to {{ $showLabel | default .Title }}"
-      class="not-prose flex h-11 w-11 items-center justify-center rounded-full border-2 border-primary-500 text-primary-500 transition hover:bg-primary-50 dark:hover:bg-primary-900/20">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-        class="h-5 w-5 translate-x-0.5" aria-hidden="true">
-        <path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.84Z"/>
-      </svg>
-    </a>
-    <span class="font-mono text-xs text-neutral-500 dark:text-neutral-400">{{ $durationStr }}</span>
   </div>
 </article>


### PR DESCRIPTION
## Summary
- simplify Shows archive cards by removing the action rail and artist/tag pill list
- make show artwork flush with the card edge while preserving proportional cropping
- improve metadata, spacing, hover/focus states, and mobile stacking for the archive card layout

## Verification
- Ran git diff --check; no whitespace errors reported, only existing line-ending warnings for touched files.
- Hugo build not run because hugo is not installed/on PATH in this environment.