### PR TITLE
Standardize Show #1 artist page metadata

### DIFF
--- a/src/content/artists/b/becky-becky/index.md
+++ b/src/content/artists/b/becky-becky/index.md
@@ -2,6 +2,8 @@
 genres: ["Electropop"]
 featured_image: artists/b/becky-becky/becky-becky.jpg
 title: Becky Becky
+summary: "Brighton synth-pop duo whose dark electronic pop blends literary detail, theatrical tension and underground club energy."
+description: "Brighton synth-pop duo whose dark electronic pop blends literary detail, theatrical tension and underground club energy with a cult independent edge."
 editorialSummary: >
   Becky Becky creates inventive art-pop filled with infectious melodies, bold ideas and unexpected musical twists.
 artist_page: true

--- a/src/content/artists/d/david-latto/index.md
+++ b/src/content/artists/d/david-latto/index.md
@@ -1,5 +1,8 @@
 ---
 title: David Latto
+summary: "Scottish singer-songwriter associated with melodic, roots-informed independent songwriting."
+description: "Scottish singer-songwriter known for melodic, roots-informed independent songwriting and a recurring Sundown Sessions favourite in the Geordie Munro thread."
+genres: ["Folk","Singer-Songwriter","Scottish"]
 featured_image: artists/d/david-latto/david-latto.jpg
 discogs_name: "David Latto (2)"
 editorialSummary: >

--- a/src/content/artists/d/del-shannon/index.md
+++ b/src/content/artists/d/del-shannon/index.md
@@ -2,6 +2,8 @@
 genres: ["Country","Pop","Pop Rock","Psychedelic Pop","Rock","Rock And Roll","Teen Pop"]
 featured_image: artists/d/del-shannon/del-shannon.jpg
 title: Del Shannon
+summary: "American rock and roll singer-songwriter remembered for dramatic pop, falsetto hooks and the classic Runaway."
+description: "American rock and roll singer-songwriter remembered for dramatic pop songwriting, falsetto hooks, the Musitron sound and the classic single Runaway."
 editorialSummary: >
   Del Shannon's timeless melodies and unmistakable voice helped shape the sound of early rock and pop.
 artist_page: true

--- a/src/content/artists/e/electric-light-orchestra/index.md
+++ b/src/content/artists/e/electric-light-orchestra/index.md
@@ -2,6 +2,8 @@
 genres: ["Art Rock","Crossover Prog","Pop","Pop Rock","Progressive","Progressive Rock","Rock","Symphonic Prog","Symphonic Rock","Progressive Pop"]
 featured_image: artists/e/electric-light-orchestra/electric-light-orchestra.jpg
 title: Electric Light Orchestra
+summary: "Birmingham orchestral rock band led by Jeff Lynne, known for lush strings, pop craft and widescreen hooks."
+description: "Birmingham orchestral rock band led by Jeff Lynne, known for lush strings, immaculate pop craft, studio polish and widescreen hooks."
 editorialSummary: >
   Electric Light Orchestra fused rock, classical ambition and unforgettable melodies into one of popular music's most distinctive sounds.
 artist_page: true

--- a/src/content/artists/f/franz-ferdinand/index.md
+++ b/src/content/artists/f/franz-ferdinand/index.md
@@ -2,6 +2,8 @@
 genres: ["Alternative Dance","Alternative Rock","Art Rock","Dance-Punk","Indie Pop","Indie Rock","Indietronica","New Wave","Pop","Post-Punk","Post-Punk Revival"]
 featured_image: artists/f/franz-ferdinand/franz-ferdinand.jpg
 title: Franz Ferdinand
+summary: "Scottish indie rock band from Glasgow, known for angular guitars, dance-punk rhythm and sharp art-pop hooks."
+description: "Scottish indie rock band from Glasgow, formed in 2002 and known for angular guitars, dance-punk rhythms, sharp art-pop hooks and enduring alternative dancefloor anthems."
 editorialSummary: >
   Franz Ferdinand reinvented British indie rock with razor-sharp guitars, infectious hooks and irresistible dancefloor energy.
 artist_page: true

--- a/src/content/artists/i/interpol/index.md
+++ b/src/content/artists/i/interpol/index.md
@@ -2,6 +2,8 @@
 genres: ["Alternative Rock","Indie Rock","Post-Punk","Post-Punk Revival"]
 featured_image: artists/i/interpol/interpol.jpg
 title: Interpol
