### PR TITLE
Add show 1 artist hero summaries

### DIFF
--- a/src/content/artists/b/becky-becky/index.md
+++ b/src/content/artists/b/becky-becky/index.md
@@ -2,6 +2,10 @@
 genres: ["Electropop"]
 featured_image: artists/b/becky-becky/becky-becky.jpg
 title: Becky Becky
+editorialSummary: >
+  Becky Becky crafts adventurous art-pop that balances infectious melodies with
+  playful experimentation. Her inventive songwriting and distinctive sound make
+  every release an unexpected musical journey.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/d/david-latto/index.md
+++ b/src/content/artists/d/david-latto/index.md
@@ -2,6 +2,10 @@
 title: David Latto
 featured_image: artists/d/david-latto/david-latto.jpg
 discogs_name: "David Latto (2)"
+editorialSummary: >
+  David Latto's songwriting captures the heart of Scotland's independent music
+  scene, pairing thoughtful lyrics with warm, melodic arrangements that reward
+  repeated listening and quiet discovery.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/d/del-shannon/index.md
+++ b/src/content/artists/d/del-shannon/index.md
@@ -2,6 +2,10 @@
 genres: ["Country","Pop","Pop Rock","Psychedelic Pop","Rock","Rock And Roll","Teen Pop"]
 featured_image: artists/d/del-shannon/del-shannon.jpg
 title: Del Shannon
+editorialSummary: >
+  Del Shannon's instantly recognisable voice and pioneering songwriting helped
+  shape the sound of early rock and pop. His emotional performances and timeless
+  melodies continue to resonate across generations of music lovers.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/e/electric-light-orchestra/index.md
+++ b/src/content/artists/e/electric-light-orchestra/index.md
@@ -2,6 +2,10 @@
 genres: ["Art Rock","Crossover Prog","Pop","Pop Rock","Progressive","Progressive Rock","Rock","Symphonic Prog","Symphonic Rock","Progressive Pop"]
 featured_image: artists/e/electric-light-orchestra/electric-light-orchestra.jpg
 title: Electric Light Orchestra
+editorialSummary: >
+  Electric Light Orchestra fused rock, classical ambition and timeless melodies
+  into one of popular music's most distinctive sounds. Their cinematic
+  songwriting and rich orchestration remain as captivating today as ever.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/f/franz-ferdinand/index.md
+++ b/src/content/artists/f/franz-ferdinand/index.md
@@ -2,6 +2,10 @@
 genres: ["Alternative Dance","Alternative Rock","Art Rock","Dance-Punk","Indie Pop","Indie Rock","Indietronica","New Wave","Pop","Post-Punk","Post-Punk Revival"]
 featured_image: artists/f/franz-ferdinand/franz-ferdinand.jpg
 title: Franz Ferdinand
+editorialSummary: >
+  Franz Ferdinand helped redefine British indie rock with razor-sharp guitars,
+  irresistible hooks and dancefloor energy. Their fearless blend of post-punk
+  attitude and melodic invention makes them an enduring favourite on Sundown Sessions.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/i/interpol/index.md
+++ b/src/content/artists/i/interpol/index.md
@@ -2,6 +2,10 @@
 genres: ["Alternative Rock","Indie Rock","Post-Punk","Post-Punk Revival"]
 featured_image: artists/i/interpol/interpol.jpg
 title: Interpol
+editorialSummary: >
+  Interpol revived the spirit of post-punk with brooding guitars, atmospheric
+  rhythms and understated intensity. Their elegant, cinematic sound has made
+  them one of the defining alternative bands of the twenty-first century.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/i/ist-ist/index.md
+++ b/src/content/artists/i/ist-ist/index.md
@@ -2,6 +2,10 @@
 genres: []
 featured_image: artists/i/ist-ist/ist-ist.jpg
 title: IST IST
+editorialSummary: >
+  IST IST create atmospheric post-punk built on hypnotic rhythms, brooding
+  guitars and commanding vocals. Their dark, immersive sound has established
+  them as one of the UK's standout modern alternative bands.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/j/jacco-gardner/index.md
+++ b/src/content/artists/j/jacco-gardner/index.md
@@ -2,6 +2,10 @@
 genres: ["Indie Pop","Psychedelic"]
 featured_image: artists/j/jacco-gardner/jacco-gardner.jpg
 title: Jacco Gardner
