### PR TITLE
Refine Track Guide layout

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1129,8 +1129,8 @@
 
 .show-track-guide {
   display: grid;
-  gap: 1rem;
-  max-width: 60rem;
+  gap: 0.95rem;
+  max-width: 64rem;
   margin: 1.25rem 0 2.5rem;
 }
 
@@ -1148,7 +1148,7 @@
 
 .show-track-guide__list {
   display: grid;
-  gap: 0.85rem;
+  gap: 0.7rem;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -1156,32 +1156,32 @@
 
 .show-track-guide__item {
   display: grid;
-  grid-template-columns: 2.6rem minmax(0, 1fr);
-  gap: 0.85rem;
+  grid-template-columns: 2.35rem minmax(0, 1fr);
+  gap: 0.8rem;
   align-items: start;
   border: 1px solid #e5e5e5; /* neutral-200 */
   border-radius: 0.5rem;
-  background: rgba(250, 250, 250, 0.78); /* neutral-50/78 */
-  padding: 1rem;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+  background: rgba(250, 250, 250, 0.58); /* neutral-50/58 */
+  padding: clamp(0.85rem, 2.4vw, 1.05rem);
+  box-shadow: none;
 }
 
 .dark .show-track-guide__item {
   border-color: #404040; /* neutral-700 */
-  background: rgba(23, 23, 23, 0.68); /* neutral-900/68 */
-  box-shadow: 0 10px 24px rgb(0 0 0 / 0.16);
+  background: rgba(23, 23, 23, 0.48); /* neutral-900/48 */
+  box-shadow: none;
 }
 
 .show-track-guide__number {
   display: grid;
-  width: 2.15rem;
-  height: 2.15rem;
+  width: 2rem;
+  height: 2rem;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--ss-color-sunset) 36%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ss-color-sunset) 28%, transparent);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--ss-color-sunset) 10%, #ffffff);
+  background: color-mix(in srgb, var(--ss-color-sunset) 7%, #ffffff);
   color: var(--ss-color-midnight);
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 850;
   font-variant-numeric: tabular-nums;
   line-height: 1;
@@ -1193,21 +1193,16 @@
   color: #f5f5f5; /* neutral-100 */
 }
 
-.show-track-guide__body,
-.show-track-guide__main {
-  display: grid;
-  min-width: 0;
-}
-
 .show-track-guide__body {
-  gap: 0.85rem;
+  display: grid;
+  grid-template-columns: 5rem minmax(0, 1fr);
+  gap: 0.7rem 0.95rem;
+  min-width: 0;
+  align-items: start;
 }
 
