### PR TITLE
Refresh About page copy

### DIFF
--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -1,7 +1,7 @@
 ---
-title: 'About'
-strapline: 'The story behind Sundown Sessions.'
-description: 'Sundown Sessions is an adventurous music show and archive from Haddington, East Lothian, Scotland, built around discovery, passionate presenters, and songs worth sharing.'
+title: 'About Sundown Sessions'
+strapline: 'An independent home for alternative music after dark.'
+description: 'Sundown Sessions is an independent home for alternative music after dark, featuring curated broadcasts, track listings, artist discovery, releases and Listen Again links.'
 featured_image: 'about-sundown-sessions.png'
 menu:
   main:

--- a/src/layouts/about/single.html
+++ b/src/layouts/about/single.html
@@ -26,59 +26,77 @@
 
     <section class="about-section about-section--intro" aria-labelledby="about-identity-heading">
       <div class="about-section__header">
-        <p class="about-kicker">The station spirit</p>
-        <h2 id="about-identity-heading">A home for songs, stories, and late-night curiosity.</h2>
+        <p class="about-kicker">After dark</p>
+        <h2 id="about-identity-heading">An independent home for alternative music after dark.</h2>
       </div>
       <div class="about-prose">
         <p>
-          Part mixtape, part conversation, and part record shelf with the interesting corners left intact, Sundown Sessions champions music that deserves a little longer in the light.
+          Sundown Sessions is built around discovery: new releases, overlooked artists, forgotten favourites, deep cuts, and records that deserve a little more attention.
         </p>
         <p>
-          The show grew from a love of eclectic radio: alternative cuts, indie discoveries, post-punk edges, overlooked classics, local voices, guest moments, and the joy of hearing something you were not expecting.
+          If you have ever stayed up far too late chasing one more song, one more recommendation, or one more unexpected musical rabbit hole, you will probably feel at home here.
         </p>
       </div>
     </section>
 
-    <section class="about-section" aria-labelledby="about-hear-heading">
+    <section class="about-section" aria-labelledby="about-why-heading">
       <div class="about-section__header">
-        <p class="about-kicker">What you'll hear</p>
-        <h2 id="about-hear-heading">Programming for listeners who like to follow a thread.</h2>
+        <p class="about-kicker">Why Sundown?</p>
+        <h2 id="about-why-heading">The right time to properly listen.</h2>
+      </div>
+      <div class="about-prose">
+        <p>
+          Sundown has always felt like the moment when music has a bit more room to breathe. The day slows down, distractions fade, and a song can draw you further in.
+        </p>
+        <p>
+          That is the mood behind Sundown Sessions: broadcasts and playlists shaped for curious listeners, late-night discoveries, and songs that linger long after they finish.
+        </p>
+      </div>
+    </section>
+
+    <section class="about-section" aria-labelledby="about-find-heading">
+      <div class="about-section__header">
+        <p class="about-kicker">What you will find</p>
+        <h2 id="about-find-heading">Music chosen by hand, not by algorithm.</h2>
       </div>
       <div class="about-feature-grid">
-        <section class="about-feature" aria-labelledby="about-music-heading">
-          <h3 id="about-music-heading">Music Programming</h3>
-          <p>Alternative, indie, post-punk, new discoveries, forgotten classics, specialist selections, and carefully sequenced detours.</p>
+        <section class="about-feature" aria-labelledby="about-broadcasts-heading">
+          <h3 id="about-broadcasts-heading">Curated Broadcasts</h3>
+          <p>Shows built around discovery rather than habit, with new music, older favourites, and the occasional beautiful surprise.</p>
         </section>
-        <section class="about-feature" aria-labelledby="about-talk-heading">
-          <h3 id="about-talk-heading">Talk Programming</h3>
-          <p>Guest conversations, interviews, technical discussions, behind-the-scenes notes, and podcast-style formats as the station grows.</p>
+        <section class="about-feature" aria-labelledby="about-archive-heading">
+          <h3 id="about-archive-heading">Track Listings</h3>
+          <p>Full playlists and Listen Again links for previous broadcasts, so you can find the song that caught your ear.</p>
         </section>
