### PR TITLE
Refine show Listen On Demand card

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -737,6 +737,7 @@
 
 .show-hero {
   max-width: 70rem;
+  margin-bottom: 1rem;
 }
 
 .show-hero__layout {
@@ -904,6 +905,171 @@
 
   .show-hero__content {
     padding: clamp(1.75rem, 3vw, 2.6rem);
+  }
+}
+
+/* Individual show page: refined listen-on-demand card and right-side section nav. */
+
+.show-listen-card {
+  max-width: 42rem;
+  margin: 0 0 2.5rem;
+  scroll-margin-top: 6rem;
+}
+
+.show-page-main .article-content > h2#listen-on-demand {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.show-listen-card__body {
+  display: grid;
+  gap: 0.9rem;
+  overflow: hidden;
+  border: 1px solid var(--ss-color-border);
+  border-radius: 0.75rem;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--ss-color-sunset) 6%, transparent),
+      transparent 44%
+    ),
+    color-mix(in srgb, var(--ss-color-surface) 92%, white);
+  box-shadow: 0 1px 2px rgb(30 36 56 / 0.05);
+  padding: clamp(1.15rem, 3vw, 1.6rem);
+}
+
+.dark .show-listen-card__body {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--ss-color-golden-hour) 7%, transparent),
+      transparent 44%
+    ),
+    color-mix(in srgb, var(--ss-color-surface) 90%, #171717);
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.16);
+}
+
+.show-listen-card__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0;
+  color: #171717; /* neutral-900 */
+  font-size: clamp(1.22rem, 2vw, 1.45rem);
+  font-weight: 820;
+  letter-spacing: 0;
+  line-height: 1.25;
+}
+
+.dark .show-listen-card__heading {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.show-listen-card__icon {
+  display: inline-flex;
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: rgba(var(--color-primary-600), 1);
+}
+
+.dark .show-listen-card__icon {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.show-listen-card__copy {
+  max-width: 34rem;
+  margin: 0;
+  color: #525252; /* neutral-600 */
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.6;
+}
+
+.dark .show-listen-card__copy {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.show-listen-card__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  max-width: 100%;
+  min-height: 2.55rem;
+  border: 1px solid color-mix(in srgb, var(--ss-color-primary-action) 34%, var(--ss-color-border));
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--ss-color-primary-action) 9%, var(--ss-color-surface));
+  padding: 0.62rem 0.95rem;
+  color: rgba(var(--color-primary-700), 1);
+  font-size: 0.95rem;
+  font-weight: 780;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.show-listen-card__button:hover,
+.show-listen-card__button:focus-visible {
+  border-color: color-mix(in srgb, var(--ss-color-primary-action) 58%, var(--ss-color-border));
+  background: color-mix(in srgb, var(--ss-color-primary-action) 14%, var(--ss-color-surface));
+  color: rgba(var(--color-primary-800), 1);
+  text-decoration: none;
+}
+
+.show-listen-card__button:focus-visible {
+  outline: 2px solid var(--ss-color-focus);
+  outline-offset: 0.18rem;
+}
+
+.dark .show-listen-card__button {
+  background: color-mix(in srgb, var(--ss-color-primary-action) 12%, var(--ss-color-surface));
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.dark .show-listen-card__button:hover,
+.dark .show-listen-card__button:focus-visible {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.show-page-toc #TOCView > div,
+.show-page-toc .toc-inside > div {
+  border-inline-start-color: var(--ss-color-border);
+  border-inline-start-style: solid;
+}
+
+.show-page-toc #TableOfContents ul {
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+}
+
+.show-page-toc #TableOfContents li {
+  margin-top: 0.18rem;
+  margin-bottom: 0.18rem;
+  line-height: 1.35;
+}
+
+.show-page-toc #TableOfContents a {
+  display: inline-block;
+  padding-block: 0.08rem;
+}
+
+@media (min-width: 1024px) {
+  .show-page-toc-column {
+    flex: 0 0 15.25rem;
+    max-width: 15.25rem;
+  }
+
+  .show-page-toc #TOCView > div {
+    min-width: 15.25rem;
   }
 }
 

--- a/src/content/shows/1/listen-again.md
+++ b/src/content/shows/1/listen-again.md
@@ -1,5 +1,3 @@
 ---
+mixcloudUrl: 'https://www.mixcloud.com/sundownsessions/sundown-sessions-show-1-the-big-now-ist-ist-becky-becky-nick-cave-the-filthy-tongues/'
 ---
-Stream the full show anytime on Mixcloud and enjoy it whenever (and wherever) you like.
-
-{{< new-tab-link "[https://mixcloud.com/sundown-sessions-show-1](https://www.mixcloud.com/sundownsessions/sundown-sessions-show-1-the-big-now-ist-ist-becky-becky-nick-cave-the-filthy-tongues/)" >}}