-.show-track-guide__main {
-  gap: 0.6rem;
-}
-
-.show-track-guide__title {
+.show-track-guide__identity {
+  display: contents;
   margin: 0;
   color: #171717; /* neutral-900 */
   font-size: 1.05rem;
@@ -1215,26 +1210,74 @@
   line-height: 1.35;
 }
 
-.dark .show-track-guide__title {
+.dark .show-track-guide__identity {
   color: #f5f5f5; /* neutral-100 */
 }
 
-.show-track-guide__title div {
-  display: grid !important;
-  grid-template-columns: 3.4rem minmax(0, 1fr);
-  gap: 0.8rem;
-  align-items: center !important;
+.show-track-guide__identity > div {
+  display: contents !important;
 }
 
-.show-track-guide__title img {
-  width: 3.4rem !important;
-  height: 3.4rem !important;
+.show-track-guide__identity img {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  width: 5rem !important;
+  height: 5rem !important;
   margin: 0 !important;
-  border-radius: 0.35rem;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.4rem;
   object-fit: cover;
 }
 
-.show-track-guide__title a,
+.dark .show-track-guide__identity img {
+  border-color: #404040; /* neutral-700 */
+}
+
+.show-track-guide__identity > div > div {
+  grid-column: 2;
+  min-width: 0;
+  align-self: end;
+  color: #525252; /* neutral-600 */
+  font-size: 0.94rem;
+  font-weight: 650;
+  line-height: 1.45;
+  overflow-wrap: break-word;
+}
+
+.dark .show-track-guide__identity > div > div {
+  color: #d4d4d4; /* neutral-300 */
+}
+
+.show-track-guide .track-title__name {
+  display: inline;
+  color: #171717; /* neutral-900 */
+  font-size: 1.06rem;
+  font-weight: 800;
+  line-height: 1.32;
+}
+
+.show-track-guide .track-title__name a {
+  color: inherit;
+  text-decoration-color: color-mix(in srgb, currentColor 28%, transparent);
+}
+
+.dark .show-track-guide .track-title__name {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.show-track-guide .track-title__artist {
+  display: inline-block;
+  margin-top: 0.12rem;
+}
+
+.show-track-guide__details {
+  display: grid;
+  grid-column: 2;
+  gap: 0.72rem;
+  min-width: 0;
+}
+
+.show-track-guide__identity a,
 .show-track-guide__meta a,
 .show-track-guide__context-copy a {
   color: var(--ss-color-link);
@@ -1243,8 +1286,8 @@
   text-underline-offset: 0.16rem;
 }
 
-.show-track-guide__title a:hover,
-.show-track-guide__title a:focus-visible,
+.show-track-guide__identity a:hover,
+.show-track-guide__identity a:focus-visible,
 .show-track-guide__meta a:hover,
 .show-track-guide__meta a:focus-visible,
 .show-track-guide__context-copy a:hover,
@@ -1256,20 +1299,20 @@
 .show-track-guide__meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.45rem 1rem;
+  gap: 0.35rem 0.8rem;
   margin: 0;
 }
 
 .show-track-guide__meta div {
   display: flex;
   min-width: 0;
-  gap: 0.35rem;
+  gap: 0.4rem;
   align-items: baseline;
 }
 
 .show-track-guide__meta dt {
   color: #737373; /* neutral-500 */
-  font-size: 0.76rem;
+  font-size: 0.72rem;
   font-weight: 750;
   line-height: 1.45;
   text-transform: uppercase;
@@ -1283,7 +1326,7 @@
   min-width: 0;
   margin: 0;
   color: #525252; /* neutral-600 */
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   font-weight: 620;
   line-height: 1.45;
 }
@@ -1294,9 +1337,10 @@
 
 .show-track-guide__context {
   display: grid;
-  gap: 0.28rem;
-  border-left: 3px solid color-mix(in srgb, var(--ss-color-sunset) 42%, transparent);
-  padding-left: 0.8rem;
+  gap: 0.3rem;
+  max-width: 56ch;
+  border-left: 2px solid color-mix(in srgb, var(--ss-color-sunset) 34%, transparent);
+  padding-left: 0.75rem;
 }
 
 .dark .show-track-guide__context {
@@ -1306,7 +1350,7 @@
 .show-track-guide__context-label {
   margin: 0;
   color: var(--ss-color-midnight);
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   font-weight: 820;
   line-height: 1.35;
   text-transform: uppercase;
@@ -1320,13 +1364,53 @@
 .show-track-guide__context-copy p {
   margin: 0;
   color: #404040; /* neutral-700 */
-  font-size: 0.95rem;
+  font-size: 0.94rem;
   line-height: 1.65;
 }
 
 .dark .show-track-guide__context-copy,
 .dark .show-track-guide__context-copy p {
   color: #d4d4d4; /* neutral-300 */
+}
+
+@media (min-width: 640px) {
+  .show-track-guide__item {
+    grid-template-columns: 2.5rem minmax(0, 1fr);
+    gap: 0.95rem;
+  }
+
+  .show-track-guide__body {
+    grid-template-columns: 5.5rem minmax(0, 1fr);
+    gap: 0.75rem 1.1rem;
+  }
+
+  .show-track-guide__identity img {
+    width: 5.5rem !important;
+    height: 5.5rem !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .show-track-guide__item {
+    grid-template-columns: 2rem minmax(0, 1fr);
+    gap: 0.65rem;
+  }
+
+  .show-track-guide__body {
+    grid-template-columns: 4.5rem minmax(0, 1fr);
+    gap: 0.65rem 0.75rem;
+  }
+
+  .show-track-guide__identity img {
+    width: 4.5rem !important;
+    height: 4.5rem !important;
+  }
+
+  .show-track-guide__number {
+    width: 1.8rem;
+    height: 1.8rem;
+    font-size: 0.72rem;
+  }
 }
 
 .show-page-toc #TableOfContents li {

--- a/src/layouts/partials/show/track-guide.html
+++ b/src/layouts/partials/show/track-guide.html
@@ -35,31 +35,23 @@
         <li class="show-track-guide__item" value="{{ .number }}">
           <div class="show-track-guide__number" aria-hidden="true">{{ .number }}</div>
           <div class="show-track-guide__body">
-            <div class="show-track-guide__main">
-              <div class="show-track-guide__title" role="heading" aria-level="3">{{ $page.RenderString .title }}</div>
-              {{ if or .album .duration }}
+            <div class="show-track-guide__identity" role="heading" aria-level="3">{{ $page.RenderString .title }}</div>
+            <div class="show-track-guide__details">
+              {{ with .album }}
                 <dl class="show-track-guide__meta">
-                  {{ with .album }}
-                    <div>
-                      <dt>Release</dt>
-                      <dd>{{ $page.RenderString . }}</dd>
-                    </div>
-                  {{ end }}
-                  {{ with .duration }}
-                    <div>
-                      <dt>Duration</dt>
-                      <dd>{{ . }}</dd>
-                    </div>
-                  {{ end }}
+                  <div>
+                    <dt>Release</dt>
+                    <dd>{{ $page.RenderString . }}</dd>
+                  </div>
                 </dl>
               {{ end }}
+              {{ with .notes }}
+                <div class="show-track-guide__context">
+                  <p class="show-track-guide__context-label">Why It Mattered</p>
+                  <div class="show-track-guide__context-copy">{{ $page.RenderString . }}</div>
+                </div>
+              {{ end }}
             </div>
-            {{ with .notes }}
-              <div class="show-track-guide__context">
-                <p class="show-track-guide__context-label">Why it mattered</p>
-                <div class="show-track-guide__context-copy">{{ $page.RenderString . }}</div>
-              </div>
-            {{ end }}
           </div>
         </li>
       {{ end }}

--- a/src/layouts/shortcodes/title.html
+++ b/src/layouts/shortcodes/title.html
@@ -21,11 +21,11 @@
     {{ $trackSlug := $track | urlize }}
     {{ $trackPage := $.Site.GetPage (printf "tracks/%s/%s/%s" $artistFirstChar $artistSlug $trackSlug) }}
     <div style="display: flex; align-items: center;">
-        <img src="{{ $releaseUri }}" alt="" style="width: 20%; height: auto; margin-right: 10px;">
+        <img src="{{ $releaseUri }}" alt="" loading="lazy" style="width: 20%; height: auto; margin-right: 10px;">
         <div>
-            {{ if $trackPage }}<a href="{{ $trackPage.Permalink }}">{{ $track }}</a>{{ else if $trackUri }}<a href="{{ $trackUri }}">{{ $track }}</a>{{ else }}{{ $track }}{{ end }}
+            <span class="track-title__name">{{ if $trackPage }}<a href="{{ $trackPage.Permalink }}">{{ $track }}</a>{{ else if $trackUri }}<a href="{{ $trackUri }}">{{ $track }}</a>{{ else }}{{ $track }}{{ end }}</span>
             <br>
-            <a href="{{ $artistUri }}">{{ $artist }}</a>
+            <span class="track-title__artist"><a href="{{ $artistUri }}">{{ $artist }}</a></span>
         </div>
     </div>
 {{ end }}

--- a/src/layouts/shortcodes/track-info-featured-guest.html
+++ b/src/layouts/shortcodes/track-info-featured-guest.html
@@ -10,11 +10,11 @@
     {{ $featuredGuestAnchor := printf "%sshows/featuring-%s/#featured-artist" $.Site.BaseURL ($artist | urlize) | safeURL }}
     {{ $featuredGuestImageUri := printf "%s-large.jpeg" $artist | urlize }}
     <div style="display: flex; align-items: center;">
-        <img src="{{ $featuredGuestImageUri }}" alt="" style="width: 20%; height: auto; margin-right: 10px;">
+        <img src="{{ $featuredGuestImageUri }}" alt="" loading="lazy" style="width: 20%; height: auto; margin-right: 10px;">
         <div>
-            {{ if $trackUri }}<a href="{{ $trackUri }}">{{ $track }}</a>{{ else }}{{ $track }}{{ end }}
+            <span class="track-title__name">{{ if $trackUri }}<a href="{{ $trackUri }}">{{ $track }}</a>{{ else }}{{ $track }}{{ end }}</span>
             <br>
-            <a href="{{ $featuredGuestAnchor }}">{{ $artist }}</a>
+            <span class="track-title__artist"><a href="{{ $featuredGuestAnchor }}">{{ $artist }}</a></span>
         </div>
     </div>
 {{ end }}


### PR DESCRIPTION
## Summary
- rework Track Guide rows into a calmer media/editorial layout
- enlarge artwork and improve title/artist wrapping with scoped shortcode hooks
- remove visible duration while preserving parsed data and release discovery links

## Testing
- Not run: Hugo is not installed/on PATH in this environment