### PR TITLE
Polish individual show pages

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -911,7 +911,7 @@
 /* Individual show page: refined listen-back card and right-side section nav. */
 
 .show-listen-card {
-  max-width: 42rem;
+  max-width: 48rem;
   margin: 0 0 2.5rem;
   scroll-margin-top: 6rem;
 }
@@ -954,9 +954,9 @@
 .show-listen-card__body--link:hover,
 .show-listen-card__body--link:focus-visible {
   border-color: color-mix(in srgb, var(--ss-color-primary-action) 32%, var(--ss-color-border));
-  box-shadow: 0 10px 24px rgb(30 36 56 / 0.11);
+  box-shadow: 0 13px 30px rgb(30 36 56 / 0.13);
   text-decoration: none;
-  transform: translateY(-0.08rem);
+  transform: translateY(-0.1rem);
 }
 
 .show-listen-card__body--link:focus-visible {
@@ -970,7 +970,7 @@
 }
 
 .show-listen-card__copy {
-  max-width: 34rem;
+  max-width: 38rem;
   margin: 0;
   color: #525252; /* neutral-600 */
   font-size: 1rem;
@@ -1022,7 +1022,7 @@
 
 .show-listen-card__body--link:hover .show-listen-card__button-icon,
 .show-listen-card__body--link:focus-visible .show-listen-card__button-icon {
-  transform: translateX(0.12rem);
+  transform: translateX(0.16rem);
 }
 
 .dark .show-listen-card__button {
@@ -1050,7 +1050,7 @@
 }
 
 .show-page-toc__heading {
-  margin: 0 0 0.4rem;
+  margin: 0 0 0.1rem;
   color: #737373; /* neutral-500 */
   font-size: 0.78rem;
   font-weight: 750;
@@ -1080,8 +1080,50 @@
 }
 
 .show-page-toc #TableOfContents ul {
-  margin-top: 0.25rem;
+  margin-top: 0.15rem;
   margin-bottom: 0;
+}
+
+.show-page-main .article-content ol > li,
+.show-page-main .article-content ul > li {
+  margin-top: 0.38rem;
+  margin-bottom: 0.38rem;
+}
+
+.show-playlist-separator {
+  display: flex;
+  max-width: 36rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  margin: 1.05rem 0;
+  color: #737373; /* neutral-500 */
+  font-size: 0.78rem;
+  font-weight: 760;
+  letter-spacing: 0;
+  line-height: 1.4;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.show-playlist-separator::before,
+.show-playlist-separator::after {
+  width: min(5.5rem, 22%);
+  border-top: 1px solid color-mix(in srgb, var(--ss-color-border) 78%, transparent);
+  content: "";
+}
+
+.show-playlist-separator__detail {
+  color: #a3a3a3; /* neutral-400 */
+  font-weight: 650;
+}
+
+.dark .show-playlist-separator {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.dark .show-playlist-separator__detail {
+  color: #737373; /* neutral-500 */
 }
 
 .show-page-toc #TableOfContents li {

--- a/src/content/shows/1/index.md
+++ b/src/content/shows/1/index.md
@@ -78,7 +78,7 @@ draft: false
 
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/1/playlist" >}}
 
 ---

--- a/src/content/shows/10/index.md
+++ b/src/content/shows/10/index.md
@@ -72,7 +72,7 @@ date: 2024-08-21T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/10/playlist" >}}
 
 ---

--- a/src/content/shows/11/index.md
+++ b/src/content/shows/11/index.md
@@ -70,7 +70,7 @@ date: 2024-08-28T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/11/playlist" >}}
 
 ---

--- a/src/content/shows/12/index.md
+++ b/src/content/shows/12/index.md
@@ -72,7 +72,7 @@ date: 2024-09-25T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/12/playlist" >}}
 
 ---

--- a/src/content/shows/13/index.md
+++ b/src/content/shows/13/index.md
@@ -68,7 +68,7 @@ date: 2024-10-01T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/13/playlist" >}}
 
 ---

--- a/src/content/shows/14/index.md
+++ b/src/content/shows/14/index.md
@@ -72,7 +72,7 @@ date: 2024-10-08T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/14/playlist" >}}
 
 ---

--- a/src/content/shows/15/index.md
+++ b/src/content/shows/15/index.md
@@ -78,7 +78,7 @@ date: 2024-10-15T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/15/playlist" >}}
 
 ---

--- a/src/content/shows/18/index.md
+++ b/src/content/shows/18/index.md
@@ -78,7 +78,7 @@ date: 2024-11-05T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/18/playlist" >}}
 
 ---

--- a/src/content/shows/19/index.md
+++ b/src/content/shows/19/index.md
@@ -70,7 +70,7 @@ date: 2024-11-12T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/19/playlist" >}}
 
 ---

--- a/src/content/shows/2/index.md
+++ b/src/content/shows/2/index.md
@@ -73,7 +73,7 @@ draft: false
 
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/2/playlist" >}}
 
 ---

--- a/src/content/shows/20/index.md
+++ b/src/content/shows/20/index.md
@@ -66,7 +66,7 @@ date: 2024-11-19T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/20/playlist" >}}
 
 ---

--- a/src/content/shows/3/index.md
+++ b/src/content/shows/3/index.md
@@ -73,7 +73,7 @@ draft: true
 
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/3/playlist" >}}
 
 ---

--- a/src/content/shows/4/index.md
+++ b/src/content/shows/4/index.md
@@ -72,7 +72,7 @@ draft: true
 
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/4/playlist" >}}
 
 ---

--- a/src/content/shows/5/index.md
+++ b/src/content/shows/5/index.md
@@ -67,7 +67,7 @@ draft: true
 
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/5/playlist" >}}
 
 ---

--- a/src/content/shows/6/index.md
+++ b/src/content/shows/6/index.md
@@ -62,7 +62,7 @@ date: 2024-07-24T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/6/playlist" >}}
 
 ---

--- a/src/content/shows/7/index.md
+++ b/src/content/shows/7/index.md
@@ -72,7 +72,7 @@ date: 2024-07-31T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/7/playlist" >}}
 
 ---

--- a/src/content/shows/8/index.md
+++ b/src/content/shows/8/index.md
@@ -74,7 +74,7 @@ date: 2024-08-07T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/8/playlist" >}}
 
 ---

--- a/src/content/shows/9/index.md
+++ b/src/content/shows/9/index.md
@@ -67,7 +67,7 @@ date: 2024-08-14T22:00:00Z
 draft: true
 ---
 
-## Playlist
+## Broadcast Playlist
 {{< include_content "/shows/9/playlist" >}}
 
 ---

--- a/src/layouts/partials/show/listen-on-demand-card.html
+++ b/src/layouts/partials/show/listen-on-demand-card.html
@@ -6,7 +6,7 @@
     <a
       class="show-listen-card__body show-listen-card__body--link"
       href="{{ . | safeURL }}"
-      aria-label="Play this broadcast on Mixcloud"
+      aria-label="Play this Sundown Sessions broadcast on Mixcloud, opens in a new tab"
       data-analytics-event="listen_again_click"
       data-analytics-provider="Mixcloud"
       target="_blank"

--- a/src/layouts/shortcodes/broadcast-separator.html
+++ b/src/layouts/shortcodes/broadcast-separator.html
@@ -1,0 +1,8 @@
+{{- $label := .Get 0 | default "Broadcast Break" -}}
+{{- $detail := .Get 1 | default "" -}}
+<div class="show-playlist-separator" role="separator" aria-label="{{ $label }}">
+  <span class="show-playlist-separator__label">{{ $label }}</span>
+  {{- with $detail }}
+    <span class="show-playlist-separator__detail">{{ . }}</span>
+  {{- end }}
+</div>

--- a/src/layouts/shortcodes/include_content.html
+++ b/src/layouts/shortcodes/include_content.html
@@ -51,6 +51,39 @@
     {{ partial "show/listen-on-demand-card.html" (dict "url" $mixcloudURL "copy" $copy) }}
   {{ else }}
 
+  {{ if and (hasPrefix $path "shows/") (hasSuffix $path "/playlist") }}
+    {{ $lines := slice }}
+    {{ range split $content "\n" }}
+      {{ $line := . }}
+      {{ $trimmed := strings.TrimSpace $line }}
+      {{ $separatorLabel := "" }}
+      {{ $separatorDetail := "" }}
+
+      {{ if findRE `(?i)^-\s*advertising break\s*$` $trimmed }}
+        {{ $separatorLabel = "Advertising Break" }}
+      {{ else if findRE `(?i)^-\s*news\s*$` $trimmed }}
+        {{ $separatorLabel = "News" }}
+      {{ else if findRE `(?i)^--\s*adverts?\s*--?\s*(\[[^]]+\])?\s*$` $trimmed }}
+        {{ $separatorLabel = "Advertising Break" }}
+        {{ $separatorDetail = strings.TrimSpace (replaceRE `(?i)^--\s*adverts?\s*--?\s*(\[[^]]+\])?\s*$` "$1" $trimmed) }}
+      {{ else if findRE `(?i)^--\s*news\s*--?\s*(\[[^]]+\])?\s*$` $trimmed }}
+        {{ $separatorLabel = "News" }}
+        {{ $separatorDetail = strings.TrimSpace (replaceRE `(?i)^--\s*news\s*--?\s*(\[[^]]+\])?\s*$` "$1" $trimmed) }}
+      {{ end }}
+
+      {{ if $separatorLabel }}
+        {{ if $separatorDetail }}
+          {{ $line = printf `{{< broadcast-separator "%s" "%s" >}}` $separatorLabel $separatorDetail }}
+        {{ else }}
+          {{ $line = printf `{{< broadcast-separator "%s" >}}` $separatorLabel }}
+        {{ end }}
+      {{ end }}
+
+      {{ $lines = $lines | append $line }}
+    {{ end }}
+    {{ $content = delimit $lines "\n" }}
+  {{ end }}
+
   {{ $forSaleTracks := slice }}
   {{ with $includedPage }}
     {{ with (.Params.forSaleTracks | default .Params.for_sale_tracks) }}

--- a/src/layouts/shows/single.html
+++ b/src/layouts/shows/single.html
@@ -12,7 +12,7 @@
         <div class="show-page-toc-column order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
           <div class="show-page-toc toc ps-5 print:hidden lg:sticky {{ $topClass }}">
             <p class="show-page-toc__heading hidden lg:block">On this page</p>
-            {{ partial "toc.html" . }}
+            {{ partial "toc.html" . | replaceRE ">Broadcast Playlist<" ">Playlist<" | safeHTML }}
           </div>
         </div>
       {{ end }}


### PR DESCRIPTION
## Summary
- make the Listen Back card feel more primary and interactive while keeping the whole card accessible as the Mixcloud link
- rename show playlist headings to Broadcast Playlist while keeping the side navigation concise
- render advertising/news playlist markers as broadcast separators and refine playlist/TOC spacing

## Verification
- Not run: \hugo --environment production\ because Hugo is not installed/on PATH in this environment.