+editorialSummary: >
+  Jacco Gardner creates beautifully crafted psychedelic pop inspired by the rich
+  textures and melodies of the late sixties. His lush arrangements reward
+  listeners who enjoy immersive, carefully constructed music.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/j/john-grant/index.md
+++ b/src/content/artists/j/john-grant/index.md
@@ -2,6 +2,11 @@
 genres: ["Alternative Rock","Folk","Folk Rock","Indie Rock"]
 featured_image: artists/j/john-grant/john-grant.jpg
 title: John Grant
+editorialSummary: >
+  John Grant combines brutally honest songwriting with rich, genre-defying
+  arrangements that move effortlessly between folk, electronic music and
+  orchestral pop. His deeply personal lyrics make every record both intimate
+  and unforgettable.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/n/nick-cave-the-bad-seeds/index.md
+++ b/src/content/artists/n/nick-cave-the-bad-seeds/index.md
@@ -1,6 +1,10 @@
 ---
 title: Nick Cave & The Bad Seeds
 featured_image: artists/n/nick-cave-the-bad-seeds/nick-cave-the-bad-seeds.jpg
+editorialSummary: >
+  Nick Cave & The Bad Seeds create music of extraordinary emotional depth,
+  combining haunting storytelling with dramatic arrangements that have
+  continually pushed the boundaries of alternative rock for more than four decades.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/p/pink-floyd/index.md
+++ b/src/content/artists/p/pink-floyd/index.md
@@ -2,6 +2,11 @@
 genres: ["Art Rock","Classic Rock","Experimental Rock","Progressive","Progressive Rock","Psychedelic","Psychedelic Pop","Psychedelic Rock","Rock","Space Rock","Symphonic Rock","Rock Opera"]
 featured_image: artists/p/pink-floyd/pink-floyd.jpg
 title: Pink Floyd
+editorialSummary: >
+  Pink Floyd transformed progressive rock into immersive musical journeys,
+  combining atmosphere, experimentation and unforgettable songwriting. Their
+  influence reaches far beyond rock, making them one of the defining bands of
+  modern music.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/r/roachford/index.md
+++ b/src/content/artists/r/roachford/index.md
@@ -2,6 +2,10 @@
 genres: []
 featured_image: artists/r/roachford/roachford.jpg
 title: Roachford
+editorialSummary: >
+  Roachford effortlessly blends soul, rock and funk into songs full of warmth,
+  groove and heartfelt emotion. His distinctive voice has remained one of
+  British music's most recognisable for decades.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/s/sparks/index.md
+++ b/src/content/artists/s/sparks/index.md
@@ -2,6 +2,10 @@
 genres: ["Art Rock","Chamber Pop","Club","Dance","Disco","Glam Rock","New Wave","Pop","Synth-Pop","Art Pop","Zolo","Baroque Pop"]
 featured_image: artists/s/sparks/sparks.jpg
 title: Sparks
+editorialSummary: >
+  Sparks have spent decades reinventing pop music through wit, invention and
+  fearless experimentation. Their unmistakable blend of art-pop, glam and
+  theatrical songwriting continues to inspire generations of musicians and listeners alike.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/s/squeeze/index.md
+++ b/src/content/artists/s/squeeze/index.md
@@ -3,6 +3,10 @@ genres: ["New Wave","Pop","Rock"]
 featured_image: artists/s/squeeze/squeeze.jpg
 title: Squeeze
 discogs_name: "Squeeze (2)"
+editorialSummary: >
+  Squeeze combine razor-sharp songwriting with unforgettable melodies, blending
+  pop craftsmanship, wit and everyday storytelling into songs that remain as
+  fresh and relatable today as when they were first recorded.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/t/the-big-now/index.md
+++ b/src/content/artists/t/the-big-now/index.md
@@ -3,6 +3,10 @@ title: The Big Now
 featured_image: artists/t/the-big-now/the-big-now.jpg
 artist_page: true
 genres: []
+editorialSummary: >
+  The Big Now deliver driving alternative rock built on soaring melodies,
+  infectious hooks and an unmistakable sense of momentum. Their energetic
+  songwriting makes them one of Scotland's most exciting emerging bands.
 ---
 ## About
 

