### PR TITLE
Remove page-level menu front matter to fix duplicate header menu items

### DIFF
--- a/src/content/about/index.md
+++ b/src/content/about/index.md
@@ -3,11 +3,6 @@ title: 'About Sundown Sessions'
 strapline: 'Alternative music after dark, curated by hand.'
 description: 'Sundown Sessions is an independent home for alternative music after dark, featuring curated broadcasts, track listings, artist discovery, releases and Listen Again links.'
 featured_image: 'about-sundown-sessions-hero.png'
-menu:
-  main:
-    name: 'About'
-    title: 'Learn about the story behind Sundown Sessions, how the music is chosen, and the people behind the broadcasts.'
-    weight: 3
 showDate: false
 showReadingTime: false
 showPagination: false

--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -2,10 +2,6 @@
 title: 'Contact'
 strapline: "We'd love to hear from you."
 description: 'Contact Sundown Sessions with music submissions, gig news, interview ideas, listener messages, label updates, promoter enquiries and festival or venue opportunities.'
-menu:
-  main:
-    title: 'Get in touch with the show.'
-    weight: 4
 showDate: false
 showReadingTime: false
 showPagination: false

--- a/src/content/shows/_index.md
+++ b/src/content/shows/_index.md
@@ -3,11 +3,6 @@ title: 'Shows Archive'
 description: 'Browse Sundown Sessions broadcasts, playlists, featured artists and music discoveries from the archive.'
 summary: 'Explore previous Sundown Sessions broadcasts, with playlists, featured artists, show notes and routes into the wider music archive.'
 strapline: 'Broadcasts, playlists and late-night discoveries from Sundown Sessions.'
-menu:
-  main:
-    name: 'Shows'
-    title: 'Browse the Sundown Sessions shows archive'
-    weight: 1
 ---
 
 Every Sundown Sessions broadcast is a trail through the world of alternative music. Browse complete playlists, discover the artists and releases behind every track, and follow the connections wherever they lead.


### PR DESCRIPTION
### Motivation

- The header navigation was rendering duplicate items because the same menu entries existed both in page front matter and the central menu configuration, causing duplication in desktop menus.

### Description

- Removed page-level `menu.main` front matter from `src/content/shows/_index.md`, `src/content/about/index.md`, and `src/content/contact/index.md` so navigation is defined only in `src/config/_default/menus.toml`.
- This consolidates primary navigation sourcing to the central `menus.toml` and prevents duplicate menu links in the header.

### Testing

- Ran `rg -n "^menu:|^\s+main:|\[\[main\]\]" src/content src/config/_default/menus.toml -S` to verify page-level `menu.main` blocks were removed and the central menu remained, which succeeded. 
- Ran `git diff --check` to validate no whitespace or diff issues, which returned clean. 
- Attempted `hugo --source src --gc --minify` but it could not run in this environment because `hugo` is not installed, so a full static build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50cd451cbc832d9614586a3f1f9f45)