### PR TITLE
Refine show listen area

### DIFF
--- a/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ShowNotes/CreateFrontmatter/ShowNotesFrontmatterBuilder.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ShowNotes/CreateFrontmatter/ShowNotesFrontmatterBuilder.cs
@@ -52,7 +52,7 @@ namespace SundownMedia.ContentOps.Application.Features.ShowNotes.CreateFrontmatt
             sb.AppendLine("draft: true");
             sb.AppendLine("---");
             sb.AppendLine();
-            sb.AppendLine("## Listen On Demand");
+            sb.AppendLine("## Listen Back");
             sb.AppendLine(CultureInfo.InvariantCulture, $"{{{{< include_content \"/shows/{command.ShowNumber}/listen-again\" >}}}}");
             sb.AppendLine();
             sb.AppendLine("---");
@@ -62,17 +62,17 @@ namespace SundownMedia.ContentOps.Application.Features.ShowNotes.CreateFrontmatt
             sb.AppendLine();
             sb.AppendLine("---");
             sb.AppendLine();
-            sb.AppendLine(CultureInfo.InvariantCulture, $"## Featured band: {command.FeaturedGuest}");
+            sb.AppendLine("## Featured Artist");
             sb.AppendLine(CultureInfo.InvariantCulture, $"{{{{< include_content \"/shows/{command.ShowNumber}/featured-guest\" >}}}}");
             sb.AppendLine();
             sb.AppendLine("---");
             sb.AppendLine();
-            sb.AppendLine("## Show discussion points");
+            sb.AppendLine("## Discussion");
             sb.AppendLine(CultureInfo.InvariantCulture, $"{{{{< include_content \"/shows/{command.ShowNumber}/discussion-points\" >}}}}");
             sb.AppendLine();
             sb.AppendLine("---");
             sb.AppendLine();
-            sb.AppendLine("## Track info");
+            sb.AppendLine("## Tracks");
             sb.AppendLine(CultureInfo.InvariantCulture, $"{{{{< include_content \"/shows/{command.ShowNumber}/track-info\" >}}}}");
 
             return sb.ToString();

--- a/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/CreateShowNotesFrontmatterCommandHandlerTests.cs
+++ b/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/CreateShowNotesFrontmatterCommandHandlerTests.cs
@@ -217,6 +217,11 @@ public sealed class CreateShowNotesFrontmatterCommandHandlerTests
         content.Should().Contain("- 'IST IST'");
         content.Should().Contain("- 'Nick Cave & The Bad Seeds'");
         content.Should().Contain("tags:");
+        content.Should().Contain("## Listen Back");
+        content.Should().Contain("## Playlist");
+        content.Should().Contain("## Featured Artist");
+        content.Should().Contain("## Discussion");
+        content.Should().Contain("## Tracks");
         content.Should().Contain("{{< include_content \"/shows/1/listen-again\" >}}");
         content.Should().Contain("{{< include_content \"/shows/1/playlist\" >}}");
         content.Should().Contain("{{< include_content \"/shows/1/featured-guest\" >}}");

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -908,23 +908,12 @@
   }
 }
 
