### PR TITLE
Restore active nav underline

### DIFF
--- a/src/layouts/partials/header/basic.html
+++ b/src/layouts/partials/header/basic.html
@@ -20,13 +20,19 @@
   {{/* Centre: desktop nav links */}}
   {{ if .Site.Menus.main }}
     <nav class="hidden md:flex flex-1 justify-center items-center gap-x-6 h-12">
+      {{ $currentPath := strings.TrimSuffix "/" $.RelPermalink }}
       {{ range .Site.Menus.main }}
+        {{ $menuPath := strings.TrimSuffix "/" (.URL | relLangURL) }}
+        {{ $isCurrent := or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }}
+        {{ $isCurrent = or $isCurrent (eq $currentPath $menuPath) }}
+        {{ $isCurrent = or $isCurrent (and (ne $menuPath "") (strings.HasPrefix $currentPath (printf "%s/" $menuPath))) }}
         <a
           href="{{ .URL }}"
           {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}
             target="_blank"
           {{ end }}
-          class="flex items-center text-base font-medium bf-icon-color-hover{{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} active{{ end }}"
+          class="flex items-center text-base font-medium bf-icon-color-hover{{ if $isCurrent }} active underline decoration-2 underline-offset-4 decoration-primary-500 dark:decoration-primary-400{{ end }}"
+          {{ if $isCurrent }}aria-current="page"{{ end }}
           {{ with or .Name .Pre }}aria-label="{{ . }}"{{ end }}
           title="{{ .Title }}">
           {{ if .Pre }}


### PR DESCRIPTION
### Motivation

- The desktop main navigation lost its persistent visual cue (an underline) when visiting pages like Shows, About, and Contact, reducing clarity after mouse or keyboard-shortcut navigation. 
- Restore the previous UX: the active menu item should show an underline and be announced as the current page for accessibility.

### Description

- Updated `src/layouts/partials/header/basic.html` to compute a normalized current URL path and each menu item's path, then set an `$isCurrent` flag that combines Hugo's `IsMenuCurrent/HasMenuCurrent` checks with a URL-path equality and prefix fallback. 
- When `$isCurrent` is true the anchor receives the `active` class plus underline/decoration utility classes and an `aria-current="page"` attribute for better screen-reader semantics. 
- The change ensures keyboard-chord navigation (e.g. `g then s/a/c`) and direct clicks both highlight the correct main nav item.

### Testing

- Ran `git diff --check`, which passed with no whitespace errors. 
- Attempted a local Hugo build with `hugo --source src --gc --minify` but it could not run because `hugo` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50cfcb75b8832d99ce2f3b5837a0d8)