### PR TITLE
Add global keyboard navigation shortcuts and help dialog

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -3874,3 +3874,118 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
     grid-template-columns: minmax(13rem, 0.65fr) minmax(0, 1.35fr);
   }
 }
+
+/* Global keyboard shortcut help dialog. */
+.keyboard-shortcuts-help[hidden] {
+  display: none;
+}
+
+.keyboard-shortcuts-help {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgb(16 19 31 / 0.58);
+  backdrop-filter: blur(0.18rem);
+}
+
+.keyboard-shortcuts-help__panel {
+  position: relative;
+  width: min(100%, 34rem);
+  max-height: min(42rem, calc(100vh - 3rem));
+  overflow: auto;
+  border: 1px solid var(--ss-color-border);
+  border-radius: 1rem;
+  background: var(--ss-color-surface);
+  color: var(--ss-color-midnight);
+  box-shadow: 0 1.25rem 3rem rgb(0 0 0 / 0.28);
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.keyboard-shortcuts-help__panel h2 {
+  margin: 0 2rem 0.5rem 0;
+  color: var(--ss-color-midnight);
+  font-size: clamp(1.4rem, 4vw, 1.8rem);
+  line-height: 1.2;
+}
+
+.keyboard-shortcuts-help__panel p {
+  margin: 0 0 1rem;
+  color: var(--ss-color-muted);
+  line-height: 1.6;
+}
+
+.keyboard-shortcuts-help__panel dl {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.keyboard-shortcuts-help__panel dl > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--ss-color-border);
+  padding-top: 0.65rem;
+}
+
+.keyboard-shortcuts-help__panel dt,
+.keyboard-shortcuts-help__panel dd {
+  margin: 0;
+}
+
+.keyboard-shortcuts-help__panel dt {
+  flex: 0 0 auto;
+  font-weight: 700;
+}
+
+.keyboard-shortcuts-help__panel dd {
+  color: var(--ss-color-muted);
+  text-align: right;
+}
+
+.keyboard-shortcuts-help__panel kbd {
+  display: inline-flex;
+  min-width: 1.8rem;
+  justify-content: center;
+  border: 1px solid var(--ss-color-border);
+  border-radius: 0.4rem;
+  background: color-mix(in srgb, var(--ss-color-surface) 74%, var(--ss-color-midnight));
+  padding: 0.1rem 0.45rem;
+  color: var(--ss-color-midnight);
+  font-size: 0.85em;
+  box-shadow: inset 0 -0.1rem 0 rgb(0 0 0 / 0.12);
+}
+
+.keyboard-shortcuts-help__close {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: var(--ss-color-midnight);
+  font-size: 1.45rem;
+  line-height: 1;
+}
+
+.keyboard-shortcuts-help__close:hover,
+.keyboard-shortcuts-help__close:focus-visible {
+  background: color-mix(in srgb, var(--ss-color-sunset) 16%, transparent);
+  outline: 2px solid var(--ss-color-focus);
+  outline-offset: 0.12rem;
+}
+
+.dark .keyboard-shortcuts-help {
+  background: rgb(0 0 0 / 0.68);
+}
+
+.dark .keyboard-shortcuts-help__panel kbd {
+  background: color-mix(in srgb, var(--ss-color-surface) 72%, white);
+}

