### PR TITLE
fix(src): restore show listen back action

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -930,7 +930,8 @@
     ),
     color-mix(in srgb, var(--ss-color-surface) 92%, white);
   box-shadow: 0 1px 2px rgb(30 36 56 / 0.05);
-  padding: clamp(1.15rem, 3vw, 1.6rem);
+  padding: clamp(1rem, 2.5vw, 1.45rem);
+  transition: border-color 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
 }
 
 .dark .show-listen-card__body {
@@ -942,6 +943,30 @@
     ),
     color-mix(in srgb, var(--ss-color-surface) 90%, #171717);
   box-shadow: 0 12px 28px rgb(0 0 0 / 0.16);
+}
+
+.show-listen-card__body--link {
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.show-listen-card__body--link:hover,
+.show-listen-card__body--link:focus-visible {
+  border-color: color-mix(in srgb, var(--ss-color-primary-action) 32%, var(--ss-color-border));
+  box-shadow: 0 10px 24px rgb(30 36 56 / 0.11);
+  text-decoration: none;
+  transform: translateY(-0.08rem);
+}
+
+.show-listen-card__body--link:focus-visible {
+  outline: 2px solid var(--ss-color-focus);
+  outline-offset: 0.2rem;
+}
+
+.dark .show-listen-card__body--link:hover,
+.dark .show-listen-card__body--link:focus-visible {
+  box-shadow: 0 16px 34px rgb(0 0 0 / 0.24);
 }
 
 .show-listen-card__copy {
@@ -984,19 +1009,20 @@
   align-items: center;
   justify-content: center;
   margin-inline-end: 0.45rem;
+  transition: transform 0.16s ease;
 }
 
-.show-listen-card__button:hover,
-.show-listen-card__button:focus-visible {
+.show-listen-card__body--link:hover .show-listen-card__button,
+.show-listen-card__body--link:focus-visible .show-listen-card__button {
   border-color: color-mix(in srgb, var(--ss-color-primary-action) 58%, var(--ss-color-border));
   background: color-mix(in srgb, var(--ss-color-primary-action) 14%, var(--ss-color-surface));
   color: rgba(var(--color-primary-800), 1);
   text-decoration: none;
 }
 
-.show-listen-card__button:focus-visible {
-  outline: 2px solid var(--ss-color-focus);
-  outline-offset: 0.18rem;
+.show-listen-card__body--link:hover .show-listen-card__button-icon,
+.show-listen-card__body--link:focus-visible .show-listen-card__button-icon {
+  transform: translateX(0.12rem);
 }
 
 .dark .show-listen-card__button {
@@ -1004,9 +1030,23 @@
   color: rgba(var(--color-primary-400), 1);
 }
 
-.dark .show-listen-card__button:hover,
-.dark .show-listen-card__button:focus-visible {
+.dark .show-listen-card__body--link:hover .show-listen-card__button,
+.dark .show-listen-card__body--link:focus-visible .show-listen-card__button {
   color: rgba(var(--color-primary-300), 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .show-listen-card__body,
+  .show-listen-card__button-icon {
+    transition: none;
+  }
+
+  .show-listen-card__body--link:hover,
+  .show-listen-card__body--link:focus-visible,
+  .show-listen-card__body--link:hover .show-listen-card__button-icon,
+  .show-listen-card__body--link:focus-visible .show-listen-card__button-icon {
+    transform: none;
+  }
 }
 
 .show-page-toc__heading {

--- a/src/layouts/partials/show/listen-on-demand-card.html
+++ b/src/layouts/partials/show/listen-on-demand-card.html
@@ -1,22 +1,27 @@
 {{- $url := .url | default "" -}}
-{{- $copy := .copy | default "Missed the live broadcast? Listen back in full whenever it suits you." -}}
+{{- $copy := .copy | default "Missed the live broadcast? Listen back in full on Mixcloud whenever it suits you." -}}
 
 <section class="show-listen-card not-prose" role="region" aria-label="Listen back">
-  <div class="show-listen-card__body">
-    {{- with $url }}
-      <a
-        class="show-listen-card__button"
-        href="{{ . | safeURL }}"
-        data-analytics-event="listen_again_click"
-        data-analytics-provider="Mixcloud"
-        target="_blank"
-        rel="noopener noreferrer external">
-        <span class="show-listen-card__button-icon" aria-hidden="true">
+  {{- with $url }}
+    <a
+      class="show-listen-card__body show-listen-card__body--link"
+      href="{{ . | safeURL }}"
+      aria-label="Play this broadcast on Mixcloud"
+      data-analytics-event="listen_again_click"
+      data-analytics-provider="Mixcloud"
+      target="_blank"
+      rel="noopener noreferrer external">
+      <span class="show-listen-card__button" aria-hidden="true">
+        <span class="show-listen-card__button-icon">
           {{ partial "icon.html" "play" }}
         </span>
         <span>Play on Mixcloud</span>
-      </a>
-    {{- end }}
-    <p class="show-listen-card__copy">{{ $copy }}</p>
-  </div>
+      </span>
+      <p class="show-listen-card__copy">{{ $copy }}</p>
+    </a>
+  {{- else }}
+    <div class="show-listen-card__body">
+      <p class="show-listen-card__copy">{{ $copy }}</p>
+    </div>
+  {{- end }}
 </section>


### PR DESCRIPTION
## Summary
- make the show Listen Back card a full-card Mixcloud link when a broadcast URL exists
- restore a prominent `Play on Mixcloud` action without exposing raw URLs
- add restrained hover/focus styling, reduced-motion handling, and balanced fallback spacing

## Testing
- Not run: `hugo --environment production` could not be executed because `hugo` is not installed/on PATH in this environment.
- Static review of the changed Hugo partial and scoped CSS completed.