### PR TITLE
Polish individual show page hero

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -755,6 +755,7 @@
   display: block;
   width: 100%;
   max-height: 18rem;
+  border-radius: 0;
   object-fit: contain;
 }
 
@@ -891,7 +892,7 @@
   }
 
   .show-hero__artwork {
-    flex: 0 0 min(34%, 18rem);
+    flex: 0 0 min(38%, 20.25rem);
   }
 
   .show-hero__artwork img {

--- a/src/layouts/partials/show/hero.html
+++ b/src/layouts/partials/show/hero.html
@@ -54,7 +54,7 @@
     {{ $trackCount = len $playlistRows }}
   {{ end }}
 {{ end }}
-{{ $duration := .Params.duration | default .Params.showDuration | default .Params.show_duration | default .Params.length }}
+{{ $duration := .Params.duration | default .Params.showDuration | default .Params.show_duration | default .Params.length | default "2 hr 00 min" }}
 {{ $showRuntime := "" }}
 {{ if and (gt $trackCount 0) $duration }}
   {{ $trackLabel := cond (eq $trackCount 1) "Track" "Tracks" }}


### PR DESCRIPTION
## Summary
- Widen the individual show hero artwork area on desktop without changing hero height
- Remove image-level rounding so the card controls the hero corners
- Add the fallback show duration so track count metadata renders beneath the broadcast date

## Verification
- Not run: Hugo is not installed/on PATH in this environment