### PR TITLE
Polish contact page

### DIFF
--- a/src/config/_default/menus.toml
+++ b/src/config/_default/menus.toml
@@ -29,6 +29,6 @@
 [[footer]]
   identifier = "contact"
   name = "Contact"
-  title = "Contact Sundown Sessions"
+  title = "Get in touch with the show."
   url = "/contact/"
   weight = 50

--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -1,10 +1,10 @@
 ---
 title: 'Contact'
-strapline: 'Send music, gig news, listener messages and ideas for the show.'
+strapline: "We'd love to hear from you."
 description: 'Contact Sundown Sessions with music submissions, gig news, interview ideas, listener messages, label updates, promoter enquiries and festival or venue opportunities.'
 menu:
   main:
-    title: 'Go to the Contact page'
+    title: 'Get in touch with the show.'
     weight: 4
 showDate: false
 showReadingTime: false
@@ -15,46 +15,26 @@ showBreadcrumbs: true
 showTaxonomies: false
 sharingLinks: []
 ---
-Sundown Sessions is built around music worth sharing, so the door is open.
+Sundown Sessions exists to discover great music and share it with people who love finding something new. If you've got music, gig news, ideas or simply want to get in touch, I'd love to hear from you.
 
-Send a note if you have a track, release, gig, artist story, interview idea or listener message that feels like it belongs in the Sundown Sessions orbit.
-
-Messages from listeners, artists, bands, labels, promoters, venues, festival organisers and people working around independent or alternative music are all welcome.
-
-## Send a message
+## Get in touch
 
 {{< form-contact action="https://formspree.io/f/xzbnwyez" >}}
 
 ## What to get in touch about
 
-You can get in touch about:
-
-- New music and artist submissions
-- Upcoming gigs, tours, festivals and local events
-- Interview ideas and guest opportunities
-- Exclusive tracks, first plays or broadcast opportunities
-- Featured artist updates or missing artist information
-- Listener messages, requests and feedback
-- Label, promoter, venue and industry enquiries
+{{< contact-reasons >}}
 
 ## Music submissions
 
 If you are sending music, include the artist name, track or release title, release date, relevant links, and a short note about the story behind it. Streaming links, Bandcamp pages, press pages and social links are all useful.
 
-Every submission is listened to with care, but not every track can be played or featured. Sundown Sessions is curated by hand, so the final selection depends on the shape of each broadcast, the wider archive and what feels right for after-dark listening.
+Every submission is listened to personally, but not every track can be played or featured. Sundown Sessions is curated by hand, so the final selection depends on the shape of each broadcast, the wider archive and what feels right for after-dark listening.
 
 ## What happens next
 
-Messages arrive through the contact form and will be reviewed as soon as possible. If something is a good fit for a broadcast, feature, show note or future conversation, you may hear back by email.
+Messages are read by the show and we'll respond where we can. There may sometimes be a delay, but thoughtful music, useful details and clear links make it much easier to listen properly.
 
-There may not always be time to reply to every submission individually, but thoughtful music, useful details and clear links make it much easier to follow up.
+## Continue exploring
 