+summary: "New York post-punk revival band known for shadowy guitars, taut rhythms and atmospheric indie rock."
+description: "New York post-punk revival band formed in the late 1990s, known for shadowy guitars, taut rhythms and atmospheric indie rock."
 editorialSummary: >
   Interpol revived post-punk with elegant guitars, cinematic atmosphere and understated intensity that continues to define modern alternative music.
 artist_page: true

--- a/src/content/artists/i/ist-ist/index.md
+++ b/src/content/artists/i/ist-ist/index.md
@@ -2,6 +2,8 @@
 genres: []
 featured_image: artists/i/ist-ist/ist-ist.jpg
 title: IST IST
+summary: "Manchester post-punk band known for stark atmospheres, driving basslines and brooding independent rock."
+description: "Manchester post-punk band known for stark atmospheres, driving basslines, brooding vocals and a fiercely independent route through modern dark guitar music."
 editorialSummary: >
   IST IST create brooding post-punk driven by hypnotic rhythms, atmospheric guitars and commanding vocals.
 artist_page: true

--- a/src/content/artists/j/jacco-gardner/index.md
+++ b/src/content/artists/j/jacco-gardner/index.md
@@ -2,6 +2,8 @@
 genres: ["Indie Pop","Psychedelic"]
 featured_image: artists/j/jacco-gardner/jacco-gardner.jpg
 title: Jacco Gardner
+summary: "Dutch multi-instrumentalist known for baroque psych-pop, vintage studio colour and dreamlike melodic detail."
+description: "Dutch multi-instrumentalist and producer known for baroque psych-pop, vintage studio colour and dreamlike melodic detail."
 editorialSummary: >
   Jacco Gardner creates beautifully crafted psychedelic pop inspired by the rich sounds and textures of the late sixties.
 artist_page: true

--- a/src/content/artists/j/john-grant/index.md
+++ b/src/content/artists/j/john-grant/index.md
@@ -2,6 +2,8 @@
 genres: ["Alternative Rock","Folk","Folk Rock","Indie Rock"]
 featured_image: artists/j/john-grant/john-grant.jpg
 title: John Grant
+summary: "American singer-songwriter whose rich baritone, electronic textures and dry humour shape deeply personal art-pop."
+description: "American singer-songwriter whose rich baritone, electronic textures, piano-led arrangements and dry humour shape deeply personal art-pop and alternative songwriting."
 editorialSummary: >
   John Grant combines fearless honesty with rich, genre-defying songwriting that is both deeply personal and unforgettable.
 artist_page: true

--- a/src/content/artists/n/nick-cave-the-bad-seeds/index.md
+++ b/src/content/artists/n/nick-cave-the-bad-seeds/index.md
@@ -1,5 +1,8 @@
 ---
 title: Nick Cave & The Bad Seeds
+summary: "Australian-founded alternative rock band led by Nick Cave, known for gothic drama, literary songwriting and intensity."
+description: "Australian-founded alternative rock band led by Nick Cave, known for gothic drama, literary songwriting, restless reinvention and profound emotional intensity."
+genres: ["Alternative Rock","Art Rock","Gothic Rock","Post-Punk","Singer-Songwriter"]
 featured_image: artists/n/nick-cave-the-bad-seeds/nick-cave-the-bad-seeds.jpg
 editorialSummary: >
   Nick Cave & The Bad Seeds create haunting, emotionally powerful music that continues to redefine alternative rock.

--- a/src/content/artists/p/pink-floyd/index.md
+++ b/src/content/artists/p/pink-floyd/index.md
@@ -2,6 +2,8 @@
 genres: ["Art Rock","Classic Rock","Experimental Rock","Progressive","Progressive Rock","Psychedelic","Psychedelic Pop","Psychedelic Rock","Rock","Space Rock","Symphonic Rock","Rock Opera"]
 featured_image: artists/p/pink-floyd/pink-floyd.jpg
 title: Pink Floyd
+summary: "English rock band whose psychedelic beginnings grew into expansive progressive rock and landmark concept albums."
+description: "English rock band whose psychedelic beginnings grew into expansive progressive rock, immersive live presentation and landmark concept albums."
 editorialSummary: >
   Pink Floyd transformed progressive rock through immersive soundscapes, fearless experimentation and timeless songwriting.
 artist_page: true

--- a/src/content/artists/r/roachford/index.md
+++ b/src/content/artists/r/roachford/index.md
@@ -2,6 +2,8 @@
 genres: []
 featured_image: artists/r/roachford/roachford.jpg
 title: Roachford
