### PR TITLE
Support music submissions via links

### DIFF
--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -27,7 +27,7 @@ Sundown Sessions exists to discover great music and share it with people who lov
 
 ## Music submissions
 
-If you are sending music, include the artist name, track or release title, release date, relevant links, and a short note about the story behind it. Streaming links, Bandcamp pages, press pages and social links are all useful.
+If you are sending music, include the artist name, track or release title, release date, relevant links, and a short note about the story behind it. Please send a streaming, download or press link rather than attaching files. Bandcamp, SoundCloud, Spotify, YouTube, Dropbox, Google Drive and official website links are all welcome.
 
 Every submission is listened to personally, but not every track can be played or featured. Sundown Sessions is curated by hand, so the final selection depends on the shape of each broadcast, the wider archive and what feels right for after-dark listening.
 

--- a/src/layouts/shortcodes/form-contact.html
+++ b/src/layouts/shortcodes/form-contact.html
@@ -18,8 +18,13 @@
         <input id="{{ $formID }}-email" name="email" type="email" autocomplete="email" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
       </div>
       <div>
+        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-link">Link</label>
+        <input id="{{ $formID }}-link" name="link" type="text" inputmode="url" autocomplete="url" placeholder="Bandcamp, SoundCloud, Spotify, YouTube, Dropbox, Google Drive or website link" class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
+      </div>
+      <div>
         <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-message">Message</label>
         <textarea id="{{ $formID }}-message" name="message" rows="6" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900"></textarea>
+        <p class="mt-2 mb-0 text-sm leading-6 text-neutral-600 dark:text-neutral-400">Tell us who you are, what you're sending, and where we can listen.</p>
       </div>
       <div class="flex flex-col gap-4 pt-1 sm:flex-row sm:items-center">
         <button type="submit" class="contact-form__submit inline-flex items-center justify-center rounded-lg bg-primary-600 px-7 py-3.5 text-sm font-semibold text-white transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-primary-500 dark:hover:bg-primary-400 dark:focus:ring-primary-900">


### PR DESCRIPTION
## Summary
- Add an optional Link field to the contact form for music submissions
- Clarify that submissions should use streaming, download or press links rather than attachments
- Add message guidance for submitters while keeping Formspree-compatible form controls

## Verification
- Confirmed form fields include name, email, link and message
- Confirmed no file upload input was added
- Ran git diff --check; only existing Windows line-ending warnings were reported
- Hugo build not run because hugo is not installed/on PATH in this environment