### PR TITLE
docs: document Pinterest social presence status

### DIFF
--- a/docs/pinterest-social-presence.md
+++ b/docs/pinterest-social-presence.md
@@ -1,0 +1,69 @@
+# Pinterest Presence and Footer Social Links
+
+Issue #487 is partially code-complete in this repository: footer social links are rendered from `params.author.links`, Pinterest is included in that configuration, article sharing includes Pinterest, and the head partial supports Pinterest domain verification when a token is supplied.
+
+## Current site configuration
+
+- Footer social links are driven by `src/config/_default/params.toml` under `params.author.links`.
+- The active Pinterest profile URL is `https://www.pinterest.co.uk/sundownsessionsshow/`.
+- Pinterest sharing is enabled for articles through the Blowfish `article.sharingLinks` setting.
+- Pinterest domain verification can be activated by setting `params.verification.pinterest`; the head partial will emit the required `p:domain_verify` meta tag.
+
+## Footer channel coverage
+
+The footer currently exposes the confirmed Sundown Sessions channels that have configured URLs:
+
+- Facebook
+- Instagram
+- TikTok
+- Mixcloud
+- Pinterest
+- X / Twitter
+- Mastodon
+- LinkedIn
+
+Bluesky was listed in the original issue as a desired footer channel, but no verified official Sundown Sessions Bluesky profile URL is currently present in the repository. It should be added to `params.author.links` only after the official account URL is confirmed.
+
+## Operational Pinterest launch checklist
+
+These items cannot be completed purely in code, but should be completed before considering the public Pinterest presence fully launched:
+
+1. Confirm whether the Pinterest account is a Business account.
+2. Confirm the official profile name and handle.
+3. Configure the approved Sundown Sessions profile image.
+4. Configure banner artwork using approved station imagery.
+5. Add a completed bio that reflects the station proposition.
+6. Complete or record the outcome of website verification for the production domain.
+7. Create starter boards before broader promotion.
+8. Publish initial pins before broader promotion.
+
+Suggested starter boards from issue #487 remain appropriate:
+
+- Listen Again Highlights
+- Presenters
+- Behind the Mic
+- Music Discovery
+- Sundown Sessions
+- Guest Interviews
+- Competitions & Promotions
+- Merchandise
+
+## White-label considerations
+
+The current implementation is already configuration-driven through `params.author.links`, which keeps footer social channels outside the theme templates and avoids hard-coded theme changes.
+
+For a future SaaS or white-label version, each hosted station should provide its own social channel map, for example:
+
+```toml
+[author]
+  links = [
+    { facebook = "https://www.facebook.com/example-station" },
+    { instagram = "https://www.instagram.com/example-station" },
+    { pinterest = "https://www.pinterest.com/example-station" },
+  ]
+
+[verification]
+  pinterest = "station-specific-domain-verification-token"
+```
+
+This preserves per-station control of social profiles and domain verification while continuing to use the shared footer rendering.


### PR DESCRIPTION
### Motivation
- Capture the current repository status against issue #487 by documenting what is already supported for Pinterest and what remains to be done outside code.
- Surface where social links are configured so future changes (e.g. adding Bluesky) are done in the correct place and only after account details are confirmed.
- Provide an operational checklist and white-label guidance to make it clear which steps are non-code tasks.

### Description
- Add `docs/pinterest-social-presence.md` which summarizes the repo's Pinterest coverage, including that footer social links are driven by `src/config/_default/params.toml` `params.author.links`, `article.sharingLinks` includes `pinterest`, and `head.html` supports `params.verification.pinterest` for domain verification.
- Document that the active Pinterest profile URL is `https://www.pinterest.co.uk/sundownsessionsshow/` and that Bluesky is not present in the repository and should only be added after confirmation.
- Include an "Operational Pinterest launch checklist" of non-code tasks and a short white-label example TOML showing how per-station social links and Pinterest verification tokens could be provided.

### Testing
- Attempted to run a local site build with `hugo --source src --themesDir themes --minify` but it could not run because `hugo` is not installed in the environment (failed).
- Attempted to lint the new markdown with `npx markdownlint-cli2 docs/pinterest-social-presence.md` but the run failed due to npm registry access returning a 403 (failed).
- Attempted `git submodule update --init --recursive` to fetch the theme for a full build but submodule cloning failed due to network/403 errors (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b9d3ac08832d8940bc979e6f056f)