### PR TITLE
Polish contact page layout

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1466,7 +1466,7 @@
    site forms keep their existing behaviour. */
 
 .contact-form__submit {
-  min-width: 9.25rem;
+  min-width: 10.75rem;
   gap: 0.5rem;
 }
 

--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -21,7 +21,7 @@ Sundown Sessions exists to discover great music and share it with people who lov
 
 {{< form-contact action="https://formspree.io/f/xzbnwyez" >}}
 
-## What to get in touch about
+## Get in touch about...
 
 {{< contact-reasons >}}
 

--- a/src/layouts/shortcodes/contact-reasons.html
+++ b/src/layouts/shortcodes/contact-reasons.html
@@ -1,13 +1,13 @@
-<div class="not-prose my-8 grid gap-4 sm:grid-cols-2">
+<div class="not-prose relative left-1/2 my-8 grid w-[min(100vw-2rem,48rem)] -translate-x-1/2 items-stretch gap-4 sm:grid-cols-2">
   {{ $reasons := slice
-    (dict "title" "Music submissions" "copy" "Send new music from independent, emerging or overlooked artists.")
+    (dict "title" "Music submissions" "copy" "Send new music from independent, emerging or overlooked artists. Every submission is listened to personally.")
     (dict "title" "Gig news" "copy" "Tell us about upcoming gigs, festivals and new releases.")
     (dict "title" "Interviews and features" "copy" "Recommend artists, projects or stories that deserve a wider audience.")
     (dict "title" "Listener requests" "copy" "Dedicate a track, suggest a song or simply say hello.")
     (dict "title" "Feedback and ideas" "copy" "Help shape future broadcasts and the website.")
   }}
   {{ range $index, $reason := $reasons }}
-    <article class="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900{{ if eq $index 4 }} sm:col-span-2{{ end }}">
+    <article class="flex h-full flex-col rounded-xl border border-neutral-200 bg-white p-6 shadow-sm dark:border-neutral-700 dark:bg-neutral-900{{ if eq $index 4 }} sm:col-span-2{{ end }}">
       <h3 class="m-0 text-base font-bold text-neutral-900 dark:text-neutral-100">{{ $reason.title }}</h3>
       <p class="mt-2 mb-0 text-sm leading-6 text-neutral-600 dark:text-neutral-400">{{ $reason.copy }}</p>
     </article>

--- a/src/layouts/shortcodes/form-contact.html
+++ b/src/layouts/shortcodes/form-contact.html
@@ -10,11 +10,11 @@
         <input id="{{ $formID }}-company" name="_gotcha" type="text" tabindex="-1" autocomplete="off" />
       </div>
       <div>
-        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-name">Your name</label>
+        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-name">Name</label>
         <input id="{{ $formID }}-name" name="name" type="text" autocomplete="name" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
       </div>
       <div>
-        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-email">Email address</label>
+        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-email">Email</label>
         <input id="{{ $formID }}-email" name="email" type="email" autocomplete="email" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
       </div>
       <div>
@@ -22,7 +22,7 @@
         <textarea id="{{ $formID }}-message" name="message" rows="6" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900"></textarea>
       </div>
       <div class="flex flex-col gap-4 pt-1 sm:flex-row sm:items-center">
-        <button type="submit" class="contact-form__submit inline-flex items-center justify-center rounded-lg bg-primary-600 px-6 py-3.5 text-sm font-semibold text-white transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-primary-500 dark:hover:bg-primary-400 dark:focus:ring-primary-900">
+        <button type="submit" class="contact-form__submit inline-flex items-center justify-center rounded-lg bg-primary-600 px-7 py-3.5 text-sm font-semibold text-white transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-primary-500 dark:hover:bg-primary-400 dark:focus:ring-primary-900">
           <span class="contact-form__button-label">Send message</span>
           <span class="contact-form__spinner" aria-hidden="true"></span>
         </button>


### PR DESCRIPTION
## Summary
- rename the contact reasons heading to a warmer conversational prompt
- widen and balance the contact cards with equal-height layout treatment
- simplify contact form labels and give the submit button slightly more presence
- reinforce that music submissions are listened to personally

## Verification
- git diff --check
- Not run: Hugo/Tailwind build unavailable in this shell because hugo and npm are not on PATH