### PR TITLE
Add accessibility standard, docs, pa11y config, workflow, and focus styles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+-
+
+## Testing
+
+-
+
+## Accessibility
+
+- [ ] I reviewed the affected pages against the WCAG 2.2 AA baseline in `docs/accessibility.md`.
+- [ ] Keyboard navigation, focus visibility, labels, alternative text, colour contrast, and responsive reflow were considered for the changed areas.
+- [ ] Automated accessibility checks were run where practical, or any limitations are noted above.

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,58 @@
+name: Accessibility
+
+on:
+  pull_request:
+    paths:
+      - src/**
+      - docs/accessibility.md
+      - .pa11yci.json
+      - .github/workflows/accessibility.yml
+  push:
+    branches:
+      - main
+    paths:
+      - src/**
+      - docs/accessibility.md
+      - .pa11yci.json
+      - .github/workflows/accessibility.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pa11y:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.146.5
+    steps:
+      - name: Checkout source using v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Set up Node.js using v6.0.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
+        with:
+          node-version: 22
+
+      - name: Build Hugo site
+        run: |
+          hugo \
+            --source src \
+            --environment production \
+            --baseURL http://127.0.0.1:1313/
+
+      - name: Serve built site
+        run: |
+          python3 -m http.server 1313 --bind 127.0.0.1 --directory ./src/public &
+          echo $! > /tmp/sundown-http-server.pid
+
+      - name: Run pa11y accessibility checks
+        run: npx --yes pa11y-ci --config .pa11yci.json

--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -1,0 +1,22 @@
+{
+  "defaults": {
+    "standard": "WCAG2AA",
+    "timeout": 30000,
+    "wait": 500,
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+    }
+  },
+  "urls": [
+    "http://127.0.0.1:1313/",
+    "http://127.0.0.1:1313/shows/",
+    "http://127.0.0.1:1313/shows/1/",
+    "http://127.0.0.1:1313/artists/",
+    "http://127.0.0.1:1313/releases/",
+    "http://127.0.0.1:1313/listen-live/",
+    "http://127.0.0.1:1313/contact/",
+    "http://127.0.0.1:1313/about/",
+    "http://127.0.0.1:1313/search/",
+    "http://127.0.0.1:1313/404.html"
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,14 @@ Examples:
 
 Pull request descriptions should clearly explain intent, context, and impact.
 
+## Accessibility Standard
+
+Sundown Sessions targets **WCAG 2.2 Level AA** as the minimum accessibility standard for public-facing website changes. Treat accessibility as part of normal design, development, content, review, and testing work.
+
+Before opening a pull request that changes `src/content/`, `src/layouts/`, `src/assets/`, or public-facing configuration, review the affected pages for keyboard access, visible focus, alternative text, colour contrast, semantic HTML, form labels, responsive reflow, and screen reader impact.
+
+The detailed accessibility baseline, review checklist, and automated/manual validation guidance are documented in [docs/accessibility.md](docs/accessibility.md).
+
 ## Release and Deployment Notes
 
 ### Website

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,81 @@
+# Accessibility Standard
+
+Sundown Sessions targets **WCAG 2.2 Level AA** as the minimum accessibility standard for the public website.
+
+Accessibility is a core quality attribute of the site. It should be considered during design, development, content creation, review, testing, and future maintenance rather than treated as a one-off remediation exercise.
+
+## Scope
+
+The standard applies to all public-facing pages, templates, components, and content, including:
+
+- Homepage and section listing pages.
+- Show, artist, release, track, about, contact, search, and listen-live pages.
+- Header navigation, footer navigation, menus, forms, media players, theme switching, search, and other interactive elements.
+- Images, artwork, icons, embedded media, and editorial content.
+
+## Development expectations
+
+All changes should preserve or improve accessibility by default. Contributors should:
+
+- Use semantic HTML before adding ARIA.
+- Provide meaningful text alternatives for informative images.
+- Mark decorative images and icons so they are ignored by assistive technologies.
+- Keep link and button text descriptive when read out of context.
+- Ensure all interactive controls have accessible names.
+- Preserve visible focus indicators and logical focus order.
+- Avoid keyboard traps and ensure all functionality can be operated with a keyboard.
+- Maintain sufficient colour contrast for text, controls, focus states, and meaningful visual indicators.
+- Support responsive reflow and text zoom without loss of content or functionality.
+- Provide labels, instructions, and status messages for forms and dynamic interactions.
+- Prefer predictable behaviour and plain, concise language for user-facing copy.
+
+## Review checklist
+
+Before opening or merging a pull request that changes public-facing output, review the affected pages against this checklist:
+
+### Perceivable
+
+- Images have appropriate `alt` text, or empty `alt` text when decorative.
+- Icons used as controls are accompanied by accessible labels.
+- Text and UI states meet WCAG AA contrast expectations.
+- Content remains readable when text is resized and at narrow viewports.
+- Audio, media, and live-stream affordances include equivalent text labels or instructions where practical.
+
+### Operable
+
+- Links, buttons, menus, forms, and media controls are reachable and usable with the keyboard.
+- Focus order follows the visual and document order.
+- Focus is visible on custom links and controls.
+- Skip links, navigation, and landmark structure remain usable.
+- Touch targets are large enough for comfortable activation where custom controls are introduced.
+
+### Understandable
+
+- Navigation labels are consistent across desktop and mobile views.
+- Forms provide clear labels, instructions, and status messages.
+- Error and success messages are announced where dynamic behaviour is used.
+- User-facing copy uses British English and avoids unnecessary jargon.
+
+### Robust
+
+- HTML is valid and uses landmarks, headings, lists, buttons, and links for their intended purposes.
+- ARIA is only used when native HTML is insufficient.
+- ARIA attributes remain synchronised with visible state.
+- Dynamic components remain understandable to screen readers and other assistive technologies.
+
+## Automated validation
+
+Automated checks cannot prove full WCAG conformance, but they help catch regressions early. The repository includes an accessibility workflow that builds the Hugo site and runs `pa11y-ci` against representative pages on pull requests and pushes that affect the website.
+
+When changing templates, layout, navigation, forms, or interactive behaviour, run an equivalent local accessibility check where possible and document any limitations in the pull request.
+
+## Manual validation
+
+Manual testing is required for meaningful accessibility confidence. For substantial user-facing changes, validate the affected journeys using:
+
+- Keyboard-only navigation.
+- Browser zoom and responsive reflow checks at 200% and, where practical, up to 400%.
+- Colour contrast inspection for new colour combinations.
+- Screen reader spot checks with available assistive technology, such as NVDA, VoiceOver, or Narrator.
+
+Document the pages and journeys tested in the pull request. If a check cannot be completed locally, call out the limitation and any follow-up needed.

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -103,6 +103,26 @@
   color: #10131f;
 }
 
+/* Baseline accessible focus treatment for custom interactive components. */
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+label[for]:focus-visible {
+  outline: 3px solid var(--ss-color-focus);
+  outline-offset: 0.2rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Listen Live page: scoped editorial listening layout. */
 
 .listen-live-page {

--- a/src/layouts/partials/header/components/mobile-menu.html
+++ b/src/layouts/partials/header/components/mobile-menu.html
@@ -30,19 +30,21 @@
     .Site.Params.enableA11y
   }}
     <input type="checkbox" id="mobile-menu-toggle" autocomplete="off" class="hidden peer">