+summary: "British singer-songwriter and bandleader Andrew Roachford, known for soulful pop-rock and the enduring hit Cuddly Toy."
+description: "British singer-songwriter and bandleader Andrew Roachford, known for soulful pop-rock, expressive vocals and the enduring late-1980s hit Cuddly Toy."
 editorialSummary: >
   Roachford blends soul, rock and funk with warmth, groove and one of Britain's most distinctive voices.
 artist_page: true

--- a/src/content/artists/s/sparks/index.md
+++ b/src/content/artists/s/sparks/index.md
@@ -2,6 +2,8 @@
 genres: ["Art Rock","Chamber Pop","Club","Dance","Disco","Glam Rock","New Wave","Pop","Synth-Pop","Art Pop","Zolo","Baroque Pop"]
 featured_image: artists/s/sparks/sparks.jpg
 title: Sparks
+summary: "American art-pop duo led by Ron and Russell Mael, celebrated for witty songwriting, theatrical pop and restless reinvention."
+description: "American art-pop duo formed by brothers Ron and Russell Mael, celebrated for witty songwriting, theatrical pop arrangements and decades of fearless stylistic reinvention."
 editorialSummary: >
   Sparks have spent decades reinventing pop music with wit, invention and fearless originality unlike anyone else.
 artist_page: true

--- a/src/content/artists/s/squeeze/index.md
+++ b/src/content/artists/s/squeeze/index.md
@@ -2,6 +2,8 @@
 genres: ["New Wave","Pop","Rock"]
 featured_image: artists/s/squeeze/squeeze.jpg
 title: Squeeze
+summary: "English new wave band built around Chris Difford and Glenn Tilbrook's melodic, sharply observed songwriting."
+description: "English new wave and pop-rock band from London, built around Chris Difford and Glenn Tilbrook's melodic, sharply observed songwriting and enduring singles."
 discogs_name: "Squeeze (2)"
 editorialSummary: >
   Squeeze pair exceptional songwriting with timeless melodies, wit and everyday storytelling that still sounds effortlessly fresh.

--- a/src/content/artists/t/the-big-now/index.md
+++ b/src/content/artists/t/the-big-now/index.md
@@ -1,5 +1,7 @@
 ---
 title: The Big Now
+summary: "Scottish band from the late 1980s, featured in the first Sundown Sessions broadcast with cassette-era alternative rock."
+description: "Scottish band active around 1989, featured in the first Sundown Sessions broadcast with cassette-era alternative rock including Fast Cars, Soul Music."
 featured_image: artists/t/the-big-now/the-big-now.jpg
 artist_page: true
 genres: []

--- a/src/content/artists/t/the-detroit-cobras/index.md
+++ b/src/content/artists/t/the-detroit-cobras/index.md
@@ -2,6 +2,8 @@
 genres: ["Garage Rock"]
 featured_image: artists/t/the-detroit-cobras/the-detroit-cobras.jpg
 title: The Detroit Cobras
+summary: "Detroit garage rock band celebrated for raw, soul-soaked covers and Rachel Nagy's commanding vocals."
+description: "Detroit garage rock band celebrated for raw, soul-soaked covers, deep rhythm-and-blues cuts and Rachel Nagy's commanding vocals."
 editorialSummary: >
   The Detroit Cobras revive forgotten rhythm and blues classics with swagger, soul and infectious garage rock energy.
 artist_page: true

--- a/src/content/artists/t/the-filthy-tongues/index.md
+++ b/src/content/artists/t/the-filthy-tongues/index.md
@@ -2,6 +2,8 @@
 genres: ["Alternative Pop","Alternative Rock","Gothic","Gothic Rock","Indie Pop","Indie Rock","Surf Rock"]
 featured_image: artists/t/the-filthy-tongues/the-filthy-tongues.jpg
 title: The Filthy Tongues
+summary: "Edinburgh rock band carrying dark Scottish storytelling, post-punk grit and cinematic guitar drama."
+description: "Edinburgh rock band carrying dark Scottish storytelling, post-punk grit and cinematic guitar drama from members of Goodbye Mr Mackenzie and Angelfish."
 editorialSummary: >
   The Filthy Tongues craft cinematic alternative rock filled with atmosphere, intensity and emotional depth.
 artist_page: true

--- a/src/content/artists/t/the-motors/index.md
+++ b/src/content/artists/t/the-motors/index.md
@@ -2,6 +2,8 @@
 genres: ["Power Pop","Pub Rock"]
 featured_image: artists/t/the-motors/the-motors.jpg
 title: The Motors
