### PR TITLE
Simplify show card metadata

### DIFF
--- a/src/layouts/partials/article-link/show-card.html
+++ b/src/layouts/partials/article-link/show-card.html
@@ -140,11 +140,6 @@
     </header>
 
     <div class="show-card__meta">
-      {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
-        <span class="show-card__meta-item">
-          {{ partial "meta/date.html" .Date }}
-        </span>
-      {{ end }}
       {{ if gt $trackCount 0 }}
         <span class="show-card__meta-item">
           {{ $trackCount }} {{ if eq $trackCount 1 }}track{{ else }}tracks{{ end }}


### PR DESCRIPTION
## Summary
- remove the repeated broadcast date from Shows archive card metadata
- keep the metadata row focused on track and featured artist counts
- leave card layout, artwork, links, and surrounding Shows page sections unchanged

## Testing
- git diff --check
- Not run: hugo build (hugo is not available on PATH in this shell)