-/* Individual show page: refined listen-on-demand card and right-side section nav. */
+/* Individual show page: refined listen-back card and right-side section nav. */
 
 .show-listen-card {
   max-width: 42rem;
   margin: 0 0 2.5rem;
   scroll-margin-top: 6rem;
-}
-
-.show-page-main .article-content > h2#listen-on-demand {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: 0;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
 }
 
 .show-listen-card__body {
@@ -953,36 +942,6 @@
     ),
     color-mix(in srgb, var(--ss-color-surface) 90%, #171717);
   box-shadow: 0 12px 28px rgb(0 0 0 / 0.16);
-}
-
-.show-listen-card__heading {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  margin: 0;
-  color: #171717; /* neutral-900 */
-  font-size: clamp(1.22rem, 2vw, 1.45rem);
-  font-weight: 820;
-  letter-spacing: 0;
-  line-height: 1.25;
-}
-
-.dark .show-listen-card__heading {
-  color: #f5f5f5; /* neutral-100 */
-}
-
-.show-listen-card__icon {
-  display: inline-flex;
-  width: 1.05rem;
-  height: 1.05rem;
-  flex: 0 0 auto;
-  align-items: center;
-  justify-content: center;
-  color: rgba(var(--color-primary-600), 1);
-}
-
-.dark .show-listen-card__icon {
-  color: rgba(var(--color-primary-400), 1);
 }
 
 .show-listen-card__copy {
@@ -1017,6 +976,16 @@
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
+.show-listen-card__button-icon {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  margin-inline-end: 0.45rem;
+}
+
 .show-listen-card__button:hover,
 .show-listen-card__button:focus-visible {
   border-color: color-mix(in srgb, var(--ss-color-primary-action) 58%, var(--ss-color-border));
@@ -1040,10 +1009,34 @@
   color: rgba(var(--color-primary-300), 1);
 }
 
+.show-page-toc__heading {
+  margin: 0 0 0.4rem;
+  color: #737373; /* neutral-500 */
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0;
+  line-height: 1.3;
+}
+
+.dark .show-page-toc__heading {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.show-page-toc #TOCView {
+  overflow-y: visible;
+}
+
 .show-page-toc #TOCView > div,
 .show-page-toc .toc-inside > div {
   border-inline-start-color: var(--ss-color-border);
   border-inline-start-style: solid;
+}
+
+.show-page-toc #TOCView > div {
+  width: fit-content;
+  max-width: 100%;
+  padding-top: 0.15rem;
+  padding-bottom: 0.15rem;
 }
 
 .show-page-toc #TableOfContents ul {

--- a/src/content/shows/1/index.md
+++ b/src/content/shows/1/index.md
@@ -73,7 +73,7 @@ date: 2024-06-05T22:00:00Z
 draft: false
 ---
 
-## Listen On Demand
+## Listen Back
 {{< include_content "/shows/1/listen-again" >}}
 
 ---
@@ -83,15 +83,15 @@ draft: false
 
 ---
 
-## Featured band: The Big Now
+## Featured Artist
 {{< include_content "/shows/1/featured-guest" >}}
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/1/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/1/track-info" >}}

--- a/src/content/shows/10/index.md
+++ b/src/content/shows/10/index.md
@@ -82,10 +82,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/10/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/10/track-info" >}}

--- a/src/content/shows/11/index.md
+++ b/src/content/shows/11/index.md
@@ -80,10 +80,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/11/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/11/track-info" >}}

--- a/src/content/shows/12/index.md
+++ b/src/content/shows/12/index.md
@@ -82,10 +82,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/12/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/12/track-info" >}}

--- a/src/content/shows/13/index.md
+++ b/src/content/shows/13/index.md
@@ -78,10 +78,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/13/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/13/track-info" >}}

--- a/src/content/shows/14/index.md
+++ b/src/content/shows/14/index.md
@@ -82,10 +82,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/14/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/14/track-info" >}}

--- a/src/content/shows/15/index.md
+++ b/src/content/shows/15/index.md
@@ -88,10 +88,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/15/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/15/track-info" >}}

--- a/src/content/shows/18/index.md
+++ b/src/content/shows/18/index.md
@@ -88,10 +88,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/18/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/18/track-info" >}}

--- a/src/content/shows/19/index.md
+++ b/src/content/shows/19/index.md
@@ -80,10 +80,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/19/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/19/track-info" >}}

--- a/src/content/shows/2/index.md
+++ b/src/content/shows/2/index.md
@@ -68,7 +68,7 @@ date: 2024-06-12T22:00:00Z
 draft: false
 ---
 
-## Listen On Demand
+## Listen Back
 {{< include_content "/shows/2/listen-again" >}}
 
 ---
@@ -78,15 +78,15 @@ draft: false
 
 ---
 
-## Featured band: The Receiving End
+## Featured Artist
 {{< include_content "/shows/2/featured-guest" >}}
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/2/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/2/track-info" >}}