+summary: "British pub rock and new wave band known for punchy power-pop songwriting and Dancing the Night Away."
+description: "British pub rock and new wave band formed in the late 1970s, known for punchy power-pop songwriting and the classic single Dancing the Night Away."
 editorialSummary: >
   The Motors fused new wave energy with classic pop songwriting to produce timeless, irresistibly catchy records.
 artist_page: true

--- a/src/content/artists/t/the-move/index.md
+++ b/src/content/artists/t/the-move/index.md
@@ -2,6 +2,8 @@
 genres: ["Hard Rock","Pop","Pop Rock","Progressive Rock","Psychedelic Pop","Psychedelic Rock","Freakbeat"]
 featured_image: artists/t/the-move/the-move.jpg
 title: The Move
+summary: "Birmingham rock band whose psychedelic pop, heavy riffs and Roy Wood songwriting bridged the 1960s and ELO."
+description: "Birmingham rock band whose psychedelic pop, heavy riffs and Roy Wood songwriting bridged the late 1960s beat boom and the roots of Electric Light Orchestra."
 editorialSummary: >
   The Move blended psychedelic pop and hard rock into adventurous songs that helped shape British rock music.
 artist_page: true

--- a/src/content/artists/t/the-teskey-brothers/index.md
+++ b/src/content/artists/t/the-teskey-brothers/index.md
@@ -2,6 +2,8 @@
 genres: ["Blues Rock","Soul"]
 featured_image: artists/t/the-teskey-brothers/the-teskey-brothers.jpg
 title: The Teskey Brothers
+summary: "Australian soul-blues band known for warm vintage production, slow-burning grooves and Josh Teskey's vocal fire."
+description: "Australian soul-blues band from Warrandyte, known for warm vintage production, slow-burning grooves and Josh Teskey's powerful vocal fire."
 editorialSummary: >
   The Teskey Brothers breathe new life into classic soul through heartfelt songwriting and remarkable musicianship.
 artist_page: true

--- a/src/content/artists/t/the-vermin-poets/index.md
+++ b/src/content/artists/t/the-vermin-poets/index.md
@@ -1,5 +1,8 @@
 ---
 title: The Vermin Poets
+summary: "English garage-pop project linked to Billy Childish, mixing rough-edged poetry, melody and underground charm."
+description: "English garage-pop project linked to Billy Childish, mixing rough-edged poetry, melody and underground charm."
+genres: ["Garage Rock","Garage Punk","Indie Rock"]
 featured_image: artists/t/the-vermin-poets/the-vermin-poets.jpg
 editorialSummary: >
   The Vermin Poets blend literate songwriting with alternative rock to create music full of character and thoughtful observation.

--- a/src/content/artists/t/the-vintage-explosion/index.md
+++ b/src/content/artists/t/the-vintage-explosion/index.md
@@ -2,6 +2,8 @@
 genres: ["Rock and Roll","Garage Rock","Rockabilly"]
 featured_image: artists/t/the-vintage-explosion/the-vintage-explosion.jpg
 title: The Vintage Explosion
+summary: "Scottish rock and roll group bringing high-energy rhythm and blues, soul and vintage stagecraft to modern audiences."
+description: "Scottish rock and roll group bringing high-energy rhythm and blues, soul and vintage stagecraft to modern audiences."
 editorialSummary: >
   The Vintage Explosion celebrate vintage rock 'n' roll with classic musicianship, infectious enthusiasm and irresistible charm.
 artist_page: true


### PR DESCRIPTION
### Motivation
- Ensure all artists referenced in Show #1 expose the same discovery front matter so site components (related artists, external links, and archive stats) can rely on consistent fields.
- Avoid missing metadata regressions by normalizing `summary`, `description` and `genres` where they were absent on referenced artist pages.

### Description
- Added missing `summary` and `description` front matter to 22 artist pages referenced by `src/content/shows/1/playlist.md` so they match the project's artist-page schema.
- Added `genres` metadata where required for `David Latto`, `The Vermin Poets`, and `Nick Cave & The Bad Seeds` so genre-driven discovery works consistently.
- Small, non-destructive content-only updates across the artist front matter totaling 22 files updated and 47 insertions.
- Verified every unique artist referenced by Show #1 has a corresponding artist page and the expected core metadata fields.

### Testing
- Ran `git diff --check` to validate there are no whitespace or index errors and it passed.
- Executed a custom Python validation that scans `src/content/shows/1/playlist.md` and checks each referenced artist page for `summary`, `description`, `editorialSummary`, `genres`, `featured_image`, and `artist_page`; the script reported no missing fields.
- Attempted `hugo --environment production` to perform a local build but it could not be run in this environment because Hugo is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50aa832a60832d9652934fceedb523)