### PR TITLE
Refine About page content

### DIFF
--- a/docs/about-page-content-review.md
+++ b/docs/about-page-content-review.md
@@ -1,0 +1,43 @@
+# About Page Content Review
+
+Issue: #574
+
+## Summary
+
+The About page already had a strong editorial shape, but the opening copy relied too heavily on mood before clearly explaining what Sundown Sessions is. The page also had opportunities to make human curation, listening routes, and archive exploration more explicit.
+
+## Priority Actions Completed
+
+1. Clarified the opening proposition so visitors immediately understand Sundown Sessions as an independent alternative music discovery project built around curated broadcasts, playlists, artist stories, and records worth spending time with.
+2. Added early onward journeys to Shows, Listen Live, and Artists so the About page is not a dead end after the introduction.
+3. Strengthened the human-curation message by directly contrasting Sundown Sessions with algorithmic feeds and generic playlists in natural editorial language.
+4. Expanded the listening section to include Listen Live, Listen Again, Mixcloud, and archive exploration.
+5. Updated the SEO description and strapline to better reflect broadcasts, playlists, artist discovery, and Listen Again routes.
+6. Improved internal linking coverage by adding clear routes to Shows, Artists, Releases, Tracks, Listen Live, Contact, and Mixcloud.
+
+## Content Findings
+
+- Page title remains clear and recognisable: "About Sundown Sessions".
+- The revised strapline is more descriptive and discovery-led while preserving the after-dark identity.
+- The introduction now answers what the site is before moving into mood and story.
+- The personal section keeps Colin Gourlay visible as presenter and curator, which supports trust and authenticity.
+- The broadcast and archive copy now better reflects the wider current site direction: shows, track listings, artist pages, release pages, and listening routes.
+- Calls to action are distributed through the page, with the strongest routes appearing near the introduction and again near the listening and contact sections.
+
+## UX Findings
+
+- The section order works well: identity, purpose, content types, curation, presenter, listening routes, exploration, contact.
+- The page can be scanned through section headings without requiring every paragraph to be read.
+- Adding an early action row improves mobile and desktop journeys for visitors who understand the proposition quickly.
+- The Listen section now has three balanced cards at desktop width, matching the updated content hierarchy.
+
+## SEO Findings
+
+- The meta description now uses natural language around alternative music discovery, curated broadcasts, playlists, featured artists, releases, and Listen Again links.
+- Heading structure remains logical, with one page hero heading followed by descriptive section headings.
+- Internal links support discoverability without keyword stuffing.
+
+## Optional Follow-Ups
+
+1. Consider adding Mixcloud to `params.author.links` if it should appear alongside the other social links generated from site params.
+2. If the About image has a meaningful story, add a visible caption in the layout; if it is primarily presentational/contextual, the current alt text is sufficient.

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -2999,4 +2999,8 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   .about-feature-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+
+  .about-statement-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }

--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'About Sundown Sessions'
-strapline: 'An independent home for alternative music after dark.'
-description: 'Sundown Sessions is an independent home for alternative music after dark, featuring curated broadcasts, track listings, artist discovery, releases and Listen Again links.'
+strapline: 'Curated alternative music broadcasts, playlists and artist discovery after dark.'
+description: 'Sundown Sessions is an independent alternative music discovery project, sharing curated broadcasts, playlists, featured artists, releases and Listen Again links.'
 featured_image: 'about-sundown-sessions.png'
 menu:
   main:

--- a/src/layouts/about/single.html
+++ b/src/layouts/about/single.html
@@ -27,15 +27,20 @@
     <section class="about-section about-section--intro" aria-labelledby="about-identity-heading">
       <div class="about-section__header">
         <p class="about-kicker">After dark</p>
-        <h2 id="about-identity-heading">An independent home for alternative music after dark.</h2>
+        <h2 id="about-identity-heading">A human route through alternative music.</h2>
       </div>
       <div class="about-prose">
         <p>
-          Sundown Sessions is built around discovery: new releases, overlooked artists, forgotten favourites, deep cuts, and records that deserve a little more attention.
+          Sundown Sessions is an independent music discovery project built around curated broadcasts, playlists, artist stories, and records worth spending time with.
         </p>
         <p>
-          If you have ever stayed up far too late chasing one more song, one more recommendation, or one more unexpected musical rabbit hole, you will probably feel at home here.
+          The focus is alternative music in the broadest, most curious sense: emerging artists, established names, overlooked records, deep cuts, and the songs that make you follow a thread further than you meant to.
         </p>
+        <div class="about-actions">
+          <a class="about-button about-button--primary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
+          <a class="about-button about-button--secondary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
+          <a class="about-button about-button--text" href="{{ "/artists/" | relURL }}">Discover Artists</a>
+        </div>
       </div>
     </section>
 
@@ -46,10 +51,10 @@
       </div>
       <div class="about-prose">
         <p>
-          Sundown has always felt like the moment when music has a bit more room to breathe. The day slows down, distractions fade, and a song can draw you further in.
+          Sundown has always felt like the moment when music gets more room to breathe. The day slows down, the noise drops away, and a song can pull you somewhere unexpected.
         </p>
         <p>
-          That is the mood behind Sundown Sessions: broadcasts and playlists shaped for curious listeners, late-night discoveries, and songs that linger long after they finish.
+          That is the mood behind the broadcasts: music chosen for curious listeners, late-night discoveries, and the kind of tracks that stay with you after they finish.
         </p>
       </div>
     </section>
@@ -62,7 +67,7 @@
       <div class="about-feature-grid">
         <section class="about-feature" aria-labelledby="about-broadcasts-heading">
           <h3 id="about-broadcasts-heading">Curated Broadcasts</h3>