--- a/src/content/shows/20/index.md
+++ b/src/content/shows/20/index.md
@@ -76,10 +76,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/20/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/20/track-info" >}}

--- a/src/content/shows/3/index.md
+++ b/src/content/shows/3/index.md
@@ -68,7 +68,7 @@ date: 2024-06-19T22:00:00Z
 draft: true
 ---
 
-## Listen On Demand
+## Listen Back
 {{< include_content "/shows/3/listen-again" >}}
 
 ---
@@ -78,15 +78,15 @@ draft: true
 
 ---
 
-## Featured band: Blue On Shock
+## Featured Artist
 {{< include_content "/shows/3/featured-guest" >}}
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/3/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/3/track-info" >}}

--- a/src/content/shows/4/index.md
+++ b/src/content/shows/4/index.md
@@ -67,7 +67,7 @@ date: 2024-06-26T22:00:00Z
 draft: true
 ---
 
-## Listen On Demand
+## Listen Back
 {{< include_content "/shows/4/listen-again" >}}
 
 ---
@@ -82,10 +82,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/4/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/4/track-info" >}}

--- a/src/content/shows/5/index.md
+++ b/src/content/shows/5/index.md
@@ -62,7 +62,7 @@ date: 2024-07-17T22:00:00Z
 draft: true
 ---
 
-## Listen On Demand
+## Listen Back
 {{< include_content "/shows/5/listen-again" >}}
 
 ---
@@ -72,15 +72,15 @@ draft: true
 
 ---
 
-## Featured band: White China
+## Featured Artist
 {{< include_content "/shows/5/featured-guest" >}}
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/5/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/5/track-info" >}}

--- a/src/content/shows/6/index.md
+++ b/src/content/shows/6/index.md
@@ -72,10 +72,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/6/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/6/track-info" >}}

--- a/src/content/shows/7/index.md
+++ b/src/content/shows/7/index.md
@@ -82,10 +82,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/7/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/7/track-info" >}}

--- a/src/content/shows/8/index.md
+++ b/src/content/shows/8/index.md
@@ -84,10 +84,10 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/8/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/8/track-info" >}}

--- a/src/content/shows/9/index.md
+++ b/src/content/shows/9/index.md
@@ -77,11 +77,11 @@ draft: true
 
 ---
 
-## Show discussion points
+## Discussion
 {{< include_content "/shows/9/discussion-points" >}}
 
 ---
 
-## Track info
+## Tracks
 {{< include_content "/shows/9/track-info" >}}
 

--- a/src/layouts/partials/show/hero.html
+++ b/src/layouts/partials/show/hero.html
@@ -60,7 +60,7 @@
     {{ end }}
   {{ end }}
 {{ end }}
-{{ $hasListenOnDemand := or (in .RawContent "## Listen On Demand") (in .RawContent "/listen-again") }}
+{{ $hasListenOnDemand := or (or (in .RawContent "## Listen Back") (in .RawContent "## Listen On Demand")) (in .RawContent "/listen-again") }}
 
 <section class="show-hero mb-8 overflow-hidden rounded-2xl border border-neutral-200 bg-white/70 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/70" role="region" aria-labelledby="show-hero-heading">
   <div class="show-hero__layout">
@@ -86,7 +86,7 @@
         <p class="show-hero__teaser">{{ . }}</p>
       {{ end }}
       {{ if $hasListenOnDemand }}
-        <a class="show-hero__shortcut" href="#listen-on-demand">Listen on Demand</a>
+        <a class="show-hero__shortcut" href="#listen-back">Listen on Demand</a>
       {{ end }}
     </div>
   </div>

--- a/src/layouts/partials/show/listen-on-demand-card.html
+++ b/src/layouts/partials/show/listen-on-demand-card.html
@@ -1,17 +1,8 @@
 {{- $url := .url | default "" -}}
