### PR TITLE
Improve artists listing archive

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1507,6 +1507,296 @@
   }
 }
 
+/* Artists archive page: curated browsing grid for the main artist listing. */
+
+.artists-archive-intro {
+  margin-bottom: 1.5rem;
+}
+
+.artists-az-nav {
+  margin: 0 0 1.35rem;
+  border-block: 1px solid #e5e5e5; /* neutral-200 */
+  padding: 0.65rem 0;
+}
+
+.dark .artists-az-nav {
+  border-color: #404040; /* neutral-700 */
+}
+
+.artists-az-nav__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.artists-az-nav__list a,
+.artists-az-nav__list span {
+  display: inline-flex;
+  width: 2rem;
+  min-height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 780;
+  line-height: 1;
+}
+
+.artists-az-nav__list a {
+  color: #262626; /* neutral-800 */
+  text-decoration: none;
+}
+
+.artists-az-nav__list a:hover,
+.artists-az-nav__list a:focus-visible {
+  background-color: rgba(var(--color-primary-100), 1);
+  color: rgba(var(--color-primary-700), 1);
+}
+
+.artists-az-nav__list a:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 2px;
+}
+
+.dark .artists-az-nav__list a {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.dark .artists-az-nav__list a:hover,
+.dark .artists-az-nav__list a:focus-visible {
+  background-color: rgba(var(--color-primary-900), 1);
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.artists-az-nav__list span {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.dark .artists-az-nav__list span {
+  color: #525252; /* neutral-600 */
+}
+
+.artists-archive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  gap: 1rem;
+  width: 100%;
+}
+
+.artists-card {
+  scroll-margin-top: 6rem;
+}
+
+.artists-card__link {
+  position: relative;
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  border-radius: 0.75rem;
+  background-color: rgba(255, 255, 255, 0.82);
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.dark .artists-card__link {
+  border-color: #404040; /* neutral-700 */
+  background-color: rgba(23, 23, 23, 0.78); /* neutral-900/78 */
+  box-shadow: 0 10px 24px rgb(0 0 0 / 0.16);
+}
+
+.artists-card__link:hover,
+.artists-card__link:focus-visible {
+  border-color: color-mix(in srgb, var(--ss-color-sunset) 42%, #d4d4d4);
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 12px 22px rgb(30 36 56 / 0.1);
+  transform: translateY(-0.08rem);
+}
+
+.artists-card__link:focus-visible {
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 3px;
+}
+
+.artists-card__media {
+  position: relative;
+  display: block;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  background: var(--ss-color-artwork-surface);
+}
+
+.artists-card__media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.artists-card__link:hover .artists-card__media img,
+.artists-card__link:focus-visible .artists-card__media img {
+  transform: scale(1.025);
+}
+
+.artists-card__placeholder {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-content: center;
+  justify-items: center;
+  gap: 0.55rem;
+  background:
+    radial-gradient(circle at 22% 18%, rgb(244 124 60 / 0.18), transparent 30%),
+    radial-gradient(circle at 78% 14%, rgb(106 63 181 / 0.16), transparent 28%),
+    var(--ss-color-artwork-surface);
+  color: var(--ss-color-midnight);
+  text-align: center;
+}
+
+.dark .artists-card__placeholder {
+  background:
+    radial-gradient(circle at 22% 18%, rgb(255 138 76 / 0.18), transparent 32%),
+    radial-gradient(circle at 78% 14%, rgb(169 140 255 / 0.18), transparent 30%),
+    var(--ss-color-artwork-surface);
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.artists-card__initials {
+  display: grid;
+  width: clamp(4rem, 36%, 6.2rem);
+  aspect-ratio: 1 / 1;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--ss-color-sunset) 38%, transparent);
+  border-radius: 50%;
+  background-color: color-mix(in srgb, var(--ss-color-surface) 82%, transparent);
+  box-shadow: 0 0.8rem 1.8rem rgb(30 36 56 / 0.12);
+  font-size: clamp(1.35rem, 4vw, 2.1rem);
+  font-weight: 850;
+  line-height: 1;
+}
+
+.dark .artists-card__initials {
+  border-color: color-mix(in srgb, var(--ss-color-golden-hour) 36%, transparent);
+  background-color: color-mix(in srgb, var(--ss-color-surface) 76%, transparent);
+  box-shadow: 0 0.9rem 2rem rgb(0 0 0 / 0.28);
+}
+
+.artists-card__brand {
+  color: var(--ss-color-muted);
+  font-size: 0.74rem;
+  font-weight: 760;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.artists-card__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 1rem;
+}
+
+.artists-card__title {
+  color: #171717; /* neutral-900 */
+  font-size: 1.08rem;
+  font-weight: 820;
+  line-height: 1.25;
+}
+
+.artists-card__link:hover .artists-card__title,
+.artists-card__link:focus-visible .artists-card__title {
+  color: rgba(var(--color-primary-700), 1);
+  text-decoration: underline;
+  text-underline-offset: 0.14rem;
+}
+
+.dark .artists-card__title {
+  color: #f5f5f5; /* neutral-100 */
+}
+
+.dark .artists-card__link:hover .artists-card__title,
+.dark .artists-card__link:focus-visible .artists-card__title {
+  color: rgba(var(--color-primary-300), 1);
+}
+
+.artists-card__broadcasts {
+  width: fit-content;
+  max-width: 100%;
+  border-left: 3px solid var(--ss-color-sunset);
+  padding-left: 0.55rem;
+  color: #262626; /* neutral-800 */
+  font-size: 0.92rem;
+  font-weight: 780;
+  line-height: 1.35;
+}
+
+.dark .artists-card__broadcasts {
+  border-left-color: var(--ss-color-golden-hour);
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.artists-card__metadata {
+  color: #737373; /* neutral-500 */
+  font-size: 0.84rem;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.dark .artists-card__metadata {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.artists-card__summary {
+  display: -webkit-box;
+  margin-top: auto;
+  overflow: hidden;
+  color: #525252; /* neutral-600 */
+  font-size: 0.88rem;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.dark .artists-card__summary {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+@media (min-width: 768px) {
+  .artists-archive-grid {
+    gap: 1.1rem;
+  }
+
+  .artists-card__body {
+    padding: 1.05rem 1.1rem 1.15rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .artists-card__link,
+  .artists-card__media img {
+    transition: none;
+  }
+
+  .artists-card__link:hover,
+  .artists-card__link:focus-visible {
+    transform: none;
+  }
+
+  .artists-card__link:hover .artists-card__media img,
+  .artists-card__link:focus-visible .artists-card__media img {
+    transform: none;
+  }
+}
+
 /* Shows archive page: editorial gateway above the broadcast list. */
 
 .shows-archive-intro {

--- a/src/layouts/artists/list.html
+++ b/src/layouts/artists/list.html
@@ -1,0 +1,56 @@
+{{ define "main" }}
+  {{ .Scratch.Set "scope" "list" }}
+  {{ $artists := .Pages.ByTitle }}
+  {{ $letters := slice }}
+  {{ range $artists }}
+    {{ $firstLetter := upper (substr (.Title | plainify) 0 1) }}
+    {{ if findRE "^[A-Z]$" $firstLetter }}
+      {{ $letters = $letters | append $firstLetter }}
+    {{ end }}
+  {{ end }}
+  {{ $letters = uniq $letters }}
+
+  {{ partial "section-hero.html" . }}
+
+  {{ with .Content }}
+    <section class="artists-archive-intro prose flex max-w-full flex-col dark:prose-invert mb-10">
+      <div class="min-w-0 min-h-0 max-w-prose w-full">
+        {{ . }}
+      </div>
+    </section>
+  {{ end }}
+
+  {{ if gt (len $artists) 0 }}
+    <nav class="artists-az-nav" aria-label="Browse artists alphabetically">
+      <ol class="artists-az-nav__list">
+        {{ range split "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "" }}
+          {{ $letter := . }}
+          {{ if in $letters $letter }}
+            <li><a href="#artists-letter-{{ lower $letter }}">{{ $letter }}</a></li>
+          {{ else }}
+            <li><span aria-disabled="true">{{ $letter }}</span></li>
+          {{ end }}
+        {{ end }}
+      </ol>
+    </nav>
+
+    {{ $seenLetters := dict }}
+    <section class="artists-archive-grid" role="list" aria-label="Artists">
+      {{ range $artists }}
+        {{ $firstLetter := upper (substr (.Title | plainify) 0 1) }}
+        {{ $anchorID := "" }}
+        {{ if and (findRE "^[A-Z]$" $firstLetter) (not (isset $seenLetters $firstLetter)) }}
+          {{ $anchorID = printf "artists-letter-%s" (lower $firstLetter) }}
+          {{ $seenLetters = merge $seenLetters (dict $firstLetter true) }}
+        {{ end }}
+        {{ partial "article-link/artist-list-card.html" (dict "page" . "anchorID" $anchorID) }}
+      {{ end }}
+    </section>
+  {{ else }}
+    <section class="mt-10 prose dark:prose-invert">
+      <p class="py-8 border-t">
+        <em>{{ i18n "list.no_articles" | emojify }}</em>
+      </p>
+    </section>
+  {{ end }}
+{{ end }}

--- a/src/layouts/partials/article-link/artist-list-card.html
+++ b/src/layouts/partials/article-link/artist-list-card.html
@@ -1,0 +1,105 @@
+{{ $page := .page }}
+{{ $anchorID := .anchorID }}
+
+{{ $featuredURL := "" }}
+{{ if not $page.Params.hideFeatureImage }}
+  {{ $featureImage := $page.Params.featureimage | default $page.Params.featured_image }}
+  {{ with $featureImage }}
+    {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+      {{ $featuredURL = . }}
+    {{ else }}
+      {{ $featured := $page.Resources.GetMatch . }}
+      {{ if not $featured }}{{ $featured = $page.Resources.GetMatch (path.Base .) }}{{ end }}
+      {{ if not $featured }}{{ $featured = resources.Get . }}{{ end }}
+      {{ with $featured }}
+        {{ $featuredURL = .RelPermalink }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{ if not $featuredURL }}
+    {{ $images := $page.Resources.ByType "image" }}
+    {{ range slice "*feature*" "*featured*" "*cover*" "*thumbnail*" "*.jpg" "*.jpeg" "*.png" "*.webp" }}
+      {{ if not $featuredURL }}
+        {{ with $images.GetMatch . }}
+          {{ $featuredURL = .RelPermalink }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $artistSlug := $page.Title | urlize }}
+{{ with $page.File }}
+  {{ $artistSlug = path.Base (strings.TrimSuffix "/" .Dir) }}
+{{ end }}
+
+{{ $broadcastCount := 0 }}
+{{ with site.GetPage "shows" }}
+  {{ range .Pages }}
+    {{ $matched := false }}
+    {{ range .Params.tags | default (slice) }}
+      {{ if or (eq (. | urlize) $artistSlug) (eq (lower .) (lower $page.Title)) }}
+        {{ $matched = true }}
+      {{ end }}
+    {{ end }}
+    {{ if $matched }}
+      {{ $broadcastCount = add $broadcastCount 1 }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $metadata := $page.Params.genres | default (slice) }}
+{{ if eq (len $metadata) 0 }}
+  {{ $metadata = $page.Params.tags | default (slice) }}
+{{ end }}
+{{ $metadata = first 3 $metadata }}
+
+{{ $summary := $page.Params.editorialSummary | default $page.Params.summary | default $page.Description }}
+
+{{ $cleanTitle := replaceRE `[^[:alnum:]]+` " " $page.Title }}
+{{ $initials := "" }}
+{{ range split $cleanTitle " " }}
+  {{ $word := strings.TrimSpace . }}
+  {{ $wordLower := lower $word }}
+  {{ if and (lt (len $initials) 2) (ne $word "") (not (in (slice "the" "and" "of" "a" "an") $wordLower)) }}
+    {{ $initials = printf "%s%s" $initials (upper (substr $word 0 1)) }}
+  {{ end }}
+{{ end }}
+{{ if eq $initials "" }}
+  {{ $initials = upper (substr ($page.Title | plainify) 0 1) }}
+{{ end }}
+
+<article
+  {{ with $anchorID }}id="{{ . }}"{{ end }}
+  role="listitem"
+  class="artists-card">
+  <a href="{{ $page.RelPermalink }}" class="artists-card__link" aria-label="Explore {{ $page.Title | plainify }}">
+    <span class="artists-card__media">
+      {{ if $featuredURL }}
+        <img
+          src="{{ $featuredURL }}"
+          alt="{{ $page.Title }}"
+          loading="lazy"
+          decoding="async">
+      {{ else }}
+        <span class="artists-card__placeholder" aria-hidden="true">
+          <span class="artists-card__initials">{{ $initials }}</span>
+          <span class="artists-card__brand">Sundown Sessions</span>
+        </span>
+      {{ end }}
+    </span>
+    <span class="artists-card__body">
+      <span class="artists-card__title">{{ $page.Title | emojify }}</span>
+      <span class="artists-card__broadcasts">
+        Featured in {{ $broadcastCount }} {{ if eq $broadcastCount 1 }}broadcast{{ else }}broadcasts{{ end }}
+      </span>
+      {{ with $metadata }}
+        <span class="artists-card__metadata">{{ delimit . " &middot; " | safeHTML }}</span>
+      {{ end }}
+      {{ with $summary }}
+        <span class="artists-card__summary">{{ . | plainify }}</span>
+      {{ end }}
+    </span>
+  </a>
+</article>


### PR DESCRIPTION
## Summary
- add an artists-only listing template with A-Z navigation
- add curated artist cards with artwork fallbacks, broadcast counts, and simplified genre metadata
- scope the visual treatment to the main Artists archive page

## Validation
- `hugo --source src --renderToMemory --noBuildLock --printPathWarnings --panicOnWarning --environment production --baseURL https://example.invalid/`
- Rendered `/artists/` check confirmed A-Z nav, broadcast wording, initials placeholders, and no old publication-date text