--- a/src/content/shows/2/listen-again.md
+++ b/src/content/shows/2/listen-again.md
@@ -1,5 +1,3 @@
 ---
+mixcloudUrl: 'https://www.mixcloud.com/sundownsessions/sundown-sessions-show-2-the-receiving-end-chikinki-air-cocteau-twins-masters-of-reality/'
 ---
-Stream the full show anytime on Mixcloud and enjoy it whenever (and wherever) you like.
-
-{{< new-tab-link "[https://mixcloud.com/sundown-sessions-show-2](https://www.mixcloud.com/sundownsessions/sundown-sessions-show-2-the-receiving-end-chikinki-air-cocteau-twins-masters-of-reality/)" >}}

--- a/src/content/shows/3/listen-again.md
+++ b/src/content/shows/3/listen-again.md
@@ -1,5 +1,3 @@
 ---
+mixcloudUrl: 'https://www.mixcloud.com/sundownsessions/sundown-sessions-show-3-blue-on-shock-magazine-aimee-mann-the-unbelievable-truth-sparks/'
 ---
-Stream the full show anytime on Mixcloud and enjoy it whenever (and wherever) you like.
-
-{{< new-tab-link "[https://mixcloud.com/sundown-sessions-show-3](https://www.mixcloud.com/sundownsessions/sundown-sessions-show-3-blue-on-shock-magazine-aimee-mann-the-unbelievable-truth-sparks/)" >}}

--- a/src/content/shows/4/listen-again.md
+++ b/src/content/shows/4/listen-again.md
@@ -1,5 +1,3 @@
 ---
+mixcloudUrl: 'https://www.mixcloud.com/sundownsessions/sundown-sessions-show-4-feat-andysmanclub-angelfish-melys-goodbye-mr-mackenzie-roddy-frame/'
 ---
-Stream the full show anytime on Mixcloud and enjoy it whenever (and wherever) you like.
-
-{{< new-tab-link "[https://mixcloud.com/sundown-sessions-show-4](https://www.mixcloud.com/sundownsessions/sundown-sessions-show-4-feat-andysmanclub-angelfish-melys-goodbye-mr-mackenzie-roddy-frame/)" >}}

--- a/src/content/shows/5/listen-again.md
+++ b/src/content/shows/5/listen-again.md
@@ -1,5 +1,3 @@
 ---
+mixcloudUrl: 'https://www.mixcloud.com/sundownsessions/sundown-sessions-show-5-feat-white-china-siobhan-wilson-kirsten-adamson-electric-six-vapors/'
 ---
-Stream the full show anytime on Mixcloud and enjoy it whenever (and wherever) you like.
-
-{{< new-tab-link "[https://mixcloud.com/sundown-sessions-show-5](https://www.mixcloud.com/sundownsessions/sundown-sessions-show-5-feat-white-china-siobhan-wilson-kirsten-adamson-electric-six-vapors/)" >}}

--- a/src/layouts/partials/show/hero.html
+++ b/src/layouts/partials/show/hero.html
@@ -60,7 +60,7 @@
     {{ end }}
   {{ end }}
 {{ end }}
-{{ $hasListenOnDemand := in .RawContent "## Listen On Demand" }}
+{{ $hasListenOnDemand := or (in .RawContent "## Listen On Demand") (in .RawContent "/listen-again") }}
 
 <section class="show-hero mb-8 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70" role="region" aria-labelledby="show-hero-heading">
   <div class="show-hero__layout">

--- a/src/layouts/partials/show/listen-again.html
+++ b/src/layouts/partials/show/listen-again.html
@@ -29,11 +29,16 @@
   {{ end }}
 {{ end }}
 
-{{ partial "components/explore-further.html" (dict
-  "links" $links
-  "heading" "Listen Again"
-  "headingId" "show-listen-again-heading"
-  "sectionClass" "mb-10 max-w-prose not-prose"
-  "rowClass" "explore-further__row"
-  "iconClass" "explore-further__icon"
-) }}
+{{ $mixcloudURL := "" }}
+{{ range $links }}
+  {{ if and (not $mixcloudURL) (in (lower .url) "mixcloud.com") }}
+    {{ $mixcloudURL = .url }}
+  {{ end }}
+{{ end }}
+
+{{ with $mixcloudURL }}
+  {{ partial "show/listen-on-demand-card.html" (dict
+    "url" .
+    "copy" ($.Params.listenOnDemandCopy | default $.Params.listen_on_demand_copy)
+  ) }}
+{{ end }}