-## Keep exploring
-
-If you are new here, start with the music:
-
-- [Listen Live](/listen-live/) when Sundown Sessions is on air
-- Browse the [Shows Archive](/shows/) for previous broadcasts and playlists
-- Read more [About Sundown Sessions](/about/)
-- Explore [Featured Artists](/artists/) and [Releases](/releases/)
-- Follow Sundown Sessions on [Instagram](https://www.instagram.com/sundownsessionsshow), [Facebook](https://www.facebook.com/sundownsessionsuk), [Mixcloud](https://www.mixcloud.com/sundownsessions/) or [Mastodon](https://mastodon.scot/@sundown_sessions)
+{{< contact-explore >}}

--- a/src/layouts/shortcodes/contact-explore.html
+++ b/src/layouts/shortcodes/contact-explore.html
@@ -1,0 +1,17 @@
+<nav class="not-prose my-6" aria-label="Continue exploring">
+  {{ $links := slice
+    (dict "label" "Shows" "url" "/shows/")
+    (dict "label" "Listen Live" "url" "/listen-live/")
+    (dict "label" "About" "url" "/about/")
+    (dict "label" "Mixcloud / Listen Again" "url" "https://www.mixcloud.com/sundownsessions/")
+  }}
+  <ul class="m-0 grid list-none gap-2 p-0 sm:grid-cols-2">
+    {{ range $links }}
+      <li>
+        <a class="block rounded-lg border border-neutral-200 bg-white px-4 py-3 text-sm font-semibold text-neutral-800 no-underline transition hover:border-primary-500 hover:text-primary-700 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-primary-400 dark:hover:text-primary-400" href="{{ .url | safeURL }}">
+          {{ .label }}
+        </a>
+      </li>
+    {{ end }}
+  </ul>
+</nav>

--- a/src/layouts/shortcodes/contact-reasons.html
+++ b/src/layouts/shortcodes/contact-reasons.html
@@ -1,0 +1,15 @@
+<div class="not-prose my-8 grid gap-4 sm:grid-cols-2">
+  {{ $reasons := slice
+    (dict "title" "Music submissions" "copy" "Send new music from independent, emerging or overlooked artists.")
+    (dict "title" "Gig news" "copy" "Tell us about upcoming gigs, festivals and new releases.")
+    (dict "title" "Interviews and features" "copy" "Recommend artists, projects or stories that deserve a wider audience.")
+    (dict "title" "Listener requests" "copy" "Dedicate a track, suggest a song or simply say hello.")
+    (dict "title" "Feedback and ideas" "copy" "Help shape future broadcasts and the website.")
+  }}
+  {{ range $index, $reason := $reasons }}
+    <article class="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900{{ if eq $index 4 }} sm:col-span-2{{ end }}">
+      <h3 class="m-0 text-base font-bold text-neutral-900 dark:text-neutral-100">{{ $reason.title }}</h3>
+      <p class="mt-2 mb-0 text-sm leading-6 text-neutral-600 dark:text-neutral-400">{{ $reason.copy }}</p>
+    </article>
+  {{ end }}
+</div>

--- a/src/layouts/shortcodes/form-contact.html
+++ b/src/layouts/shortcodes/form-contact.html
@@ -2,27 +2,27 @@
 {{ $formID := printf "contact-form-%d" .Ordinal }}
 {{ $toastRegionID := printf "contact-form-toast-region-%d" .Ordinal }}
 {{ if $action }}
-  <div class="not-prose mt-10 rounded-2xl border border-neutral-300 bg-neutral-50 px-6 py-6 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
-    <form id="{{ $formID }}" action="{{ $action }}" method="POST" accept-charset="UTF-8" class="space-y-6" data-analytics-event="contact_submit" data-analytics-provider="formspree">
+  <div class="not-prose mt-8 max-w-2xl rounded-xl border border-neutral-300 bg-neutral-50 px-5 py-6 shadow-sm dark:border-neutral-700 dark:bg-neutral-900 sm:px-7 sm:py-7">
+    <form id="{{ $formID }}" action="{{ $action }}" method="POST" accept-charset="UTF-8" class="space-y-5" data-analytics-event="contact_submit" data-analytics-provider="formspree">
       <input type="hidden" name="_subject" value="Sundown Sessions website enquiry" />
       <div class="hidden">
         <label for="{{ $formID }}-company">Company</label>
         <input id="{{ $formID }}-company" name="_gotcha" type="text" tabindex="-1" autocomplete="off" />
       </div>
       <div>
-        <label class="mb-2 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-name">Your name</label>
-        <input id="{{ $formID }}-name" name="name" type="text" autocomplete="name" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
+        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-name">Your name</label>
+        <input id="{{ $formID }}-name" name="name" type="text" autocomplete="name" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
       </div>
       <div>
-        <label class="mb-2 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-email">Email address</label>
-        <input id="{{ $formID }}-email" name="email" type="email" autocomplete="email" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
+        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-email">Email address</label>
+        <input id="{{ $formID }}-email" name="email" type="email" autocomplete="email" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
       </div>
       <div>
-        <label class="mb-2 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-message">Message</label>
-        <textarea id="{{ $formID }}-message" name="message" rows="6" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900"></textarea>
+        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-message">Message</label>
+        <textarea id="{{ $formID }}-message" name="message" rows="6" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900"></textarea>
       </div>
-      <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
-        <button type="submit" class="contact-form__submit inline-flex items-center justify-center rounded-lg bg-primary-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-primary-500 dark:hover:bg-primary-400 dark:focus:ring-primary-900">
+      <div class="flex flex-col gap-4 pt-1 sm:flex-row sm:items-center">
+        <button type="submit" class="contact-form__submit inline-flex items-center justify-center rounded-lg bg-primary-600 px-6 py-3.5 text-sm font-semibold text-white transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-primary-500 dark:hover:bg-primary-400 dark:focus:ring-primary-900">
           <span class="contact-form__button-label">Send message</span>
           <span class="contact-form__spinner" aria-hidden="true"></span>
         </button>


### PR DESCRIPTION
## Summary
- refresh Contact page copy with a warmer editorial tone
- replace contact reasons with compact Blowfish-style shortcode cards
- refine contact form spacing and update contact tooltip wording

## Testing
- git diff --check
- not run: hugo --environment production (hugo is not available on PATH in this session)