### PR TITLE
feat: prioritise listen live CTA

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -3874,3 +3874,36 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
     grid-template-columns: minmax(13rem, 0.65fr) minmax(0, 1.35fr);
   }
 }
+
+/* Homepage primary listen-live call-to-action. */
+.homepage-listen-cta {
+  min-height: 3.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.045em;
+  box-shadow:
+    0 1rem 2.4rem rgb(0 0 0 / 0.32),
+    0 0 0 0.18rem rgb(255 255 255 / 0.28);
+}
+
+.homepage-listen-cta:hover,
+.homepage-listen-cta:focus-visible {
+  transform: translateY(-1px);
+  box-shadow:
+    0 1.15rem 2.7rem rgb(0 0 0 / 0.38),
+    0 0 0 0.2rem rgb(255 255 255 / 0.34);
+}
+
+.homepage-listen-cta__icon {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.homepage-live-note {
+  max-width: 22rem;
+}
+
+@media (max-width: 640px) {
+  .homepage-listen-cta {
+    width: min(100%, 18rem);
+  }
+}

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -1,27 +1,21 @@
 <footer id="site-footer" class="py-10 print:hidden">
   {{/* Footer menu */}}
   {{ if .Site.Params.footer.showMenu | default true }}
-    {{ $listenURL := .Site.Params.listen_live_stream_url | default "" }}
-    {{ $hasListenURL := and (ne $listenURL "") (ne $listenURL "#") }}
-    {{ if or $hasListenURL .Site.Menus.footer }}
+    {{ $listenURL := "/listen-live/" | relURL }}
+    {{ if or $listenURL .Site.Menus.footer }}
       <nav class="pb-4 text-base font-medium text-neutral-500 dark:text-neutral-400" aria-label="Footer">
         <ul class="flex list-none flex-wrap justify-center gap-x-5 gap-y-2 p-0 sm:justify-start">
-          {{ if $hasListenURL }}
-            <li class="flex">
-              <a
-                class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2"
-                href="{{ $listenURL }}"
-                data-analytics-event="listen_live_click"
-                data-analytics-provider="live-stream"
-                {{ if or (strings.HasPrefix $listenURL "http:") (strings.HasPrefix $listenURL "https:") }}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                {{ end }}
-                title="Listen to Sundown Sessions live">
-                Listen Live
-              </a>
-            </li>
-          {{ end }}
+          <li class="flex">
+            <a
+              class="font-semibold text-primary-700 decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2 dark:text-primary-400"
+              href="{{ $listenURL }}"
+              data-analytics-event="listen_live_click"
+              data-analytics-provider="footer-listen-live"
+              aria-label="Listen live to Sundown Sessions"
+              title="Listen to Sundown Sessions live">
+              ▶ Listen Live
+            </a>
+          </li>
           {{ range .Site.Menus.footer }}
             {{ $isExternal := or (strings.HasPrefix .URL "http:") (strings.HasPrefix .URL "https:") }}
             <li class="flex">

--- a/src/layouts/partials/home/custom.html
+++ b/src/layouts/partials/home/custom.html
@@ -42,6 +42,18 @@
             {{ with .Params.strapline }}
               <p class="mt-2 text-base font-semibold tracking-widest text-neutral-200 drop-shadow-lg hero-text-shadow uppercase sm:text-lg">{{ . }}</p>
             {{ end }}
+            <a
+              class="homepage-listen-cta ss-primary-action mt-6 inline-flex items-center justify-center gap-3 rounded-full px-7 py-3.5 text-base font-extrabold tracking-wide transition sm:px-8 sm:py-4 sm:text-lg"
+              href="{{ "/listen-live/" | relURL }}"
+              data-analytics-event="listen_live_click"
+              data-analytics-provider="homepage-hero"
+              aria-label="Listen live to Sundown Sessions">
+              <span class="homepage-listen-cta__icon flex items-center justify-center" aria-hidden="true">
+                {{ partial "icon.html" "play" }}
+              </span>
+              <span>Listen Live</span>
+            </a>
+            <p class="homepage-live-note mt-3 text-sm font-bold tracking-wider text-neutral-100 drop-shadow-lg hero-text-shadow uppercase sm:text-base">Live stream and latest track info</p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Make the site’s primary call-to-action for live listening prominent and accessible so visitors can quickly open the Listen Live page from the homepage hero. 
- Ensure a persistent Listen Live entry in the footer that links to the dedicated listen page rather than depending on a configured stream URL. 
- Add basic analytics attributes and accessible labelling so clicks can be tracked and the CTA is screen-reader friendly.

### Description
- Added a prominent hero CTA to the homepage by updating `src/layouts/partials/home/custom.html` with a `Listen Live` button (play icon, `aria-label`, and analytics attributes `data-analytics-event` / `data-analytics-provider`).
- Made the footer always expose a `▶ Listen Live` entry by changing the logic in `src/layouts/partials/footer.html` to link to `"/listen-live/"` and added analytics and an `aria-label` for the footer link.
- Added responsive styling for the homepage CTA in `src/assets/css/custom.css` (styles for `.homepage-listen-cta`, `.homepage-listen-cta__icon`, and `.homepage-live-note`).
- Files modified: `src/layouts/partials/home/custom.html`, `src/layouts/partials/footer.html`, `src/assets/css/custom.css`.

### Testing
- Ran `git diff --check` to validate diff hygiene and it succeeded. 
- Attempted to run `hugo --source src --environment production --printPathWarnings --panicOnWarning` to validate the site build, but Hugo was not available locally and fetching the workflow-pinned Hugo package was blocked by the environment proxy, so the build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50be5219f4832da7068111885dcf6c)