--- a/src/layouts/partials/show/listen-on-demand-card.html
+++ b/src/layouts/partials/show/listen-on-demand-card.html
@@ -1,0 +1,27 @@
+{{- $url := .url | default "" -}}
+{{- $copy := .copy | default "Missed the live broadcast? Listen back in full on Mixcloud whenever it suits you." -}}
+{{- $heading := .heading | default "Listen On Demand" -}}
+{{- $headingId := .headingId | default "show-listen-on-demand-heading" -}}
+
+<section class="show-listen-card not-prose" role="region" aria-labelledby="{{ $headingId }}">
+  <div class="show-listen-card__body">
+    <h2 id="{{ $headingId }}" class="show-listen-card__heading">
+      <span class="show-listen-card__icon" aria-hidden="true">
+        {{ partial "icon.html" "play" }}
+      </span>
+      <span>{{ $heading }}</span>
+    </h2>
+    <p class="show-listen-card__copy">{{ $copy }}</p>
+    {{- with $url }}
+      <a
+        class="show-listen-card__button"
+        href="{{ . | safeURL }}"
+        data-analytics-event="listen_again_click"
+        data-analytics-provider="Mixcloud"
+        target="_blank"
+        rel="noopener noreferrer external">
+        Listen on Mixcloud
+      </a>
+    {{- end }}
+  </div>
+</section>

--- a/src/layouts/shortcodes/include_content.html
+++ b/src/layouts/shortcodes/include_content.html
@@ -28,6 +28,29 @@
     {{ end }}
   {{ end }}
 
+  {{ if and (hasPrefix $path "shows/") (hasSuffix $path "/listen-again") }}
+    {{ $mixcloudURL := "" }}
+    {{ $copy := "" }}
+    {{ with $includedPage }}
+      {{ $mixcloudURL = .Params.mixcloudUrl | default .Params.mixcloud_url | default .Params.url | default .Params.href | default "" }}
+      {{ $copy = .Params.listenOnDemandCopy | default .Params.listen_on_demand_copy | default .Params.copy | default "" }}
+    {{ end }}
+    {{ if not $mixcloudURL }}
+      {{ $mixcloudURL = $.Page.Params.mixcloudUrl | default $.Page.Params.mixcloud_url | default $.Page.Params.listenAgainUrl | default $.Page.Params.listen_again_url | default "" }}
+    {{ end }}
+    {{ if not $copy }}
+      {{ $copy = $.Page.Params.listenOnDemandCopy | default $.Page.Params.listen_on_demand_copy | default "" }}
+    {{ end }}
+    {{ if not $mixcloudURL }}
+      {{ range findRE `https?://[A-Za-z0-9./?&_%=#:+~-]+` $content }}
+        {{ if and (not $mixcloudURL) (in (lower .) "mixcloud.com") }}
+          {{ $mixcloudURL = . }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+    {{ partial "show/listen-on-demand-card.html" (dict "url" $mixcloudURL "copy" $copy) }}
+  {{ else }}
+
   {{ $forSaleTracks := slice }}
   {{ with $includedPage }}
     {{ with (.Params.forSaleTracks | default .Params.for_sale_tracks) }}
@@ -81,4 +104,5 @@
   {{ end }}
 
   {{ $.Page.RenderString $content }}
+  {{ end }}
 {{ end }}

--- a/src/layouts/shows/single.html
+++ b/src/layouts/shows/single.html
@@ -3,20 +3,20 @@
   <article>
     {{ partial "show/hero.html" . }}
 
-    <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
+    <section class="show-page-layout flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
       {{ $enableToc := site.Params.article.showTableOfContents | default false }}
       {{ $enableToc = .Params.showTableOfContents | default (.Params.toc | default $enableToc) }}
       {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
       {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
       {{ if $showToc }}
-        <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
-          <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+        <div class="show-page-toc-column order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
+          <div class="show-page-toc toc ps-5 print:hidden lg:sticky {{ $topClass }}">
             {{ partial "toc.html" . }}
           </div>
         </div>
       {{ end }}
 
-      <div class="min-w-0 min-h-0 max-w-fit">
+      <div class="show-page-main min-w-0 min-h-0 max-w-fit">
         {{ partial "series/series.html" . }}
         <div class="article-content max-w-prose mb-10">
           {{ .Content }}


### PR DESCRIPTION
## Summary
- Present show listen-again links as a featured Listen On Demand card
- Replace raw Mixcloud URL rendering with a clear Mixcloud CTA
- Refine show-page TOC spacing, divider colour, column width, and hero gap
- Move existing show listen-again URLs into front matter data

## Testing
- git diff --cached --check before commit
- Not run: hugo build, because hugo is not installed on this machine's PATH