### PR TITLE
Polish show track guide presentation

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1162,7 +1162,7 @@
   border: 1px solid #e5e5e5; /* neutral-200 */
   border-radius: 0.5rem;
   background: rgba(250, 250, 250, 0.58); /* neutral-50/58 */
-  padding: clamp(0.85rem, 2.4vw, 1.05rem);
+  padding: clamp(0.5rem, 1.8vw, 0.65rem) clamp(0.72rem, 2.2vw, 0.9rem);
   box-shadow: none;
 }
 
@@ -1174,22 +1174,22 @@
 
 .show-track-guide__number {
   display: grid;
-  width: 1.9rem;
-  height: 1.9rem;
+  width: 1.75rem;
+  height: 1.75rem;
   place-items: center;
-  border: 0.8px solid color-mix(in srgb, var(--ss-color-sunset) 20%, transparent);
+  border: 0.7px solid color-mix(in srgb, var(--ss-color-sunset) 16%, transparent);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--ss-color-sunset) 4%, #ffffff);
+  background: color-mix(in srgb, var(--ss-color-sunset) 3%, #ffffff);
   color: var(--ss-color-midnight);
-  font-size: 0.74rem;
+  font-size: 0.7rem;
   font-weight: 760;
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 
 .dark .show-track-guide__number {
-  border-color: color-mix(in srgb, var(--ss-color-golden-hour) 28%, transparent);
-  background: color-mix(in srgb, var(--ss-color-golden-hour) 8%, #171717);
+  border-color: color-mix(in srgb, var(--ss-color-golden-hour) 22%, transparent);
+  background: color-mix(in srgb, var(--ss-color-golden-hour) 6%, #171717);
   color: #f5f5f5; /* neutral-100 */
 }
 
@@ -1320,41 +1320,25 @@
 }
 
 .show-track-guide__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem 0.8rem;
   margin: 0;
-}
-
-.show-track-guide__meta div {
-  display: flex;
   min-width: 0;
-  gap: 0.4rem;
-  align-items: baseline;
-}
-
-.show-track-guide__meta dt {
-  color: #858585; /* neutral-500/400 */
-  font-size: 0.68rem;
-  font-weight: 560;
-  line-height: 1.45;
-}
-
-.dark .show-track-guide__meta dt {
-  color: #a3a3a3; /* neutral-400 */
-}
-
-.show-track-guide__meta dd {
-  min-width: 0;
-  margin: 0;
   color: #525252; /* neutral-600 */
   font-size: 0.9rem;
   font-weight: 620;
   line-height: 1.45;
 }
 
-.dark .show-track-guide__meta dd {
+.dark .show-track-guide__meta {
   color: #d4d4d4; /* neutral-300 */
+}
+
+.show-track-guide .for-sale-badge {
+  margin-left: 0.34rem;
+  border-width: 0.8px;
+  padding: 0.08rem 0.42rem;
+  font-size: 0.65rem;
+  font-weight: 680;
+  line-height: 1.32;
 }
 
 .show-track-guide__context {
@@ -1369,7 +1353,6 @@
   font-size: 0.76rem;
   font-weight: 820;
   line-height: 1.35;
-  text-transform: uppercase;
 }
 
 .dark .show-track-guide__context-label {
@@ -1425,9 +1408,9 @@
   }
 
   .show-track-guide__number {
-    width: 1.7rem;
-    height: 1.7rem;
-    font-size: 0.68rem;
+    width: 1.58rem;
+    height: 1.58rem;
+    font-size: 0.64rem;
   }
 }
 

--- a/src/layouts/partials/for-sale-badge.html
+++ b/src/layouts/partials/for-sale-badge.html
@@ -1,1 +1,5 @@
-<span class="for-sale-badge">Available to buy</span>
+{{ $label := "Available to buy" }}
+{{ if reflect.IsMap . }}
+  {{ with .label }}{{ $label = . }}{{ end }}
+{{ end }}
+<span class="for-sale-badge">{{ $label }}</span>

--- a/src/layouts/partials/show/track-guide.html
+++ b/src/layouts/partials/show/track-guide.html
@@ -61,12 +61,9 @@
             {{ $page.Scratch.Delete "trackGuideReleaseHref" }}
             <div class="show-track-guide__details">
               {{ with .album }}
-                <dl class="show-track-guide__meta">
-                  <div>
-                    <dt>Release</dt>
-                    <dd>{{ $page.RenderString . }}</dd>
-                  </div>
-                </dl>
+                {{ $page.Scratch.Set "trackGuideReleaseMeta" true }}
+                <div class="show-track-guide__meta">{{ $page.RenderString . }}</div>
+                {{ $page.Scratch.Delete "trackGuideReleaseMeta" }}
               {{ end }}
               {{ with .notes }}
                 <div class="show-track-guide__context">

--- a/src/layouts/shortcodes/release.html
+++ b/src/layouts/shortcodes/release.html
@@ -10,5 +10,6 @@
         {{ with index $parts 2 | strings.TrimSpace }}{{ $releaseSlug = . | urlize }}{{ end }}
     {{ end }}
     {{ $releasePage := $.Site.GetPage (printf "releases/%s/%s/%s" $artistFirstChar $artistSlug $releaseSlug) }}
-    {{ if $releasePage }}<a href="{{ $releasePage.Permalink }}">{{ $releaseName }}</a>{{ if $releasePage.Params.for_sale }} {{ partial "for-sale-badge.html" . }}{{ end }}{{ else }}{{ $releaseName }}{{ end }}
+    {{ $badgeLabel := cond ($.Page.Scratch.Get "trackGuideReleaseMeta") "Available to Buy" "Available to buy" }}
+    {{ if $releasePage }}<a href="{{ $releasePage.Permalink }}">{{ $releaseName }}</a>{{ if $releasePage.Params.for_sale }} {{ partial "for-sale-badge.html" (dict "label" $badgeLabel) }}{{ end }}{{ else }}{{ $releaseName }}{{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- remove the explicit Release label from show Track Guide metadata
- quieten Track Guide card spacing, sale badge styling, and track number treatment
- keep the editorial heading in Title Case and scope badge wording to the Track Guide context

## Verification
- git diff --check
- Hugo build not run locally because the Hugo CLI is not installed in this environment