-{{- $copy := .copy | default "Missed the live broadcast? Listen back in full on Mixcloud whenever it suits you." -}}
-{{- $heading := .heading | default "Listen On Demand" -}}
-{{- $headingId := .headingId | default "show-listen-on-demand-heading" -}}
+{{- $copy := .copy | default "Missed the live broadcast? Listen back in full whenever it suits you." -}}
 
-<section class="show-listen-card not-prose" role="region" aria-labelledby="{{ $headingId }}">
+<section class="show-listen-card not-prose" role="region" aria-label="Listen back">
   <div class="show-listen-card__body">
-    <h2 id="{{ $headingId }}" class="show-listen-card__heading">
-      <span class="show-listen-card__icon" aria-hidden="true">
-        {{ partial "icon.html" "play" }}
-      </span>
-      <span>{{ $heading }}</span>
-    </h2>
-    <p class="show-listen-card__copy">{{ $copy }}</p>
     {{- with $url }}
       <a
         class="show-listen-card__button"
@@ -20,8 +11,12 @@
         data-analytics-provider="Mixcloud"
         target="_blank"
         rel="noopener noreferrer external">
-        Listen on Mixcloud
+        <span class="show-listen-card__button-icon" aria-hidden="true">
+          {{ partial "icon.html" "play" }}
+        </span>
+        <span>Play on Mixcloud</span>
       </a>
     {{- end }}
+    <p class="show-listen-card__copy">{{ $copy }}</p>
   </div>
 </section>

--- a/src/layouts/shortcodes/featured-guest-wikilink.html
+++ b/src/layouts/shortcodes/featured-guest-wikilink.html
@@ -1,3 +1,3 @@
 {{ $link := .Get 0 }}
 {{ $slug := .Get 0 | urlize }}
-<a href="{{ printf "%sshows/featuring-%s/#featured-band-%s" .Site.BaseURL $slug $slug | safeURL}}">{{ $link }}</a>
+<a href="{{ printf "%sshows/featuring-%s/#featured-artist" .Site.BaseURL $slug | safeURL}}">{{ $link }}</a>

--- a/src/layouts/shortcodes/track-info-featured-guest.html
+++ b/src/layouts/shortcodes/track-info-featured-guest.html
@@ -7,7 +7,7 @@
     {{ if ge (len $parts) 3 }}
         {{ with index $parts 2 | strings.TrimSpace }}{{ $trackUri = . }}{{ end }}
     {{ end }}
-    {{ $featuredGuestAnchor := printf "%sshows/featuring-%s/#featured-band-%s" $.Site.BaseURL ($artist | urlize) ($artist | urlize) | safeURL }}
+    {{ $featuredGuestAnchor := printf "%sshows/featuring-%s/#featured-artist" $.Site.BaseURL ($artist | urlize) | safeURL }}
     {{ $featuredGuestImageUri := printf "%s-large.jpeg" $artist | urlize }}
     <div style="display: flex; align-items: center;">
         <img src="{{ $featuredGuestImageUri }}" alt="" style="width: 20%; height: auto; margin-right: 10px;">

--- a/src/layouts/shows/single.html
+++ b/src/layouts/shows/single.html
@@ -11,6 +11,7 @@
       {{ if $showToc }}
         <div class="show-page-toc-column order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
           <div class="show-page-toc toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+            <p class="show-page-toc__heading hidden lg:block">On this page</p>
             {{ partial "toc.html" . }}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- rename individual show listen sections to Listen Back and simplify adjacent TOC labels
- update the listen card action to Play on Mixcloud while preserving graceful omission when no Mixcloud URL exists
- add an understated show-page "On this page" nav heading and proportionate divider styling
- update show-note generation and featured guest anchors for the new heading structure

## Verification
- Static searches confirmed old visible show headings and stale anchors were removed
- Not run: `hugo --environment production` because `hugo` is not installed/on PATH in this environment
- Not run: `dotnet test tests/SundownMedia.ContentOps.Application.Tests/SundownMedia.ContentOps.Application.Tests.csproj` because the pinned .NET SDK 10.0.100 is not installed in this environment