-        <section class="about-feature" aria-labelledby="about-specials-heading">
-          <h3 id="about-specials-heading">Special Programming</h3>
-          <p>Guest sessions, first plays, charity broadcasts, festival coverage, anniversary specials, and milestone shows.</p>
+        <section class="about-feature" aria-labelledby="about-explore-heading">
+          <h3 id="about-explore-heading">Deeper Exploration</h3>
+          <p>Artist and release pages for independent acts, emerging names, overlooked records, forgotten classics, and deep cuts.</p>
         </section>
       </div>
     </section>
 
-    <section class="about-split about-section" aria-labelledby="about-roots-heading">
+    <section class="about-split about-section" aria-labelledby="about-curation-heading">
       <div class="about-section__header">
-        <p class="about-kicker">Our roots</p>
-        <h2 id="about-roots-heading">Based in Haddington, East Lothian.</h2>
+        <p class="about-kicker">Curation</p>
+        <h2 id="about-curation-heading">How the music is chosen.</h2>
       </div>
       <div class="about-prose">
         <p>
-          Sundown Sessions comes from Scotland's east coast, shaped by community radio values and the simple belief that good music deserves careful attention.
+          Music comes from everywhere: labels, promoters, artists, listeners, Bandcamp, record shops, live shows, old favourites, new obsessions, and the occasional happy accident.
         </p>
         <p>
-          What began as a broadcast has become an archive of shows, playlists, featured artists, releases, notes, and musical paths worth revisiting.
+          Some songs arrive with a press release. Some are found by following a thread from one artist to another. Some simply refuse to leave the room.
+        </p>
+        <p>
+          That is the heart of Sundown Sessions: human curation, proper listening, and the belief that discovery should still feel exciting.
         </p>
       </div>
     </section>
 
     <section class="about-section" aria-labelledby="about-people-heading">
       <div class="about-section__header">
-        <p class="about-kicker">Behind the microphone</p>
-        <h2 id="about-people-heading">Presented with genuine musical obsession.</h2>
+        <p class="about-kicker">Meet Colin</p>
+        <h2 id="about-people-heading">Curated and hosted by Colin Gourlay.</h2>
       </div>
       <div class="about-presenter">
         {{ with $image }}
@@ -92,55 +110,62 @@
           <h3>Colin Gourlay</h3>
           <p class="about-presenter__role">Presenter and curator, Sundown Sessions</p>
           <p>
-            Colin brings together adventurous playlists, guest features, local connections, and the kind of music conversation that rewards close listening.
+            What started as a radio show has grown into a wider music discovery project: a place for memorable broadcasts, full track listings, artist features, release pages, and carefully chosen recommendations.
+          </p>
+          <p>
+            The aim is simple: to share music with the care, curiosity, and enthusiasm it deserves.
           </p>
           <div class="about-actions">
-            <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Meet the shows</a>
+            <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
             <a class="about-button about-button--text" href="{{ "/contact/" | relURL }}">Contact Sundown Sessions</a>
           </div>
         </div>
       </div>
     </section>
 
-    <section class="about-section" aria-labelledby="about-purpose-heading">
+    <section class="about-section" aria-labelledby="about-listen-heading">
       <div class="about-section__header">
-        <p class="about-kicker">Purpose</p>
-        <h2 id="about-purpose-heading">Why Sundown Sessions exists.</h2>
+        <p class="about-kicker">Sundown Radio</p>
+        <h2 id="about-listen-heading">Listen live, listen again, or explore the archive.</h2>
       </div>
       <div class="about-statement-grid">
-        <section class="about-statement" aria-labelledby="about-mission-heading">
-          <h3 id="about-mission-heading">Our Mission</h3>
-          <p>To champion great music, celebrate passionate voices, and create a welcoming home for listeners who believe discovery is one of life's great pleasures.</p>
+        <section class="about-statement" aria-labelledby="about-live-heading">
+          <h3 id="about-live-heading">Listen Live</h3>
+          <p>Sundown Sessions now has a home on Sundown Radio, with live broadcasts made for careful, curious listening.</p>
         </section>