--- a/src/content/artists/t/the-detroit-cobras/index.md
+++ b/src/content/artists/t/the-detroit-cobras/index.md
@@ -2,6 +2,10 @@
 genres: ["Garage Rock"]
 featured_image: artists/t/the-detroit-cobras/the-detroit-cobras.jpg
 title: The Detroit Cobras
+editorialSummary: >
+  The Detroit Cobras breathe new life into forgotten rhythm and blues classics,
+  delivering raw garage rock performances packed with swagger, soul and
+  irresistible energy.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/t/the-filthy-tongues/index.md
+++ b/src/content/artists/t/the-filthy-tongues/index.md
@@ -2,6 +2,10 @@
 genres: ["Alternative Pop","Alternative Rock","Gothic","Gothic Rock","Indie Pop","Indie Rock","Surf Rock"]
 featured_image: artists/t/the-filthy-tongues/the-filthy-tongues.jpg
 title: The Filthy Tongues
+editorialSummary: >
+  The Filthy Tongues produce cinematic alternative rock filled with atmosphere,
+  intensity and emotional weight. Their expansive soundscapes have made them one
+  of Scotland's most compelling contemporary bands.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/t/the-motors/index.md
+++ b/src/content/artists/t/the-motors/index.md
@@ -2,6 +2,10 @@
 genres: ["Power Pop","Pub Rock"]
 featured_image: artists/t/the-motors/the-motors.jpg
 title: The Motors
+editorialSummary: >
+  The Motors combined the energy of new wave with classic pop songwriting,
+  producing timeless singles that continue to demonstrate just how effortlessly
+  catchy intelligent guitar music can be.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/t/the-move/index.md
+++ b/src/content/artists/t/the-move/index.md
@@ -2,6 +2,10 @@
 genres: ["Hard Rock","Pop","Pop Rock","Progressive Rock","Psychedelic Pop","Psychedelic Rock","Freakbeat"]
 featured_image: artists/t/the-move/the-move.jpg
 title: The Move
+editorialSummary: >
+  The Move blended psychedelic pop, hard rock and fearless experimentation long
+  before genre boundaries became fashionable. Their adventurous songwriting laid
+  important foundations for generations of British rock musicians.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/t/the-teskey-brothers/index.md
+++ b/src/content/artists/t/the-teskey-brothers/index.md
@@ -2,6 +2,10 @@
 genres: ["Blues Rock","Soul"]
 featured_image: artists/t/the-teskey-brothers/the-teskey-brothers.jpg
 title: The Teskey Brothers
+editorialSummary: >
+  The Teskey Brothers revive the timeless spirit of classic soul through
+  heartfelt songwriting, rich musicianship and deeply emotional performances
+  that feel both authentic and refreshingly contemporary.
 artist_page: true
 ---
 ## About

--- a/src/content/artists/t/the-vermin-poets/index.md
+++ b/src/content/artists/t/the-vermin-poets/index.md
@@ -1,6 +1,10 @@
 ---
 title: The Vermin Poets
 featured_image: artists/t/the-vermin-poets/the-vermin-poets.jpg
+editorialSummary: >
+  The Vermin Poets combine literate songwriting with alternative rock influences
+  to create music full of character, wit and thoughtful observation, offering
+  something genuinely distinctive within the independent music scene.
 artist_page: true
 ---
 ## Current Lineup

--- a/src/content/artists/t/the-vintage-explosion/index.md
+++ b/src/content/artists/t/the-vintage-explosion/index.md
@@ -2,6 +2,10 @@
 genres: ["Rock and Roll","Garage Rock","Rockabilly"]
 featured_image: artists/t/the-vintage-explosion/the-vintage-explosion.jpg
 title: The Vintage Explosion
+editorialSummary: >
+  The Vintage Explosion celebrate the golden age of rock 'n' roll and rhythm
+  and blues with infectious enthusiasm, classic musicianship and performances
+  that capture the joy of vintage popular music.
 artist_page: true
 ---
 ## About


### PR DESCRIPTION
## Summary
- add curated `editorialSummary` front matter to the remaining Sundown Sessions #1 artist pages
- keep existing biographies and factual summaries intact
- rely on the existing artist header fallback that prefers editorial summaries when present

## Verification
- confirmed all 23 Sundown Sessions #1 artist pages now contain `editorialSummary`
- attempted `hugo --environment production`, but Hugo is not installed or not on PATH in this shell