### PR TITLE
Polish individual show pages

### DIFF
--- a/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ShowNotes/CreateFrontmatter/ShowNotesFrontmatterBuilder.cs
+++ b/automation/dotnet/src/SundownMedia.ContentOps.Application/Features/ShowNotes/CreateFrontmatter/ShowNotesFrontmatterBuilder.cs
@@ -62,7 +62,7 @@ namespace SundownMedia.ContentOps.Application.Features.ShowNotes.CreateFrontmatt
             sb.AppendLine();
             sb.AppendLine("---");
             sb.AppendLine();
-            sb.AppendLine("## Featured Artist");
+            sb.AppendLine("## Artist Spotlight");
             sb.AppendLine(CultureInfo.InvariantCulture, $"{{{{< include_content \"/shows/{command.ShowNumber}/featured-guest\" >}}}}");
             sb.AppendLine();
             sb.AppendLine("---");

--- a/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/CreateShowNotesFrontmatterCommandHandlerTests.cs
+++ b/automation/dotnet/tests/SundownMedia.ContentOps.Application.Tests/CreateShowNotesFrontmatterCommandHandlerTests.cs
@@ -219,7 +219,7 @@ public sealed class CreateShowNotesFrontmatterCommandHandlerTests
         content.Should().Contain("tags:");
         content.Should().Contain("## Listen Back");
         content.Should().Contain("## Playlist");
-        content.Should().Contain("## Featured Artist");
+        content.Should().Contain("## Artist Spotlight");
         content.Should().Contain("## Discussion");
         content.Should().Contain("## Tracks");
         content.Should().Contain("{{< include_content \"/shows/1/listen-again\" >}}");

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -824,8 +824,8 @@
 .show-hero__teaser {
   color: #525252; /* neutral-600 */
   font-size: 1rem;
-  font-weight: 650;
-  line-height: 1.45;
+  font-weight: 400;
+  line-height: 1.65;
 }
 
 .dark .show-hero__date,
