### PR TITLE
fix: derive artist track counts from playlists

### DIFF
--- a/src/layouts/partials/artist-archive-stats.html
+++ b/src/layouts/partials/artist-archive-stats.html
@@ -1,0 +1,45 @@
+{{/* Derive artist archive statistics from the show playlists.
+     Playlist entries are the canonical source for tracks played because a
+     dedicated track page may not exist for every broadcast entry. */}}
+
+{{ $artistTitleLower := lower .Title }}
+{{ $artistSlug := .Title | urlize }}
+{{ with .File }}
+  {{ $artistSlug = path.Base (strings.TrimSuffix "/" .Dir) }}
+{{ end }}
+
+{{ $featuredShows := slice }}
+{{ $trackCount := 0 }}
+{{ $showsSection := site.GetPage "shows" }}
+
+{{ if $showsSection }}
+  {{ range where $showsSection.Pages ".Date.IsZero" false }}
+    {{ $showPage := . }}
+    {{ $showTrackCount := 0 }}
+    {{ $playlistPath := printf "content/%s/playlist.md" .File.Dir }}
+    {{ if fileExists $playlistPath }}
+      {{ $playlist := readFile $playlistPath }}
+      {{ range findRE `(?m)^\s*\d+\.\s+.*{{<\s*(?:artist-wikilink|featured-guest-wikilink)\s+[^>]+>}}.*\s-\s+\S.*$` $playlist }}
+        {{ range findRE `{{<\s*(?:artist-wikilink|featured-guest-wikilink)\s+[^>]+>}}` . }}
+          {{ $quotedArgs := findRE `"[^"]+"` . }}
+          {{ if gt (len $quotedArgs) 0 }}
+            {{ $linkTitle := index $quotedArgs 0 | strings.TrimPrefix `"` | strings.TrimSuffix `"` }}
+            {{ $linkSlug := $linkTitle | urlize }}
+            {{ if gt (len $quotedArgs) 1 }}
+              {{ $linkSlug = index $quotedArgs 1 | strings.TrimPrefix `"` | strings.TrimSuffix `"` | urlize }}
+            {{ end }}
+            {{ if or (eq $linkSlug $artistSlug) (eq (lower $linkTitle) $artistTitleLower) }}
+              {{ $trackCount = add $trackCount 1 }}
+              {{ $showTrackCount = add $showTrackCount 1 }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+    {{ if gt $showTrackCount 0 }}
+      {{ $featuredShows = $featuredShows | append $showPage }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return (dict "featuredShows" $featuredShows "trackCount" $trackCount) }}

--- a/src/layouts/partials/artist-header.html
+++ b/src/layouts/partials/artist-header.html
@@ -57,22 +57,10 @@
   {{ $artistSummary = $artistSummary | truncate $artistSummaryMaxLength }}
 {{ end }}
 
-{{/* Sundown Sessions statistics — find all featured shows for this artist */}}
-{{ $artistTitleLower := lower .Title }}
-{{ $featuredShows := slice }}
-{{ $showsSection := site.GetPage "shows" }}
-{{ if $showsSection }}
-  {{ range where $showsSection.Pages ".Date.IsZero" false }}
-    {{ $showPage := . }}
-    {{ $matched := false }}
-    {{ range .Params.tags }}
-      {{ if and (not $matched) (eq (lower .) $artistTitleLower) }}
-        {{ $featuredShows = $featuredShows | append $showPage }}
-        {{ $matched = true }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
+{{/* Sundown Sessions statistics — derive featured shows and tracks from playlists */}}
+{{ $artistArchiveStats := partial "artist-archive-stats.html" . }}
+{{ $featuredShows := $artistArchiveStats.featuredShows }}
+{{ $trackCount := $artistArchiveStats.trackCount }}
 
 {{ $showCount := len $featuredShows }}
 {{ $firstShow := "" }}
@@ -82,16 +70,6 @@
   {{ $sorted := $featuredShows.ByDate }}
   {{ $firstShow = index $sorted 0 }}
   {{ $latestShow = index $sorted (sub $showCount 1) }}
-{{ end }}
-{{ $trackCount := 0 }}
-{{ $tracksSection := site.GetPage "tracks" }}
-{{ if $tracksSection }}
-  {{ range $tracksSection.RegularPagesRecursive }}
-    {{ $trackArtistLower := lower (.Params.artist | default "") }}
-    {{ if eq $trackArtistLower $artistTitleLower }}
-      {{ $trackCount = add $trackCount 1 }}
-    {{ end }}
-  {{ end }}
 {{ end }}
 {{ $dateFormat := site.Params.dateFormat | default "2 January 2006" }}
 {{ $latestShowPermalink := "" }}

--- a/src/layouts/partials/artist-stats.html
+++ b/src/layouts/partials/artist-stats.html
@@ -1,23 +1,10 @@
 {{/* Artist Statistics — displays a dedicated statistics section showing the artist's
-     history within Sundown Sessions. Shows are matched by case-insensitive tag comparison.
-     Tracks are counted from the tracks section using the artist front matter field.
+     history within Sundown Sessions. Shows and tracks are derived from playlist entries.
      Only rendered when the artist has appeared in at least one broadcast. */}}
 
-{{ $artistTitleLower := lower .Title }}
-{{ $featuredShows := slice }}
-{{ $showsSection := site.GetPage "shows" }}
-{{ if $showsSection }}
-  {{ range where $showsSection.Pages ".Date.IsZero" false }}
-    {{ $showPage := . }}
-    {{ $matched := false }}
-    {{ range .Params.tags }}
-      {{ if and (not $matched) (eq (lower .) $artistTitleLower) }}
-        {{ $featuredShows = $featuredShows | append $showPage }}
-        {{ $matched = true }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
+{{ $artistArchiveStats := partial "artist-archive-stats.html" . }}
+{{ $featuredShows := $artistArchiveStats.featuredShows }}
+{{ $trackCount := $artistArchiveStats.trackCount }}
 
 {{ $showCount := len $featuredShows }}
 
@@ -27,17 +14,6 @@
   {{ $firstShow := index $sorted 0 }}
   {{ $latestShow := index $sorted (sub $showCount 1) }}
   {{ $dateFormat := site.Params.dateFormat | default "2 January 2006" }}
-
-  {{/* Tracks played — count all track pages whose artist field matches this artist */}}
-  {{ $trackCount := 0 }}
-  {{ $tracksSection := site.GetPage "tracks" }}
-  {{ if $tracksSection }}
-    {{ range $tracksSection.RegularPagesRecursive }}
-      {{ if eq (lower .Params.artist) $artistTitleLower }}
-        {{ $trackCount = add $trackCount 1 }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
 
   <section
     class="mb-10 not-prose"


### PR DESCRIPTION
## Summary
- derive artist featured-show and track counts from show playlist entries
- share the calculation between artist header and artist statistics partials
- count repeated playlist entries while supporting artist slug overrides

Fixes #695

## Verification
- git diff --check
- data sanity check: published Sparks playlist entries count as 2

Note: Hugo build was not run locally because the hugo executable is not installed in this environment.