### PR TITLE
Revise About page editorial tone

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -2561,28 +2561,18 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   }
 }
 
-/* About page: editorial introduction for the Sundown Sessions story. */
+/* About page: quiet editorial introduction for the Sundown Sessions story. */
 
 .about-page {
   display: flex;
   flex-direction: column;
-  gap: 4rem;
+  gap: clamp(3.25rem, 7vw, 5.5rem);
+  max-width: 66rem;
   margin-bottom: 5rem;
 }
 
-.about-hero {
-  display: grid;
-  gap: 2rem;
-  align-items: center;
-  margin-top: 1.5rem;
-}
-
-.about-hero__copy {
-  min-width: 0;
-}
-
 .about-kicker {
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.7rem;
   color: rgba(var(--color-primary-600), 1);
   font-size: 0.78rem;
   font-weight: 800;
@@ -2594,58 +2584,78 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: rgba(var(--color-primary-400), 1);
 }
 
-.about-hero h1,
-.about-section h2,
-.about-cta h2 {
-  margin: 0;
-  color: #171717; /* neutral-900 */
-  font-weight: 850;
-  letter-spacing: 0;
+.about-section {
+  max-width: 50rem;
 }
 
-.dark .about-hero h1,
-.dark .about-section h2,
-.dark .about-cta h2 {
+.about-section--opening {
+  max-width: 54rem;
+  padding-top: clamp(0.25rem, 1vw, 0.75rem);
+}
+
+.about-section--closing {
+  padding-top: clamp(0.25rem, 1vw, 0.75rem);
+  border-top: 1px solid #e5e5e5; /* neutral-200 */
+}
+
+.dark .about-section--closing {
+  border-top-color: #404040; /* neutral-700 */
+}
+
+.about-section h2 {
+  max-width: 18ch;
+  margin: 0 0 1rem;
+  color: #171717; /* neutral-900 */
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  font-weight: 850;
+  letter-spacing: 0;
+  line-height: 1.12;
+}
+
+.dark .about-section h2 {
   color: #f5f5f5; /* neutral-100 */
 }
 
-.about-hero h1 {
-  max-width: 12ch;
-  font-size: 2.5rem;
-  line-height: 0.95;
-}
-
-.about-hero__lede {
-  max-width: 42rem;
-  margin: 1.35rem 0 0;
+.about-prose {
+  max-width: 48rem;
   color: #404040; /* neutral-700 */
-  font-size: 1.12rem;
-  line-height: 1.75;
+  font-size: 1.05rem;
+  line-height: 1.8;
 }
 
-.dark .about-hero__lede {
+.about-prose--lead {
+  color: #262626; /* neutral-800 */
+  font-size: clamp(1.16rem, 2vw, 1.35rem);
+  line-height: 1.72;
+}
+
+.dark .about-prose {
   color: #d4d4d4; /* neutral-300 */
 }
 
-.about-hero__media {
+.dark .about-prose--lead {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.about-prose p,
+.about-presenter p {
   margin: 0;
-  overflow: hidden;
-  border-radius: 0.5rem;
-  border: 1px solid #e5e5e5; /* neutral-200 */
-  background: #f5f5f5; /* neutral-100 */
-  box-shadow: 0 18px 50px rgb(0 0 0 / 0.16);
 }
 
-.dark .about-hero__media {
-  border-color: #404040; /* neutral-700 */
-  background: #171717; /* neutral-900 */
+.about-prose p + p,
+.about-presenter p + p {
+  margin-top: 1rem;
 }
 
-.about-hero__media img {
-  display: block;
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  object-fit: cover;
+.about-discovery-list {
+  display: grid;
+  gap: 0.55rem 2rem;
+  margin: 0.9rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.about-discovery-list li {
+  padding-left: 0.15rem;
 }
 
 .about-actions {
@@ -2653,10 +2663,6 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   flex-wrap: wrap;
   gap: 0.75rem;
   margin-top: 1.5rem;
-}
-
-.about-actions--center {
-  justify-content: center;
 }
 
 .about-button {
@@ -2673,8 +2679,7 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.about-button:focus-visible,
-.about-socials a:focus-visible {
+.about-button:focus-visible {
   outline: 3px solid rgba(var(--color-primary-500), 0.6);
   outline-offset: 3px;
 }
@@ -2723,131 +2728,21 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: #ffffff;
 }
 
-.about-button--text {
-  color: #404040; /* neutral-700 */
-  padding-inline: 0.25rem;
-}
-
-.about-button--text:hover {
-  color: rgba(var(--color-primary-700), 1);
-  text-decoration: underline;
-  text-underline-offset: 0.16rem;
-}
-
-.dark .about-button--text {
-  color: #d4d4d4; /* neutral-300 */
-}
-
-.dark .about-button--text:hover {
-  color: rgba(var(--color-primary-300), 1);
-}
-
-.about-section {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.about-section--intro {
-  padding-top: 0.5rem;
-}
-
-.about-section__header {
-  max-width: 44rem;
-}
-
-.about-section h2,
-.about-cta h2 {
-  max-width: 16ch;
-  font-size: 1.9rem;
-  line-height: 1.05;
-}
-
-.about-prose {
-  max-width: 46rem;
-  color: #404040; /* neutral-700 */
-  font-size: 1.05rem;
-  line-height: 1.8;
-}
-
-.about-prose p {
-  margin: 0;
-}
-
-.about-prose p + p {
-  margin-top: 1rem;
-}
-
-.dark .about-prose {
-  color: #d4d4d4; /* neutral-300 */
-}
-
-.about-feature-grid,
-.about-statement-grid,
-.about-values {
-  display: grid;
-  gap: 1rem;
-}
-
-.about-feature,
-.about-statement,
-.about-values li,
-.about-presenter {
-  border: 1px solid #e5e5e5; /* neutral-200 */
-  border-radius: 0.5rem;
-  background: rgb(255 255 255 / 0.74);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
-}
-
-.dark .about-feature,
-.dark .about-statement,
-.dark .about-values li,
-.dark .about-presenter {
-  border-color: #404040; /* neutral-700 */
-  background: rgb(23 23 23 / 0.72);
-}
-
-.about-feature,
-.about-statement {
-  padding: 1.35rem;
-}
-
-.about-feature h3,
-.about-statement h3,
-.about-presenter h3 {
-  margin: 0 0 0.65rem;
-  color: #171717; /* neutral-900 */
-  font-size: 1.1rem;
-  font-weight: 800;
-  line-height: 1.3;
-}
-
-.dark .about-feature h3,
-.dark .about-statement h3,
-.dark .about-presenter h3 {
-  color: #f5f5f5; /* neutral-100 */
-}
-
-.about-feature p,
-.about-statement p,
-.about-presenter p,
-.about-cta p {
-  margin: 0;
-  color: #525252; /* neutral-600 */
-  line-height: 1.7;
-}
-
-.dark .about-feature p,
-.dark .about-statement p,
-.dark .about-presenter p,
-.dark .about-cta p {
-  color: #d4d4d4; /* neutral-300 */
-}
-
 .about-presenter {
   display: grid;
   gap: 1.25rem;
+  max-width: 54rem;
   align-items: center;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.5rem;
+  background: rgb(255 255 255 / 0.74);
   padding: 1rem;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+}
+
+.dark .about-presenter {
+  border-color: #404040; /* neutral-700 */
+  background: rgb(23 23 23 / 0.72);
 }
 
 .about-presenter img {
@@ -2858,149 +2753,22 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   object-fit: cover;
 }
 
-.about-presenter__role {
-  margin-bottom: 0.8rem;
-  font-size: 0.9rem;
-  font-weight: 750;
-}
-
-.about-values {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.about-values li {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 1.1rem;
-}
-
-.about-values strong {
-  color: #171717; /* neutral-900 */
-  font-size: 1rem;
-}
-
-.about-values span {
+.about-presenter p {
   color: #525252; /* neutral-600 */
-  line-height: 1.55;
+  line-height: 1.7;
 }
 
-.dark .about-values strong {
-  color: #f5f5f5; /* neutral-100 */
-}
-
-.dark .about-values span {
+.dark .about-presenter p {
   color: #d4d4d4; /* neutral-300 */
-}
-
-.about-cta {
-  border-radius: 0.5rem;
-  border: 1px solid #d4d4d4; /* neutral-300 */
-  background: linear-gradient(135deg, #ffffff, #f5f5f5);
-  padding: clamp(1.5rem, 4vw, 3rem);
-  text-align: center;
-}
-
-.dark .about-cta {
-  border-color: #404040; /* neutral-700 */
-  background: linear-gradient(135deg, #171717, #262626);
-}
-
-.about-cta h2,
-.about-cta p {
-  margin-right: auto;
-  margin-left: auto;
-}
-
-.about-cta p {
-  max-width: 42rem;
-  margin-top: 1rem;
-}
-
-.about-socials {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.5rem 1rem;
-  margin-top: 1.5rem;
-}
-
-.about-socials a {
-  color: #525252; /* neutral-600 */
-  font-size: 0.9rem;
-  font-weight: 750;
-  text-decoration: none;
-}
-
-.about-socials a:hover {
-  color: rgba(var(--color-primary-700), 1);
-  text-decoration: underline;
-  text-underline-offset: 0.16rem;
-}
-
-.dark .about-socials a {
-  color: #d4d4d4; /* neutral-300 */
-}
-
-.dark .about-socials a:hover {
-  color: rgba(var(--color-primary-300), 1);
 }
 
 @media (min-width: 700px) {
-  .about-hero h1 {
-    font-size: 4rem;
-  }
-
-  .about-section h2,
-  .about-cta h2 {
-    font-size: 2.55rem;
-  }
-
-  .about-feature-grid,
-  .about-statement-grid,
-  .about-values {
+  .about-discovery-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .about-presenter {
     grid-template-columns: minmax(12rem, 0.75fr) minmax(0, 1.25fr);
     padding: 1.25rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  .about-page {
-    gap: 5rem;
-  }
-
-  .about-hero h1 {
-    font-size: 5.25rem;
-  }
-
-  .about-section h2,
-  .about-cta h2 {
-    font-size: 3.2rem;
-  }
-
-  .about-hero {
-    grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.82fr);
-    gap: 3rem;
-  }
-
-  .about-section,
-  .about-split {
-    grid-template-columns: minmax(18rem, 0.78fr) minmax(0, 1fr);
-    align-items: start;
-    gap: 3rem;
-  }
-
-  .about-feature-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .about-statement-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'About Sundown Sessions'
-strapline: 'Curated alternative music broadcasts, playlists and artist discovery after dark.'
-description: 'Sundown Sessions is an independent alternative music discovery project, sharing curated broadcasts, playlists, featured artists, releases and Listen Again links.'
+strapline: 'Alternative music after dark, curated by hand.'
+description: 'Sundown Sessions is an independent home for alternative music after dark, featuring curated broadcasts, track listings, artist discovery, releases and Listen Again links.'
 featured_image: 'about-sundown-sessions.png'
 menu:
   main:

--- a/src/layouts/about/single.html
+++ b/src/layouts/about/single.html
@@ -24,85 +24,65 @@
   <article class="about-page">
     {{ partial "section-hero.html" . }}
 
-    <section class="about-section about-section--intro" aria-labelledby="about-identity-heading">
-      <div class="about-section__header">
-        <p class="about-kicker">After dark</p>
-        <h2 id="about-identity-heading">A human route through alternative music.</h2>
-      </div>
-      <div class="about-prose">
-        <p>
-          Sundown Sessions is an independent music discovery project built around curated broadcasts, playlists, artist stories, and records worth spending time with.
-        </p>
-        <p>
-          The focus is alternative music in the broadest, most curious sense: emerging artists, established names, overlooked records, deep cuts, and the songs that make you follow a thread further than you meant to.
-        </p>
-        <div class="about-actions">
-          <a class="about-button about-button--primary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
-          <a class="about-button about-button--secondary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
-          <a class="about-button about-button--text" href="{{ "/artists/" | relURL }}">Discover Artists</a>
-        </div>
+    <section class="about-section about-section--opening" aria-labelledby="about-opening-heading">
+      <h2 id="about-opening-heading" class="sr-only">An editorial introduction to Sundown Sessions</h2>
+      <div class="about-prose about-prose--lead">
+        <p>Some of the best music I have ever heard was not handed to me by an algorithm.</p>
+        <p>It came from recommendations, tiny venues, independent labels, late-night rabbit holes, old favourites, new obsessions, and records someone quietly insisted I should hear.</p>
+        <p>Sundown Sessions grew from that same belief: that discovering music should still feel personal, surprising and worth staying up for.</p>
       </div>
     </section>
 
-    <section class="about-section" aria-labelledby="about-why-heading">
-      <div class="about-section__header">
-        <p class="about-kicker">Why Sundown?</p>
-        <h2 id="about-why-heading">The right time to properly listen.</h2>
-      </div>
+    <section class="about-section" aria-labelledby="about-what-heading">
+      <p class="about-kicker">What Sundown Sessions is</p>
+      <h2 id="about-what-heading">An independent home for alternative music after dark.</h2>
       <div class="about-prose">
-        <p>
-          Sundown has always felt like the moment when music gets more room to breathe. The day slows down, the noise drops away, and a song can pull you somewhere unexpected.
-        </p>
-        <p>
-          That is the mood behind the broadcasts: music chosen for curious listeners, late-night discoveries, and the kind of tracks that stay with you after they finish.
-        </p>
+        <p>Sundown Sessions is an independent home for alternative music after dark.</p>
+        <p>Each broadcast brings together new releases, overlooked artists, forgotten classics, deep cuts and songs that deserve a little more attention.</p>
+        <p>It is part radio show, part archive, part listening notebook - a place to hear the broadcasts, follow the track listings, explore featured artists and discover records that might otherwise pass you by.</p>
       </div>
     </section>
 
-    <section class="about-section" aria-labelledby="about-find-heading">
-      <div class="about-section__header">
-        <p class="about-kicker">What you will find</p>
-        <h2 id="about-find-heading">Music chosen by hand, not by algorithm.</h2>
-      </div>
-      <div class="about-feature-grid">
-        <section class="about-feature" aria-labelledby="about-broadcasts-heading">
-          <h3 id="about-broadcasts-heading">Curated Broadcasts</h3>
-          <p>Shows built around discovery rather than habit, with new music, older favourites, interviews, exclusive tracks, and the occasional beautiful surprise.</p>
-        </section>
-        <section class="about-feature" aria-labelledby="about-archive-heading">
-          <h3 id="about-archive-heading">Track Listings</h3>
-          <p>Full playlists and Listen Again links for previous broadcasts, so you can find the song that caught your ear.</p>
-        </section>
-        <section class="about-feature" aria-labelledby="about-explore-heading">
-          <h3 id="about-explore-heading">Deeper Exploration</h3>
-          <p>Artist and release pages that connect broadcasts to independent acts, emerging names, overlooked records, forgotten classics, and deep cuts.</p>
-        </section>
+    <section class="about-section" aria-labelledby="about-dark-heading">
+      <p class="about-kicker">Why after dark?</p>
+      <h2 id="about-dark-heading">The right time to properly listen.</h2>
+      <div class="about-prose">
+        <p>Sundown has always felt like the right time to properly listen.</p>
+        <p>The day slows down, distractions fade, and music has more room to breathe. That is the mood behind the show: curious, unhurried, atmospheric and open to the unexpected.</p>
       </div>
     </section>
 
-    <section class="about-split about-section" aria-labelledby="about-curation-heading">
-      <div class="about-section__header">
-        <p class="about-kicker">Curation</p>
-        <h2 id="about-curation-heading">How the music is chosen.</h2>
-      </div>
+    <section class="about-section" aria-labelledby="about-discover-heading">
+      <p class="about-kicker">What you will discover</p>
+      <h2 id="about-discover-heading">Music chosen by hand, not by algorithm.</h2>
       <div class="about-prose">
-        <p>
-          Music comes from everywhere: artists, labels, promoters, listeners, Bandcamp, record shops, live shows, old favourites, new obsessions, and the occasional happy accident.
-        </p>
-        <p>
-          Some songs arrive with a press release. Some are found by following a thread from one artist to another. Some simply refuse to leave the room.
-        </p>
-        <p>
-          That is where Sundown Sessions differs from an algorithmic feed or a generic playlist. It is one person listening closely, joining the dots, and sharing the music that feels worth passing on.
-        </p>
+        <p>You will find:</p>
+        <ul class="about-discovery-list">
+          <li>Carefully curated broadcasts</li>
+          <li>Complete track listings</li>
+          <li>Independent and emerging artists</li>
+          <li>New releases and overlooked records</li>
+          <li>Forgotten favourites and deep cuts</li>
+          <li>Artist and release pages for deeper exploration</li>
+          <li>Listen Again links for previous shows</li>
+          <li>Music chosen by hand, not by algorithm</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="about-section" aria-labelledby="about-curation-heading">
+      <p class="about-kicker">How the music is chosen</p>
+      <h2 id="about-curation-heading">Proper listening, followed by a thread.</h2>
+      <div class="about-prose">
+        <p>Music comes from everywhere: labels, promoters, artists, listeners, Bandcamp, record shops, live shows, old favourites, new obsessions and the occasional happy accident.</p>
+        <p>Some tracks arrive with a press release. Some are found by following a thread from one artist to another. Some simply refuse to leave the room.</p>
+        <p>That is the heart of Sundown Sessions: human curation, proper listening and the belief that discovery should still feel exciting.</p>
       </div>
     </section>
 
     <section class="about-section" aria-labelledby="about-people-heading">
-      <div class="about-section__header">
-        <p class="about-kicker">Meet Colin</p>
-        <h2 id="about-people-heading">Curated and hosted by Colin Gourlay.</h2>
-      </div>
+      <p class="about-kicker">Meet Colin</p>
+      <h2 id="about-people-heading">Curated and hosted by Colin Gourlay.</h2>
       <div class="about-presenter">
         {{ with $image }}
           <img
@@ -112,80 +92,24 @@
             decoding="async">
         {{ end }}
         <div>
-          <h3>Colin Gourlay</h3>
-          <p class="about-presenter__role">Presenter and curator, Sundown Sessions</p>
-          <p>
-            What started as a radio show has grown into a wider archive for memorable broadcasts, full track listings, artist features, release pages, and carefully chosen recommendations.
-          </p>
-          <p>
-            The aim is simple: to share music with care, curiosity, and the enthusiasm of someone who still believes the next great discovery might be one song away.
-          </p>
-          <div class="about-actions">
-            <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
-            <a class="about-button about-button--text" href="{{ "/contact/" | relURL }}">Contact Sundown Sessions</a>
-          </div>
+          <p>Sundown Sessions is curated and hosted by Colin Gourlay.</p>
+          <p>What started as a radio show has grown into a wider music discovery project, bringing together broadcasts, track listings, artist features, release pages and carefully chosen recommendations.</p>
+          <p>The aim is simple: to share music with care, curiosity and enthusiasm.</p>
         </div>
       </div>
     </section>
 
-    <section class="about-section" aria-labelledby="about-listen-heading">
-      <div class="about-section__header">
-        <p class="about-kicker">Sundown Radio</p>
-        <h2 id="about-listen-heading">Listen live, listen again, or explore the archive.</h2>
-      </div>
-      <div class="about-statement-grid">
-        <section class="about-statement" aria-labelledby="about-live-heading">
-          <h3 id="about-live-heading">Listen Live</h3>
-          <p>Tune in on Sundown Radio for live broadcasts made for careful, curious listening.</p>
-        </section>
-        <section class="about-statement" aria-labelledby="about-listen-again-heading">
-          <h3 id="about-listen-again-heading">Listen Again</h3>
-          <p>Catch previous shows through the archive and Mixcloud when you want the full broadcast experience.</p>
-        </section>
-        <section class="about-statement" aria-labelledby="about-archive-route-heading">
-          <h3 id="about-archive-route-heading">Explore the Archive</h3>
-          <p>Use the site as a growing map of shows, artists, releases, track listings, and routes into the music.</p>
-        </section>
+    <section class="about-section about-section--closing" aria-labelledby="about-listen-heading">
+      <p class="about-kicker">Listen and explore</p>
+      <h2 id="about-listen-heading">Start with the music.</h2>
+      <div class="about-prose">
+        <p>You can listen live on Sundown Radio, explore previous broadcasts, or use the site as a growing archive of artists, releases and track listings.</p>
       </div>
       <div class="about-actions">
         <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
         <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
-        <a class="about-button about-button--secondary" href="https://www.mixcloud.com/sundownsessions/" rel="noopener" target="_blank">Mixcloud</a>
-        <a class="about-button about-button--text" href="{{ "/contact/" | relURL }}">Send Music</a>
-      </div>
-    </section>
-
-    <section class="about-section" aria-labelledby="about-explore-links-heading">
-      <div class="about-section__header">
-        <p class="about-kicker">Start exploring</p>
-        <h2 id="about-explore-links-heading">Follow the music wherever it leads.</h2>
-      </div>
-      <ul class="about-values" aria-label="Ways to explore Sundown Sessions">
-        <li><strong>Shows</strong><span><a href="{{ "/shows/" | relURL }}">Browse previous broadcasts</a>.</span></li>
-        <li><strong>Artists</strong><span><a href="{{ "/artists/" | relURL }}">Discover featured artists</a>.</span></li>
-        <li><strong>Releases</strong><span><a href="{{ "/releases/" | relURL }}">Explore albums, EPs and singles</a>.</span></li>
-        <li><strong>Tracks</strong><span><a href="{{ "/tracks/" | relURL }}">Find songs from the playlists</a>.</span></li>
-      </ul>
-    </section>
-
-    <section class="about-cta" aria-labelledby="about-involved-heading">
-      <p class="about-kicker">Get in touch</p>
-      <h2 id="about-involved-heading">Have a recommendation?</h2>
-      <p>Released something that feels right for the show? Found an artist I should hear? Want to ask about a broadcast, playlist, or feature? I would love to hear from you.</p>
-      <div class="about-actions about-actions--center">
-        <a class="about-button about-button--primary" href="{{ "/listen-live/" | relURL }}">Listen Live</a>
-        <a class="about-button about-button--secondary" href="{{ "/shows/" | relURL }}">Browse Shows</a>
         <a class="about-button about-button--secondary" href="{{ "/contact/" | relURL }}">Contact</a>
       </div>
-      {{ if $sameAs }}
-        <nav class="about-socials" aria-label="Sundown Sessions social links">
-          {{ range site.Params.Author.links }}
-            {{ range $service, $url := . }}
-              <a href="{{ $url }}" rel="me noopener" target="_blank">{{ title $service }}</a>
-            {{ end }}
-          {{ end }}
-        </nav>
-      {{ end }}
     </section>
   </article>
 {{ end }}


### PR DESCRIPTION
## Summary
- Simplifies the About page into a warmer editorial introduction
- Removes most card-heavy sections and repeated split layouts
- Keeps the existing hero image and uses one Colin curator card with clear Listen Live / Shows / Contact calls to action

## Verification
- `git diff --check`
- Could not run `hugo --environment production`: Hugo is not installed or available on PATH in this environment