-          <p>Shows built around discovery rather than habit, with new music, older favourites, and the occasional beautiful surprise.</p>
+          <p>Shows built around discovery rather than habit, with new music, older favourites, interviews, exclusive tracks, and the occasional beautiful surprise.</p>
         </section>
         <section class="about-feature" aria-labelledby="about-archive-heading">
           <h3 id="about-archive-heading">Track Listings</h3>
@@ -70,7 +75,7 @@
         </section>
         <section class="about-feature" aria-labelledby="about-explore-heading">
           <h3 id="about-explore-heading">Deeper Exploration</h3>
-          <p>Artist and release pages for independent acts, emerging names, overlooked records, forgotten classics, and deep cuts.</p>
+          <p>Artist and release pages that connect broadcasts to independent acts, emerging names, overlooked records, forgotten classics, and deep cuts.</p>
         </section>
       </div>
     </section>
@@ -82,13 +87,13 @@
       </div>
       <div class="about-prose">
         <p>
-          Music comes from everywhere: labels, promoters, artists, listeners, Bandcamp, record shops, live shows, old favourites, new obsessions, and the occasional happy accident.
+          Music comes from everywhere: artists, labels, promoters, listeners, Bandcamp, record shops, live shows, old favourites, new obsessions, and the occasional happy accident.
         </p>
         <p>
           Some songs arrive with a press release. Some are found by following a thread from one artist to another. Some simply refuse to leave the room.
         </p>
         <p>
-          That is the heart of Sundown Sessions: human curation, proper listening, and the belief that discovery should still feel exciting.
+          That is where Sundown Sessions differs from an algorithmic feed or a generic playlist. It is one person listening closely, joining the dots, and sharing the music that feels worth passing on.
         </p>
       </div>
     </section>
@@ -110,10 +115,10 @@
           <h3>Colin Gourlay</h3>
           <p class="about-presenter__role">Presenter and curator, Sundown Sessions</p>
           <p>
-            What started as a radio show has grown into a wider music discovery project: a place for memorable broadcasts, full track listings, artist features, release pages, and carefully chosen recommendations.
+            What started as a radio show has grown into a wider archive for memorable broadcasts, full track listings, artist features, release pages, and carefully chosen recommendations.
           </p>
           <p>
-            The aim is simple: to share music with the care, curiosity, and enthusiasm it deserves.
+            The aim is simple: to share music with care, curiosity, and the enthusiasm of someone who still believes the next great discovery might be one song away.
           </p>
           <div class="about-actions">
             <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
@@ -131,16 +136,21 @@
       <div class="about-statement-grid">
         <section class="about-statement" aria-labelledby="about-live-heading">
           <h3 id="about-live-heading">Listen Live</h3>
-          <p>Sundown Sessions now has a home on Sundown Radio, with live broadcasts made for careful, curious listening.</p>
+          <p>Tune in on Sundown Radio for live broadcasts made for careful, curious listening.</p>
+        </section>
+        <section class="about-statement" aria-labelledby="about-listen-again-heading">
+          <h3 id="about-listen-again-heading">Listen Again</h3>
+          <p>Catch previous shows through the archive and Mixcloud when you want the full broadcast experience.</p>
         </section>
         <section class="about-statement" aria-labelledby="about-archive-route-heading">
-          <h3 id="about-archive-route-heading">Explore More</h3>
-          <p>Use the site as a growing archive of shows, artists, releases, track listings, and routes into the music.</p>
+          <h3 id="about-archive-route-heading">Explore the Archive</h3>
+          <p>Use the site as a growing map of shows, artists, releases, track listings, and routes into the music.</p>
         </section>
       </div>
       <div class="about-actions">
         <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
         <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
+        <a class="about-button about-button--secondary" href="https://www.mixcloud.com/sundownsessions/" rel="noopener" target="_blank">Mixcloud</a>
         <a class="about-button about-button--text" href="{{ "/contact/" | relURL }}">Send Music</a>
       </div>
     </section>
@@ -154,14 +164,14 @@
         <li><strong>Shows</strong><span><a href="{{ "/shows/" | relURL }}">Browse previous broadcasts</a>.</span></li>
         <li><strong>Artists</strong><span><a href="{{ "/artists/" | relURL }}">Discover featured artists</a>.</span></li>
         <li><strong>Releases</strong><span><a href="{{ "/releases/" | relURL }}">Explore albums, EPs and singles</a>.</span></li>
-        <li><strong>Listen</strong><span><a href="{{ "/listen-live/" | relURL }}">Tune in to Sundown Radio</a>.</span></li>
+        <li><strong>Tracks</strong><span><a href="{{ "/tracks/" | relURL }}">Find songs from the playlists</a>.</span></li>
       </ul>
     </section>
 
     <section class="about-cta" aria-labelledby="about-involved-heading">
       <p class="about-kicker">Get in touch</p>
       <h2 id="about-involved-heading">Have a recommendation?</h2>
-      <p>Released something that feels right for the show? Want to point me towards an artist I should hear? I would love to hear from you.</p>
+      <p>Released something that feels right for the show? Found an artist I should hear? Want to ask about a broadcast, playlist, or feature? I would love to hear from you.</p>
       <div class="about-actions about-actions--center">
         <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
         <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>


### PR DESCRIPTION
## Summary
- Clarifies the About page positioning around independent alternative music discovery
- Strengthens human-curation messaging and adds clearer routes into Shows, Listen Live, Artists, Tracks, Contact, and Mixcloud
- Documents the content, UX, internal linking, and SEO review findings for issue #574

## Testing
- `git diff --check`
- Not run: full Hugo build, because `hugo` is not available on PATH in this shell

Closes #574