-        <section class="about-statement" aria-labelledby="about-vision-heading">
-          <h3 id="about-vision-heading">Our Vision</h3>
-          <p>To become a trusted destination for adventurous listeners, connecting communities through exceptional programming, authentic personality, and a shared love of music.</p>
+        <section class="about-statement" aria-labelledby="about-archive-route-heading">
+          <h3 id="about-archive-route-heading">Explore More</h3>
+          <p>Use the site as a growing archive of shows, artists, releases, track listings, and routes into the music.</p>
         </section>
+      </div>
+      <div class="about-actions">
+        <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
+        <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
+        <a class="about-button about-button--text" href="{{ "/contact/" | relURL }}">Send Music</a>
       </div>
     </section>
 
-    <section class="about-section" aria-labelledby="about-values-heading">
+    <section class="about-section" aria-labelledby="about-explore-links-heading">
       <div class="about-section__header">
-        <p class="about-kicker">Values</p>
-        <h2 id="about-values-heading">The notes we keep returning to.</h2>
+        <p class="about-kicker">Start exploring</p>
+        <h2 id="about-explore-links-heading">Follow the music wherever it leads.</h2>
       </div>
-      <ul class="about-values" aria-label="Sundown Sessions values">
-        <li><strong>Discovery</strong><span>Finding music worth sharing.</span></li>
-        <li><strong>Authenticity</strong><span>Real people with genuine passion.</span></li>
-        <li><strong>Community</strong><span>Building meaningful connections.</span></li>
-        <li><strong>Curiosity</strong><span>Following the unexpected path.</span></li>
-        <li><strong>Inclusivity</strong><span>Welcoming anyone who wants to listen.</span></li>
+      <ul class="about-values" aria-label="Ways to explore Sundown Sessions">
+        <li><strong>Shows</strong><span><a href="{{ "/shows/" | relURL }}">Browse previous broadcasts</a>.</span></li>
+        <li><strong>Artists</strong><span><a href="{{ "/artists/" | relURL }}">Discover featured artists</a>.</span></li>
+        <li><strong>Releases</strong><span><a href="{{ "/releases/" | relURL }}">Explore albums, EPs and singles</a>.</span></li>
+        <li><strong>Listen</strong><span><a href="{{ "/listen-live/" | relURL }}">Tune in to Sundown Radio</a>.</span></li>
       </ul>
     </section>
 
     <section class="about-cta" aria-labelledby="about-involved-heading">
-      <p class="about-kicker">Get involved</p>
-      <h2 id="about-involved-heading">Become part of the story.</h2>
-      <p>Listen live, explore the archive, send a note, or follow Sundown Sessions wherever you like to keep up with new music.</p>
+      <p class="about-kicker">Get in touch</p>
+      <h2 id="about-involved-heading">Have a recommendation?</h2>
+      <p>Released something that feels right for the show? Want to point me towards an artist I should hear? I would love to hear from you.</p>
       <div class="about-actions about-actions--center">
         <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
         <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
-        <a class="about-button about-button--secondary" href="{{ "/contact/" | relURL }}">Contact Us</a>
+        <a class="about-button about-button--secondary" href="{{ "/contact/" | relURL }}">Contact</a>
       </div>
       {{ if $sameAs }}
         <nav class="about-socials" aria-label="Sundown Sessions social links">


### PR DESCRIPTION
## Summary
- Reposition the About page around Sundown Sessions as an independent alternative music discovery platform
- Add warmer listener-focused sections for the after-dark identity, curation, Sundown Radio, archive exploration and contact
- Update About page title, strapline and SEO description

## Verification
- git diff --check -- src/content/about/index.md src/layouts/about/single.html
- Hugo build not run locally because hugo is not installed or available on PATH in this shell