@@ -836,7 +836,7 @@
 .show-hero__teaser {
   max-width: 44rem;
   color: #737373; /* neutral-500 */
-  font-style: italic;
+  font-style: normal;
 }
 
 .dark .show-hero__teaser {
@@ -1135,6 +1135,77 @@
 .show-page-toc #TableOfContents a {
   display: inline-block;
   padding-block: 0.08rem;
+}
+
+.show-artist-spotlight {
+  max-width: 48rem;
+  margin: 0 0 2.5rem;
+}
+
+.show-artist-spotlight__card {
+  overflow: hidden;
+  border: 1px solid var(--ss-color-border);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--ss-color-surface) 92%, white);
+  box-shadow: 0 1px 2px rgb(30 36 56 / 0.05);
+}
+
+.dark .show-artist-spotlight__card {
+  background: color-mix(in srgb, var(--ss-color-surface) 90%, #171717);
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.16);
+}
+
+.show-artist-spotlight__body {
+  padding: clamp(1rem, 2.5vw, 1.45rem);
+}
+
+.show-artist-spotlight__body > :first-child {
+  margin-top: 0;
+}
+
+.show-artist-spotlight__body > :last-child {
+  margin-bottom: 0;
+}
+
+.show-artist-spotlight__body figure {
+  margin: 0 0 1.25rem;
+}
+
+.show-artist-spotlight__body figure img {
+  width: min(100%, 32rem);
+  border-radius: 0.5rem;
+}
+
+.show-artist-spotlight__body figcaption {
+  color: #737373; /* neutral-500 */
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.dark .show-artist-spotlight__body figcaption {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.show-artist-spotlight__links {
+  margin: 0;
+  border-top: 1px solid var(--ss-color-border);
+  padding: clamp(1rem, 2.5vw, 1.25rem) clamp(1rem, 2.5vw, 1.45rem) clamp(1rem, 2.5vw, 1.45rem);
+}
+
+.show-artist-spotlight__links h2 {
+  margin: 0 0 0.85rem;
+  color: #262626; /* neutral-800 */
+  font-size: 1.05rem;
+  font-weight: 750;
+  line-height: 1.35;
+}
+
+.dark .show-artist-spotlight__links h2 {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.show-artist-spotlight__links ul {
+  border-radius: 0.5rem;
 }
 
 @media (min-width: 1024px) {

--- a/src/content/shows/1/index.md
+++ b/src/content/shows/1/index.md
@@ -83,7 +83,7 @@ draft: false
 
 ---
 
-## Featured Artist
+## Artist Spotlight
 {{< include_content "/shows/1/featured-guest" >}}
 
 ---

--- a/src/content/shows/2/index.md
+++ b/src/content/shows/2/index.md
@@ -78,7 +78,7 @@ draft: false
 
 ---
 
-## Featured Artist
+## Artist Spotlight
 {{< include_content "/shows/2/featured-guest" >}}
 
 ---

--- a/src/content/shows/3/index.md
+++ b/src/content/shows/3/index.md
@@ -78,7 +78,7 @@ draft: true
 
 ---
 
-## Featured Artist
+## Artist Spotlight
 {{< include_content "/shows/3/featured-guest" >}}
 
 ---

--- a/src/content/shows/5/index.md
+++ b/src/content/shows/5/index.md
@@ -72,7 +72,7 @@ draft: true
 
 ---
 
-## Featured Artist
+## Artist Spotlight
 {{< include_content "/shows/5/featured-guest" >}}
 
 ---

--- a/src/layouts/shortcodes/include_content.html
+++ b/src/layouts/shortcodes/include_content.html
@@ -50,6 +50,76 @@
     {{ end }}
     {{ partial "show/listen-on-demand-card.html" (dict "url" $mixcloudURL "copy" $copy) }}
   {{ else }}
+  {{ if and (hasPrefix $path "shows/") (hasSuffix $path "/featured-guest") }}
+    {{ $skipSection := false }}
+    {{ $spotlightLines := slice }}
+    {{ $spotlightLinks := slice }}
+    {{ $linkPattern := `\[(.*?)\]\((https?://[^)]+)\)` }}
+
+    {{ range split $content "\n" }}
+      {{ $line := . }}
+      {{ $trimmed := strings.TrimSpace $line }}
+      {{ $plainHeading := $trimmed | replaceRE `^#+\s*` "" | replaceRE `\*\*` "" | strings.TrimSpace }}
+      {{ $plainHeadingLower := lower $plainHeading }}
+      {{ $isContactHeading := or (eq $plainHeadingLower "contact details") (eq $plainHeadingLower "contact detail") }}
+      {{ $isSocialHeading := or (eq $plainHeadingLower "social media") (eq $plainHeadingLower "social links") }}
+      {{ $isSkippedHeading := or $isContactHeading $isSocialHeading }}
+      {{ $isHeading := hasPrefix $trimmed "###" }}
+
+      {{ if $isSkippedHeading }}
+        {{ $skipSection = true }}
+      {{ else }}
+        {{ if and $skipSection $isHeading }}
+          {{ $skipSection = false }}
+        {{ end }}
+
+        {{ if $skipSection }}
+          {{ range findRESubmatch $linkPattern $line }}
+            {{ $label := index . 1 | strings.TrimSpace }}
+            {{ $url := index . 2 | strings.TrimSpace }}
+            {{ $prefix := $line | replaceRE `(?s)\[.*$` "" | replaceRE `^\s*-\s*` "" | replaceRE `\{\{<\s*new-tab-link\s+"?` "" | replaceRE `\*\*` "" | replaceRE `:` "" | strings.TrimSpace }}
+            {{ if or (eq $label "") (hasPrefix $label "http") }}
+              {{ $label = $prefix | default "Official Website" }}
+            {{ end }}
+            {{ $labelLower := lower $label }}
+            {{ if eq $labelLower "website" }}
+              {{ $label = "Official Website" }}
+              {{ $labelLower = "official website" }}
+            {{ end }}
+            {{ $icon := "link" }}
+            {{ if in $labelLower "website" }}{{ $icon = "globe" }}{{ end }}
+            {{ if in $labelLower "facebook" }}{{ $icon = "facebook" }}{{ end }}
+            {{ if in $labelLower "instagram" }}{{ $icon = "instagram" }}{{ end }}
+            {{ if or (in $labelLower "twitter") (eq $labelLower "x") }}{{ $icon = "x-twitter" }}{{ end }}
+            {{ if in $labelLower "youtube" }}{{ $icon = "youtube" }}{{ end }}
+            {{ if in $labelLower "linkedin" }}{{ $icon = "linkedin" }}{{ end }}
+            {{ if in $labelLower "bandcamp" }}{{ $icon = "music" }}{{ end }}
+            {{ if in $labelLower "spotify" }}{{ $icon = "spotify" }}{{ end }}
+            {{ $spotlightLinks = $spotlightLinks | append (dict "label" $label "url" $url "icon" $icon) }}
+          {{ end }}
+        {{ else if not (or (findRE `(?i)contact details|social media|social media links` $trimmed) (findRE `^-\s*~~` $trimmed)) }}
+          {{ $spotlightLines = $spotlightLines | append $line }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{ $content = delimit $spotlightLines "\n" | strings.TrimSpace }}
+    <div class="show-artist-spotlight not-prose">
+      <div class="show-artist-spotlight__card">
+        <div class="show-artist-spotlight__body prose max-w-none leading-relaxed dark:prose-invert">
+          {{ $.Page.RenderString $content }}
+        </div>
+        {{ partial "components/explore-further.html" (dict
+          "links" $spotlightLinks
+          "heading" "Explore Further"
+          "headingId" "show-artist-spotlight-explore-heading"
+          "sectionClass" "show-artist-spotlight__links not-prose"
+          "rowClass" "explore-further__row"
+          "iconClass" "explore-further__icon"
+        ) }}
+      </div>
+    </div>
+  {{ else }}
 
   {{ if and (hasPrefix $path "shows/") (hasSuffix $path "/playlist") }}
     {{ $lines := slice }}
@@ -137,5 +207,6 @@
   {{ end }}
 
   {{ $.Page.RenderString $content }}
+  {{ end }}
   {{ end }}
 {{ end }}

--- a/src/layouts/shows/single.html
+++ b/src/layouts/shows/single.html
@@ -12,7 +12,7 @@
         <div class="show-page-toc-column order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
           <div class="show-page-toc toc ps-5 print:hidden lg:sticky {{ $topClass }}">
             <p class="show-page-toc__heading hidden lg:block">On this page</p>
-            {{ partial "toc.html" . | replaceRE ">Broadcast Playlist<" ">Playlist<" | safeHTML }}
+            {{ partial "toc.html" . | replaceRE ">Broadcast Playlist<" ">Playlist<" | replaceRE ">Featured Artist<" ">Artist Spotlight<" | safeHTML }}
           </div>
         </div>
       {{ end }}


### PR DESCRIPTION
## Summary
- rename the show-page feature section to Artist Spotlight, including TOC handling and generated show notes
- consolidate featured-guest contact/social links into a single Explore Further area inside a scoped spotlight card
- refine show hero teaser typography and keep broadcast separators visually distinct

## Verification
- `git diff --check` passed, with existing line-ending warnings only
- Could not run `hugo --environment production`: Hugo is not installed on PATH in this environment
- Could not run `dotnet test SundownMedia.ContentOps.sln --configuration Release`: pinned .NET SDK 10.0.100 is not installed