--- a/src/assets/js/global-navigation-shortcuts.js
+++ b/src/assets/js/global-navigation-shortcuts.js
@@ -1,0 +1,177 @@
+(function () {
+  "use strict";
+
+  var chordTimeout;
+  var awaitingGoTo = false;
+  var shortcutTimeoutMs = 1500;
+  var routes = {
+    h: { label: "Home", path: "/" },
+    s: { label: "Shows", path: "/shows/" },
+    a: { label: "About", path: "/about/" },
+    c: { label: "Contact", path: "/contact/" },
+  };
+
+  function isEditableTarget(target) {
+    if (!target) return false;
+    var editableSelector = "input, textarea, select, [contenteditable=''], [contenteditable='true'], [role='textbox']";
+    return Boolean(target.closest && target.closest(editableSelector));
+  }
+
+  function resetChord() {
+    awaitingGoTo = false;
+    window.clearTimeout(chordTimeout);
+  }
+
+  function getHomeUrl() {
+    var homeLink = document.querySelector('a[title*="home" i][href], a[href="/"]');
+    return homeLink ? homeLink.href : window.location.origin + "/";
+  }
+
+  function withSiteRoot(path) {
+    return new URL(path.replace(/^\//, ""), getHomeUrl()).href;
+  }
+
+  function goTo(path) {
+    window.location.assign(withSiteRoot(path));
+  }
+
+  function focusSearch() {
+    var activeSearchInput = document.querySelector("#search input[type='search'], #search input, input[type='search'], #search-query");
+    if (activeSearchInput) {
+      activeSearchInput.focus();
+      if (typeof activeSearchInput.select === "function") activeSearchInput.select();
+      return;
+    }
+
+    var searchButton = document.getElementById("search-button") || document.getElementById("search-button-mobile");
+    if (searchButton) {
+      searchButton.click();
+      window.setTimeout(function () {
+        var openedSearchInput = document.querySelector("#search input[type='search'], #search input, input[type='search'], #search-query");
+        if (openedSearchInput) openedSearchInput.focus();
+      }, 50);
+      return;
+    }
+
+    goTo("/search/");
+  }
+
+  function toggleTheme() {
+    var switcher = document.getElementById("appearance-switcher") || document.getElementById("appearance-switcher-mobile");
+    if (switcher) switcher.click();
+  }
+
+  function ensureHelpDialog() {
+    var existing = document.getElementById("keyboard-shortcuts-help");
+    if (existing) return existing;
+
+    var dialog = document.createElement("section");
+    dialog.id = "keyboard-shortcuts-help";
+    dialog.className = "keyboard-shortcuts-help";
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.setAttribute("aria-labelledby", "keyboard-shortcuts-help-title");
+    dialog.setAttribute("hidden", "");
+    dialog.innerHTML = [
+      '<div class="keyboard-shortcuts-help__panel" role="document">',
+      '<button type="button" class="keyboard-shortcuts-help__close" aria-label="Close keyboard shortcuts help">&times;</button>',
+      '<h2 id="keyboard-shortcuts-help-title">Keyboard shortcuts</h2>',
+      '<p>Use these shortcuts anywhere on the site. They are ignored while typing in form fields.</p>',
+      '<dl>',
+      '<div><dt><kbd>g</kbd> then <kbd>h</kbd></dt><dd>Go to Home</dd></div>',
+      '<div><dt><kbd>g</kbd> then <kbd>s</kbd></dt><dd>Go to Shows</dd></div>',
+      '<div><dt><kbd>g</kbd> then <kbd>a</kbd></dt><dd>Go to About</dd></div>',
+      '<div><dt><kbd>g</kbd> then <kbd>c</kbd></dt><dd>Go to Contact</dd></div>',
+      '<div><dt><kbd>/</kbd></dt><dd>Open or focus Search</dd></div>',
+      '<div><dt><kbd>g</kbd> then <kbd>d</kbd></dt><dd>Toggle dark mode</dd></div>',
+      '<div><dt><kbd>?</kbd></dt><dd>Show this help</dd></div>',
+      '</dl>',
+      '</div>',
+    ].join("");
+
+    document.body.appendChild(dialog);
+    dialog.querySelector(".keyboard-shortcuts-help__close").addEventListener("click", closeHelp);
+    dialog.addEventListener("click", function (event) {
+      if (event.target === dialog) closeHelp();
+    });
+    return dialog;
+  }
+
+  function openHelp() {
+    var dialog = ensureHelpDialog();
+    dialog.removeAttribute("hidden");
+    var closeButton = dialog.querySelector("button");
+    if (closeButton) closeButton.focus();
+  }
+
+  function closeHelp() {
+    var dialog = document.getElementById("keyboard-shortcuts-help");
+    if (dialog) dialog.setAttribute("hidden", "");
+  }
+
+  function addShortcutTitle(selector, shortcut) {
+    document.querySelectorAll(selector).forEach(function (element) {
+      var title = element.getAttribute("title") || element.getAttribute("aria-label") || element.textContent.trim();
+      if (!title || title.indexOf(shortcut) !== -1) return;
+      element.setAttribute("title", title + " (" + shortcut + ")");
+    });
+  }
+
+  function annotateShortcuts() {
+    addShortcutTitle('a[href="/"], a[href$="/"][title*="home" i]', "g then h");
+    addShortcutTitle('a[href="/shows/"], a[href$="/shows/"]', "g then s");
+    addShortcutTitle('a[href="/about/"], a[href$="/about/"]', "g then a");
+    addShortcutTitle('a[href="/contact/"], a[href$="/contact/"]', "g then c");
+    addShortcutTitle('#search-button, #search-button-mobile, a[href="/search/"], a[href$="/search/"]', "/");
+    addShortcutTitle('#appearance-switcher, #appearance-switcher-mobile', "g then d");
+  }
+
+  document.addEventListener("keydown", function (event) {
+    if (event.defaultPrevented || event.ctrlKey || event.metaKey || event.altKey || isEditableTarget(event.target)) return;
+
+    var key = event.key.toLowerCase();
+    if (key === "escape") {
+      closeHelp();
+      resetChord();
+      return;
+    }
+
+    if (key === "?") {
+      event.preventDefault();
+      resetChord();
+      openHelp();
+      return;
+    }
+
+    if (key === "/") {
+      event.preventDefault();
+      resetChord();
+      focusSearch();
+      return;
+    }
+
+    if (awaitingGoTo) {
+      if (routes[key]) {
+        event.preventDefault();
+        goTo(routes[key].path);
+      } else if (key === "d") {
+        event.preventDefault();
+        toggleTheme();
+      }
+      resetChord();
+      return;
+    }
+
+    if (key === "g") {
+      awaitingGoTo = true;
+      window.clearTimeout(chordTimeout);
+      chordTimeout = window.setTimeout(resetChord, shortcutTimeoutMs);
+    }
+  });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", annotateShortcuts);
+  } else {
+    annotateShortcuts();
+  }
+})();

--- a/src/config/_default/menus.toml
+++ b/src/config/_default/menus.toml
@@ -1,3 +1,24 @@
+[[main]]
+  identifier = "shows"
+  name = "Shows"
+  title = "Browse Sundown Sessions shows (g then s)"
+  url = "/shows/"
+  weight = 10
+
+[[main]]
+  identifier = "about"
+  name = "About"
+  title = "Learn about Sundown Sessions (g then a)"
+  url = "/about/"
+  weight = 20
+
+[[main]]
+  identifier = "contact"
+  name = "Contact"
+  title = "Get in touch with the show (g then c)"
+  url = "/contact/"
+  weight = 30
+
 [[footer]]
   identifier = "listen-again"
   name = "Listen Again"

--- a/src/layouts/partials/head.html
+++ b/src/layouts/partials/head.html
@@ -176,6 +176,9 @@
   {{ $jsResources = $jsResources | append (resources.Get "js/katex-render.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/print-support.js") }}
   {{ $jsResources = $jsResources | append (resources.Get "js/email.js") }}
+  {{ with resources.Get "js/global-navigation-shortcuts.js" }}
+    {{ $jsResources = $jsResources | append . }}
+  {{ end }}
   {{ if $jsResources }}
     {{ $bundleJS := $jsResources | resources.Concat "js/main.bundle.js" | resources.Minify | resources.Fingerprint $alg }}
     <script


### PR DESCRIPTION
### Motivation
- Improve site discoverability and keyboard accessibility by adding global navigation shortcuts and an in-page help dialog.
- Provide quick navigation (`g` chords), search activation (`/`), and appearance toggling to support power users and keyboard-first workflows.
- Ensure shortcuts are ignored while typing and that the help dialog is accessible and styled for both light and dark themes.

### Description
- Added `src/assets/js/global-navigation-shortcuts.js` which implements `g` chord navigation (`g` then `h|s|a|c`), `/` to focus/open search, `g d` to toggle theme, `?` to open a keyboard-shortcuts help dialog, `Escape` to close help, and editable-field ignoring for safe input.
- Added UI annotations in the script to append shortcut hints to navigation, search, and appearance controls via `title` attributes for discoverability.
- Added CSS in `src/assets/css/custom.css` to style the help dialog and provide dark-mode support and focus/close affordances.
- Restored primary navigation entries in `src/config/_default/menus.toml` (Shows, About, Contact) with shortcut-aware titles and included the shortcut script in the Hugo JS bundle by updating `src/layouts/partials/head.html`.

### Testing
- Ran `node --check src/assets/js/global-navigation-shortcuts.js` which succeeded with no syntax errors. 
- Ran `git diff --check` which reported no indexable whitespace or diff issues. 
- Attempted `hugo --source src --gc --minify` but it could not be run in this environment because `hugo` is not installed, so site build verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50be813d08832da5138794beabc2a2)