### PR TITLE
docs: refine contact page content

### DIFF
--- a/docs/contact-page-content-review.md
+++ b/docs/contact-page-content-review.md
@@ -1,0 +1,46 @@
+# Contact Page Content Review
+
+Issue: #575
+
+## Summary
+
+The Contact page previously gave visitors a short list of possible reasons to get in touch, but it did not fully explain who the page was for, what kinds of messages were welcome, how music submissions would be reviewed, or where visitors could go next.
+
+The page has been rewritten as a clearer contact hub for listeners, artists, bands, labels, promoters, venues, festival organisers and industry contacts while keeping the tone friendly, independent and music-first.
+
+## Priority Actions Completed
+
+1. Updated the page title, strapline and meta description so the Contact page is clearer in search results and site navigation.
+2. Replaced the short bullet list with a warmer introduction that immediately explains how to contact Sundown Sessions and why.
+3. Added clear guidance for listener messages, artist submissions, gig news, interviews, exclusive tracks, broadcast opportunities and general enquiries.
+4. Added music submission guidance that asks for artist, release, date, link and story details without sounding formal or gatekeeping.
+5. Added expectation-setting copy explaining that submissions are listened to with care, not every track can be featured, and replies happen where appropriate.
+6. Added onward journeys to Listen Live, Shows, About, Artists, Releases, Instagram, Facebook, Mixcloud and Mastodon so the page is not a dead end.
+7. Kept the existing Formspree contact form endpoint and form fields unchanged.
+
+## Content Findings
+
+- The revised page title, "Contact Sundown Sessions", is more specific than the previous generic "Contact".
+- The opening copy now quickly answers who should use the page and what kinds of contact are welcome.
+- Artist and industry contact routes are clearer, including labels, promoters, venues and festival organisers.
+- Music submission guidance now gives senders practical details to include while preserving an approachable editorial tone.
+- Response expectations are clearer and more realistic without making the page feel automated or corporate.
+
+## UX Findings
+
+- The page can now be scanned by heading: contact topics, music submissions, what happens next, onward routes and the message form.
+- The form remains visible after the guidance, so visitors get context before committing time to the message.
+- Internal links support continued browsing for visitors who are not ready to send a message.
+- Social links offer alternative lightweight ways to follow the show without inventing a public email address.
+
+## SEO Findings
+
+- The meta description now includes natural language around music submissions, gig news, listener messages, labels, promoters, venues, festivals and interview ideas.
+- Heading structure remains simple and readable, with one page title followed by focused section headings.
+- Internal links improve discoverability for Shows, About, Listen Live, Artists and Releases without keyword stuffing.
+
+## Optional Follow-Ups
+
+1. Consider adding Mixcloud to `params.author.links` if it should appear alongside the other generated social links.
+2. Consider adding a subject or enquiry-type field to the contact form if messages become difficult to triage.
+3. If response volume grows, consider adding a short expected response-time note that still feels personal and non-corporate.

--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -1,15 +1,60 @@
 ---
-title: 'Contact'
-strapline: 'Get in touch with the show.'
-description: 'If you want to get in touch - this is the place!'
+title: 'Contact Sundown Sessions'
+strapline: 'Send music, gig news, listener messages and ideas for the show.'
+description: 'Contact Sundown Sessions with music submissions, gig news, interview ideas, listener messages, label updates, promoter enquiries and festival or venue opportunities.'
 menu:
   main:
     title: 'Go to the Contact page'
     weight: 4
+showDate: false
+showReadingTime: false
+showPagination: false
+showAuthor: false
+showHero: false
+showBreadcrumbs: true
+showTaxonomies: false
+sharingLinks: []
 ---
-- Would you like to dedicate a song request to someone special?
-- Are you a local band with upcoming gigs you want to share with our listeners?
-- Are you a local band seeking exposure on the airwaves?
-- Do you have any feedback for the show? Your input is invaluable for our continuous improvement.
+Sundown Sessions is built around music worth sharing, so the door is open.
+
+Use the form below if you have a track, release, gig, artist story, interview idea or general message that feels like it belongs in the Sundown Sessions orbit.
+
+## What to get in touch about
+
+Messages are welcome from listeners, artists, bands, labels, promoters, venues, festival organisers and anyone working around independent or alternative music.
+
+You can get in touch about:
+
+- New music and artist submissions
+- Upcoming gigs, tours, festivals and local events
+- Interview ideas and guest opportunities
+- Exclusive tracks, first plays or broadcast opportunities
+- Featured artist updates or missing artist information
+- Listener messages, requests and feedback
+- Label, promoter, venue and industry enquiries
+
+## Music submissions
+
+If you are sending music, include the artist name, track or release title, release date, relevant links, and a short note about the story behind it. Streaming links, Bandcamp pages, press pages and social links are all useful.
+
+Every submission is listened to with care, but not every track can be played or featured. Sundown Sessions is curated by hand, so the final selection depends on the shape of each broadcast, the wider archive and what feels right for after-dark listening.
+
+## What happens next
+
+Messages arrive through the contact form and will be reviewed as soon as possible. If something is a good fit for a broadcast, feature, show note or future conversation, you may hear back by email.
+
+There may not always be time to reply to every submission individually, but thoughtful music, useful details and clear links make it much easier to follow up.
+
+## Keep exploring
+
+If you are new here, you might also want to:
+
+- [Listen Live](/listen-live/) when Sundown Sessions is on air
+- Browse the [Shows Archive](/shows/) for previous broadcasts and playlists
+- Read more [About Sundown Sessions](/about/)
+- Explore [Featured Artists](/artists/) and [Releases](/releases/)
+- Follow Sundown Sessions on [Instagram](https://www.instagram.com/sundownsessionsshow), [Facebook](https://www.facebook.com/sundownsessionsuk), [Mixcloud](https://www.mixcloud.com/sundownsessions/) or [Mastodon](https://mastodon.scot/@sundown_sessions)
+
+## Send a message
 
 {{< form-contact action="https://formspree.io/f/xzbnwyez" >}}


### PR DESCRIPTION
## Summary
- expands the Contact page into a clearer contact hub for listeners, artists, labels, promoters, venues, festival organisers and industry contacts
- updates Contact page metadata, submission guidance, response expectations, internal links and social routes
- documents the completed content, UX and SEO review for issue #575

Closes #575

## Verification
- Confirmed internal routes exist for Listen Live, Shows, About, Artists and Releases
- Ran `git diff --check -- src/content/contact/index.md docs/contact-page-content-review.md`
- `hugo --environment production` could not be run locally because `hugo` is not installed or not on PATH in this environment