-    <label for="mobile-menu-toggle" class="flex items-center justify-center cursor-pointer bf-icon-color-hover">
+    <label for="mobile-menu-toggle" class="flex items-center justify-center cursor-pointer bf-icon-color-hover" aria-label="Open navigation menu">
       {{ partial "icon.html" "bars" }}
     </label>
 
     <div
       role="dialog"
       aria-modal="true"
+      aria-label="Site navigation"
       style="scrollbar-gutter: stable;"
       class="fixed inset-0 z-50 invisible overflow-y-auto px-6 py-20 opacity-0 transition-[opacity,visibility] duration-300 peer-checked:visible peer-checked:opacity-100 bg-neutral-50/97 dark:bg-neutral-900/99
       {{ if site.Params.enableStyledScrollbar | default true }}bf-scrollbar{{ end }}">
       <label
         for="mobile-menu-toggle"
-        class="fixed end-8 top-5 flex items-center justify-center z-50 h-12 w-12 cursor-pointer select-none rounded-full bf-icon-color-hover border bf-border-color bf-border-color-hover bg-neutral-50 dark:bg-neutral-900">
+        class="fixed end-8 top-5 flex items-center justify-center z-50 h-12 w-12 cursor-pointer select-none rounded-full bf-icon-color-hover border bf-border-color bf-border-color-hover bg-neutral-50 dark:bg-neutral-900"
+        aria-label="Close navigation menu">
         {{ partial "icon.html" "xmark" }}
       </label>
       <nav class="mx-auto max-w-md space-y-6">
@@ -77,7 +79,8 @@
         {{ if .HasChildren }}
           <label
             for="{{ $submenuId }}"
-            class="ms-auto flex items-center justify-center h-10 w-10 cursor-pointer rounded-lg bf-icon-color-hover border bf-border-color bf-border-color-hover">
+            class="ms-auto flex items-center justify-center h-10 w-10 cursor-pointer rounded-lg bf-icon-color-hover border bf-border-color bf-border-color-hover"
+            aria-label="Toggle submenu">
             {{ partial "icon.html" "chevron-down" }}
           </label>
         {{ end }}


### PR DESCRIPTION
### Motivation

- Establish a clear accessibility baseline (WCAG 2.2 AA) and make accessibility part of normal development and review. 
- Provide automated regression checks and representative pages to catch accessibility issues early. 
- Improve keyboard and focus affordances for custom interactive components and the mobile navigation.

### Description

- Add `docs/accessibility.md` documenting the accessibility standard, development expectations, review checklist, and validation guidance. 
- Add an accessibility GitHub Actions workflow (`.github/workflows/accessibility.yml`) that builds the Hugo site and runs `pa11y-ci` against representative pages. 
- Add `.pa11yci.json` with `WCAG2AA` defaults and a list of URLs to scan. 
- Update `CONTRIBUTING.md` with an accessibility section referencing the new baseline and guidance. 
- Add a PR template at `.github/pull_request_template.md` including an accessibility checklist. 
- Improve frontend accessibility: add focus-visible outlines and reduced-motion handling in `src/assets/css/custom.css`, and add ARIA labels and modal semantics to the mobile menu in `src/layouts/partials/header/components/mobile-menu.html`.

### Testing

- No automated tests were executed as part of this rollout; the new `Accessibility` workflow will run `hugo` and `pa11y-ci` on CI for future pull requests and pushes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51005f6bc4832d81f2e155c79bce38)