### PR TITLE
Refine individual show page hero

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -733,6 +733,177 @@
   }
 }
 
+/* Individual show hero: compact editorial lead-in for broadcast pages. */
+
+.show-hero {
+  max-width: 70rem;
+}
+
+.show-hero__layout {
+  display: flex;
+  flex-direction: column;
+}
+
+.show-hero__artwork {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.show-hero__artwork img {
+  display: block;
+  width: 100%;
+  max-height: 18rem;
+  object-fit: contain;
+}
+
+.show-hero__content {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: clamp(1.35rem, 4vw, 2.25rem);
+}
+
+.show-hero__eyebrow,
+.show-hero__feature-label,
+.show-hero__date,
+.show-hero__runtime {
+  margin: 0;
+}
+
+.show-hero__eyebrow {
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.dark .show-hero__eyebrow {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.show-hero__feature {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.show-hero__feature-label {
+  color: #737373; /* neutral-500 */
+  font-size: 0.95rem;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.dark .show-hero__feature-label {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.show-hero__artist {
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-size: clamp(2rem, 5vw, 3.35rem);
+  font-weight: 850;
+  letter-spacing: 0;
+  line-height: 1.04;
+  overflow-wrap: anywhere;
+}
+
+.dark .show-hero__artist {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.show-hero__date,
+.show-hero__runtime {
+  color: #525252; /* neutral-600 */
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.dark .show-hero__date,
+.dark .show-hero__runtime {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.show-hero__runtime {
+  color: #737373; /* neutral-500 */
+}
+
+.dark .show-hero__runtime {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.show-hero__shortcut {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 0.15rem;
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.95rem;
+  font-weight: 750;
+  line-height: 1.35;
+  text-decoration: underline;
+  text-decoration-color: rgba(var(--color-primary-500), 0.45);
+  text-underline-offset: 0.16rem;
+}
+
+.show-hero__shortcut:hover,
+.show-hero__shortcut:focus-visible {
+  color: rgba(var(--color-primary-700), 1);
+  text-decoration-color: currentColor;
+}
+
+.show-hero__shortcut:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 0.2rem;
+}
+
+.show-hero__shortcut::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border-block: 0.28rem solid transparent;
+  border-left: 0.42rem solid currentColor;
+  margin-right: 0.42rem;
+}
+
+.dark .show-hero__shortcut {
+  color: rgba(var(--color-primary-400), 1);
+  text-decoration-color: rgba(var(--color-primary-400), 0.5);
+}
+
+.dark .show-hero__shortcut:hover,
+.dark .show-hero__shortcut:focus-visible {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+@media (min-width: 640px) {
+  .show-hero__layout {
+    min-height: 16rem;
+    flex-direction: row;
+  }
+
+  .show-hero__artwork {
+    flex: 0 0 min(34%, 18rem);
+  }
+
+  .show-hero__artwork img {
+    height: 100%;
+    max-height: none;
+  }
+
+  .show-hero__content {
+    padding: clamp(1.75rem, 3vw, 2.6rem);
+  }
+}
+
 /* Shows archive page: editorial gateway above the broadcast list. */
 
 .shows-archive-intro {

--- a/src/layouts/partials/show/hero.html
+++ b/src/layouts/partials/show/hero.html
@@ -19,31 +19,74 @@
 {{ end }}
 {{ if not $featuredURL }}{{ with $featured }}{{ $featuredURL = .RelPermalink }}{{ end }}{{ end }}
 
-<section class="mb-10 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70" role="region" aria-labelledby="show-hero-heading">
-  <div class="flex flex-col sm:flex-row">
+{{ $showNumber := .Title | replaceRE `(?i)^show\s*#?([0-9]+).*$` "$1" }}
+{{ if eq $showNumber .Title }}{{ $showNumber = "" }}{{ end }}
+{{ $showLabel := cond (ne $showNumber "") (printf "Show #%s" $showNumber) (.Title | replaceRE `(?i):\s*broadcast.*$` "") }}
+
+{{ $featuredArtist := "" }}
+{{ with .Description }}
+  {{ $featuredArtist = . | replaceRE `(?i)^\s*featuring\s+` "" | strings.TrimSpace }}
+{{ end }}
+{{ if not $featuredArtist }}
+  {{ with .Params.summary }}
+    {{ $summaryArtists := findRE `(?m)^\s*-\s+(.+?)\s*$` . }}
+    {{ with $summaryArtists }}
+      {{ $featuredArtist = index . 0 | replaceRE `^\s*-\s+` "" | strings.TrimSpace }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ if not $featuredArtist }}
+  {{ with .Params.tags }}
+    {{ $featuredArtist = index . 0 }}
+  {{ end }}
+{{ end }}
+
+{{ $trackCount := 0 }}
+{{ with .File }}
+  {{ $showDir := path.Dir (replace .Path "\\" "/") }}
+  {{ $trackInfoPath := printf "content/%s/track-info.md" $showDir }}
+  {{ $playlistPath := printf "content/%s/playlist.md" $showDir }}
+  {{ if fileExists $trackInfoPath }}
+    {{ $trackRows := findRE `(?m)^\|\s*\d+\s*\|` (readFile $trackInfoPath) }}
+    {{ $trackCount = len $trackRows }}
+  {{ else if fileExists $playlistPath }}
+    {{ $playlistRows := findRE `(?m)^\d+\.\s+` (readFile $playlistPath) }}
+    {{ $trackCount = len $playlistRows }}
+  {{ end }}
+{{ end }}
+{{ $duration := .Params.duration | default .Params.showDuration | default .Params.show_duration | default .Params.length }}
+{{ $showRuntime := "" }}
+{{ if and (gt $trackCount 0) $duration }}
+  {{ $trackLabel := cond (eq $trackCount 1) "Track" "Tracks" }}
+  {{ $showRuntime = printf "%d %s &bull; %v" $trackCount $trackLabel $duration }}
+{{ end }}
+{{ $hasListenOnDemand := in .RawContent "## Listen On Demand" }}
+
+<section class="show-hero mb-8 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70" role="region" aria-labelledby="show-hero-heading">
+  <div class="show-hero__layout">
     {{ with $featuredURL }}
-      <div class="flex items-center justify-center bg-neutral-100 p-4 dark:bg-neutral-800 sm:w-64 sm:shrink-0">
-        <img src="{{ . }}" alt="{{ $.Title }} artwork" loading="eager" decoding="async" fetchpriority="high" class="nozoom h-auto max-h-96 w-full object-contain">
+      <div class="show-hero__artwork bg-neutral-100 dark:bg-neutral-800">
+        <img src="{{ . }}" alt="{{ $.Title }} artwork" loading="eager" decoding="async" fetchpriority="high" class="nozoom">
       </div>
     {{ end }}
-    <div class="flex flex-1 flex-col justify-center gap-4 p-6 sm:p-8">
-      {{ if $.Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
-        <div class="mb-1 text-sm">{{ partial "breadcrumbs.html" $ }}</div>
-      {{ end }}
-      <p class="mb-0 text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Broadcast</p>
-      <h1 id="show-hero-heading" class="mt-0 text-3xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral sm:text-4xl lg:text-5xl">
-        {{ $.Title | emojify }}
-      </h1>
-      {{ with $.Description }}
-        <p class="text-base text-neutral-600 dark:text-neutral-300">{{ . }}</p>
+    <div class="show-hero__content">
+      <p class="show-hero__eyebrow">{{ $showLabel }}</p>
+      {{ with $featuredArtist }}
+        <div class="show-hero__feature">
+          <p class="show-hero__feature-label">Featuring</p>
+          <h1 id="show-hero-heading" class="show-hero__artist">{{ . }}</h1>
+        </div>
+      {{ else }}
+        <h1 id="show-hero-heading" class="show-hero__artist">{{ $.Title | emojify }}</h1>
       {{ end }}
       {{ if not $.Date.IsZero }}
-        <dl class="artist-header-stats">
-          <div>
-            <dt>Broadcast Date</dt>
-            <dd>{{ $.Date | time.Format (site.Params.dateFormat | default "2 January 2006") }}</dd>
-          </div>
-        </dl>
+        <p class="show-hero__date">{{ $.Date | time.Format (site.Params.dateFormat | default "2 January 2006") }}</p>
+      {{ end }}
+      {{ with $showRuntime }}
+        <p class="show-hero__runtime">{{ . | safeHTML }}</p>
+      {{ end }}
+      {{ if $hasListenOnDemand }}
+        <a class="show-hero__shortcut" href="#listen-on-demand">Listen on Demand</a>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- simplify the individual show hero around show number, featured artist, date, and optional runtime metadata
- make show artwork flush with the hero card while preserving contained artwork rendering
- remove in-hero breadcrumbs and add a lightweight Listen on Demand anchor when the section exists

## Testing
- `git diff --check -- src/layouts/partials/show/hero.html src/assets/css/custom.css`
- Not run: `hugo --minify` because `hugo` is not installed on this PATH