### PR TITLE
Align Artist Spotlight anchor and update shortcodes to use partial

### DIFF
--- a/src/layouts/partials/show/artist-spotlight-anchor.html
+++ b/src/layouts/partials/show/artist-spotlight-anchor.html
@@ -1,0 +1,2 @@
+{{- /* Keep Artist Spotlight in-page links aligned with Hugo's generated heading id for `## Artist Spotlight`. */ -}}
+{{- return "artist-spotlight" -}}

--- a/src/layouts/shortcodes/featured-guest-wikilink.html
+++ b/src/layouts/shortcodes/featured-guest-wikilink.html
@@ -1,3 +1,4 @@
 {{ $link := .Get 0 }}
 {{ $slug := .Get 0 | urlize }}
-<a href="{{ printf "%sshows/featuring-%s/#featured-artist" .Site.BaseURL $slug | safeURL}}">{{ $link }}</a>
+{{ $artistSpotlightAnchorId := partial "show/artist-spotlight-anchor.html" . }}
+<a href="{{ printf "%sshows/featuring-%s/#%s" .Site.BaseURL $slug $artistSpotlightAnchorId | safeURL}}">{{ $link }}</a>

--- a/src/layouts/shortcodes/track-info-featured-guest.html
+++ b/src/layouts/shortcodes/track-info-featured-guest.html
@@ -7,7 +7,8 @@
     {{ if ge (len $parts) 3 }}
         {{ with index $parts 2 | strings.TrimSpace }}{{ $trackUri = . }}{{ end }}
     {{ end }}
-    {{ $featuredGuestAnchor := printf "%sshows/featuring-%s/#featured-artist" $.Site.BaseURL ($artist | urlize) | safeURL }}
+    {{ $artistSpotlightAnchorId := partial "show/artist-spotlight-anchor.html" . }}
+    {{ $featuredGuestAnchor := printf "%sshows/featuring-%s/#%s" $.Site.BaseURL ($artist | urlize) $artistSpotlightAnchorId | safeURL }}
     {{ $featuredGuestImageUri := printf "%s-large.jpeg" $artist | urlize }}
     <div style="display: flex; align-items: center;">
         <img src="{{ $featuredGuestImageUri }}" alt="" loading="lazy" style="width: 20%; height: auto; margin-right: 10px;">


### PR DESCRIPTION
### Motivation
- Ensure in-page links to the Artist Spotlight heading match Hugo's generated heading id for `## Artist Spotlight` so featured guest links navigate correctly.

### Description
- Add `src/layouts/partials/show/artist-spotlight-anchor.html` which returns the canonical anchor id `artist-spotlight` and update `src/layouts/shortcodes/featured-guest-wikilink.html` and `src/layouts/shortcodes/track-info-featured-guest.html` to use that partial when constructing the show links instead of the hardcoded `#featured-artist` anchor.

### Testing
- Ran a site build with `hugo` to generate pages and verify the shortcodes render anchor links pointing to `#artist-spotlight`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510db8abd0832dba50f6979d4f9893)