### PR TITLE
Restore footer social links

### DIFF
--- a/src/config/_default/menus.toml
+++ b/src/config/_default/menus.toml
@@ -6,29 +6,8 @@
   weight = 10
 
 [[footer]]
-  identifier = "mixcloud"
-  name = "Mixcloud"
-  title = "Sundown Sessions on Mixcloud"
-  url = "https://www.mixcloud.com/sundownsessions/"
-  weight = 20
-
-[[footer]]
-  identifier = "instagram"
-  name = "Instagram"
-  title = "Sundown Sessions on Instagram"
-  url = "https://www.instagram.com/sundownsessionsshow"
-  weight = 30
-
-[[footer]]
-  identifier = "facebook"
-  name = "Facebook"
-  title = "Sundown Sessions on Facebook"
-  url = "https://www.facebook.com/sundownsessionsuk"
-  weight = 40
-
-[[footer]]
   identifier = "contact"
   name = "Contact"
   title = "Get in touch with the show."
   url = "/contact/"
-  weight = 50
+  weight = 20

--- a/src/config/_default/params.toml
+++ b/src/config/_default/params.toml
@@ -172,8 +172,9 @@ headerAvatar = "/images/sundown-sessions-logo.jpg"
     { facebook = "https://www.facebook.com/sundownsessionsuk" },
     { instagram = "https://www.instagram.com/sundownsessionsshow" },
     { tiktok = "https://www.tiktok.com/@sundownsessionsshow" },
+    { mixcloud = "https://www.mixcloud.com/sundownsessions/" },
     { pinterest = "https://www.pinterest.co.uk/sundownsessionsshow/" },
-    { twitter = "https://x.com/sundown_session" },
+    { "x-twitter" = "https://x.com/sundown_session" },
     { mastodon = "https://mastodon.scot/@sundown_sessions" },
     { linkedin = "https://www.linkedin.com/in/colingourlay" },
   ]

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -41,6 +41,43 @@
       </nav>
     {{ end }}
   {{ end }}
+  {{ with .Site.Params.Author.links }}
+    {{ $socialLabels := dict
+      "facebook" "Facebook"
+      "instagram" "Instagram"
+      "tiktok" "TikTok"
+      "mixcloud" "Mixcloud"
+      "pinterest" "Pinterest"
+      "x-twitter" "X"
+      "mastodon" "Mastodon"
+      "linkedin" "LinkedIn"
+    }}
+    <nav class="pb-5" aria-label="Sundown Sessions social links">
+      <ul class="flex list-none flex-wrap justify-center gap-4 p-0 sm:justify-start">
+        {{ range $links := . }}
+          {{ range $name, $url := $links }}
+            {{ $isEmail := eq $name "email" }}
+            {{ $label := index $socialLabels $name | default ($name | title) }}
+            <li class="flex">
+              <a
+                class="{{ cond $isEmail "email-link" "" }} text-neutral-500 transition hover:text-primary-700 dark:text-neutral-400 dark:hover:text-primary-400"
+                href="{{ cond $isEmail "#" ($url | safeURL) }}"
+                {{ if $isEmail }}
+                  data-email="{{ $url | base64Encode }}"
+                {{ else }}
+                  target="_blank"
+                {{ end }}
+                aria-label="Follow Sundown Sessions on {{ $label }}"
+                title="Follow Sundown Sessions on {{ $label }}"
+                rel="me noopener noreferrer">
+                <span class="inline-block align-text-bottom">{{ partial "icon.html" $name }}</span>
+              </a>
+            </li>
+          {{ end }}
+        {{ end }}
+      </ul>
+    </nav>
+  {{ end }}
   <div class="flex flex-col items-center justify-between gap-2 text-center sm:flex-row sm:text-left">
     {{/* Copyright */}}
     {{ if .Site.Params.footer.showCopyright | default true }}


### PR DESCRIPTION
## Summary
- render footer social icons from Blowfish author links
- add Mixcloud to the canonical author social links and use the Blowfish X icon key
- keep the footer menu focused on navigation to avoid duplicate social text links

## Validation
- git diff --check
- curl.exe link checks returned 200 for Facebook, Instagram, TikTok, Mixcloud, Pinterest, X, and Mastodon
- LinkedIn returned 999, consistent with LinkedIn bot blocking

Closes #480