### PR TITLE
fix: prevent blurred Listen Live artwork

### DIFF
--- a/docs/listen-live-artwork.md
+++ b/docs/listen-live-artwork.md
@@ -1,0 +1,48 @@
+# Listen Live Artwork Quality
+
+## Investigation
+
+The NuCast now-playing response was inspected on 15 July 2026 from the same
+public endpoint used by the Listen Live page. The response supplied a local
+NuCast cover URL whose intrinsic image dimensions were 185 by 185 pixels. The
+endpoint did not expose a separate large-artwork field, and requesting common
+larger URL variants returned either the same 185-pixel asset or a missing
+resource.
+
+The Listen Live artwork frame can render at 280 by 280 CSS pixels. The source
+image was therefore being enlarged to roughly 151% of its intrinsic size on a
+standard-density display, with a larger effective deficit on high-density
+screens. This browser interpolation was the cause of the visible softness.
+Changing `object-fit` alone could not improve the source image detail.
+
+## Rendering Behaviour
+
+The now-playing script continues to prefer explicit large-artwork metadata and
+known higher-resolution renditions when the upstream URL supports them. Once an
+image loads, the script compares its intrinsic dimensions with the available
+artwork frame.
+
+- Adequately sized square artwork fills the established square frame.
+- Non-square artwork uses `object-fit: contain` so it keeps its proportions and
+  is not cropped or stretched.
+- Low-resolution artwork is displayed as an intentional inset within the
+  branded frame. Its rendered dimensions are capped using the intrinsic image
+  size and a 1.5 source-pixel density target, rather than allowing the browser
+  to stretch it to 280 pixels.
+- Artwork with an edge below 96 pixels, artwork that fails to load, and missing
+  artwork use the existing branded Sundown Sessions fallback.
+- If a higher-resolution URL variant fails, the original artwork URL is tried
+  before the fallback is shown. Unrecoverable failures are retried on the next
+  metadata poll so a transient network problem does not hide artwork for the
+  rest of the track.
+
+This remains a client-side enhancement with no image-processing dependency,
+proxy, persisted third-party data, or change to audio playback and metadata
+polling.
+
+## Validation Notes
+
+The implementation can be checked off-air with captured metadata and images at
+representative square, portrait, landscape, tiny, and missing-image sizes. A
+listener-facing check during a live Tuesday broadcast is still required after
+deployment because the precise cover supplied by NuCast varies by track.

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -402,9 +402,15 @@ label[for]:focus-visible {
   padding: clamp(0.75rem, 4vw, 1.25rem);
 }
 
-.listen-live-now-playing__artwork[data-now-playing-low-resolution] img {
+.listen-live-now-playing__artwork[data-now-playing-low-resolution] > img {
+  width: min(100%, var(--now-playing-artwork-width, 100%));
+  height: min(100%, var(--now-playing-artwork-height, 100%));
   border-radius: 0.35rem;
   box-shadow: 0 10px 24px rgb(0 0 0 / 0.16);
+  object-fit: contain;
+}
+
+.listen-live-now-playing__artwork[data-now-playing-contain] > img {
   object-fit: contain;
 }
 

--- a/src/assets/js/listen-live-now-playing.js
+++ b/src/assets/js/listen-live-now-playing.js
@@ -4,6 +4,7 @@
   var POLL_INTERVAL_MS = 45000;
   var FALLBACK_COPY = "Waiting for track information...";
   var MIN_SHARP_ARTWORK_DENSITY = 1.5;
+  var MIN_USEFUL_ARTWORK_EDGE = 96;
 
   var root = document.querySelector("[data-now-playing]");
   if (!root || !window.fetch) {
@@ -53,15 +54,22 @@
     return null;
   }
 
-  function firstUrl(values) {
+  function firstArtwork(values) {
     for (var i = 0; i < values.length; i += 1) {
-      var value = improveArtworkUrl(clean(values[i]));
-      if (isUsefulUrl(value)) {
-        return value;
+      var original = clean(values[i]);
+      if (isUsefulUrl(original)) {
+        var improved = improveArtworkUrl(original);
+        return {
+          url: improved,
+          fallback: improved === original ? "" : original
+        };
       }
     }
 
-    return "";
+    return {
+      url: "",
+      fallback: ""
+    };
   }
 
   function improveArtworkUrl(value) {
@@ -157,6 +165,46 @@
       source.text
     ]);
 
+    var artwork = firstArtwork([
+      source.artworkLarge,
+      source.artwork_large,
+      source.coverartLarge,
+      source.coverart_large,
+      source.coverArtLarge,
+      source.cover_art_large,
+      source.imageLarge,
+      source.image_large,
+      source.imageUrlLarge,
+      source.image_url_large,
+      source.coverart,
+      source.coverArt,
+      source.cover_art,
+      source.artwork,
+      source.artworkUrl,
+      source.artwork_url,
+      source.art,
+      source.albumArt,
+      source.album_art,
+      source.cover,
+      source.coverUrl,
+      source.cover_url,
+      source.image,
+      source.imageUrl,
+      source.image_url,
+      trackObject && trackObject.artworkLarge,
+      trackObject && trackObject.artwork_large,
+      trackObject && trackObject.coverartLarge,
+      trackObject && trackObject.cover_art_large,
+      trackObject && trackObject.imageLarge,
+      trackObject && trackObject.image_url_large,
+      trackObject && trackObject.coverart,
+      trackObject && trackObject.artwork,
+      trackObject && trackObject.artworkUrl,
+      trackObject && trackObject.albumArt,
+      trackObject && trackObject.cover,
+      trackObject && trackObject.image
+    ]);
+
     var metadata = {
       artist: firstClean([
         source.artist,
@@ -185,45 +233,8 @@
         trackObject && trackObject.albumTitle,
         trackObject && trackObject.album_title
       ]),
-      artwork: firstUrl([
-        source.artworkLarge,
-        source.artwork_large,
-        source.coverartLarge,
-        source.coverart_large,
-        source.coverArtLarge,
-        source.cover_art_large,
-        source.imageLarge,
-        source.image_large,
-        source.imageUrlLarge,
-        source.image_url_large,
-        source.coverart,
-        source.coverArt,
-        source.cover_art,
-        source.artwork,
-        source.artworkUrl,
-        source.artwork_url,
-        source.art,
-        source.albumArt,
-        source.album_art,
-        source.cover,
-        source.coverUrl,
-        source.cover_url,
-        source.image,
-        source.imageUrl,
-        source.image_url,
-        trackObject && trackObject.artworkLarge,
-        trackObject && trackObject.artwork_large,
-        trackObject && trackObject.coverartLarge,
-        trackObject && trackObject.cover_art_large,
-        trackObject && trackObject.imageLarge,
-        trackObject && trackObject.image_url_large,
-        trackObject && trackObject.coverart,
-        trackObject && trackObject.artwork,
-        trackObject && trackObject.artworkUrl,
-        trackObject && trackObject.albumArt,
-        trackObject && trackObject.cover,
-        trackObject && trackObject.image
-      ])
+      artwork: artwork.url,
+      artworkFallback: artwork.fallback
     };
 
     if ((!metadata.artist || !metadata.track) && combinedTitle) {
@@ -254,6 +265,40 @@
 
     row.hidden = !value;
     setText(node, value || "");
+  }
+
+  function resetArtworkPresentation() {
+    if (!elements.artworkWrap) {
+      return;
+    }
+
+    elements.artworkWrap.removeAttribute("data-now-playing-low-resolution");
+    elements.artworkWrap.removeAttribute("data-now-playing-contain");
+    elements.artworkWrap.style.removeProperty("--now-playing-artwork-width");
+    elements.artworkWrap.style.removeProperty("--now-playing-artwork-height");
+  }
+
+  function showArtworkPlaceholder() {
+    if (elements.artwork) {
+      elements.artwork.hidden = true;
+    }
+    if (elements.placeholder) {
+      elements.placeholder.hidden = false;
+    }
+  }
+
+  function clearArtwork() {
+    if (elements.artwork) {
+      elements.artwork.hidden = true;
+      elements.artwork.onload = null;
+      elements.artwork.onerror = null;
+      elements.artwork.removeAttribute("src");
+      elements.artwork.removeAttribute("srcset");
+      elements.artwork.alt = "";
+    }
+
+    resetArtworkPresentation();
+    showArtworkPlaceholder();
   }
 
   function markTransition() {
@@ -299,33 +344,92 @@
     setRow(elements.artistRow, elements.artist, "");
     setRow(elements.trackRow, elements.track, "");
     setRow(elements.albumRow, elements.album, "");
-    if (elements.artwork) {
-      elements.artwork.hidden = true;
-      elements.artwork.removeAttribute("src");
-      elements.artwork.removeAttribute("srcset");
-      elements.artwork.alt = "";
-      elements.artwork.onload = null;
-      if (elements.artworkWrap) {
-        elements.artworkWrap.removeAttribute("data-now-playing-low-resolution");
-      }
-    }
-    if (elements.placeholder) {
-      elements.placeholder.hidden = false;
-    }
+    clearArtwork();
   }
 
   function updateArtworkQualityState() {
     if (!elements.artwork || !elements.artworkWrap || !elements.artwork.naturalWidth || !elements.artwork.naturalHeight) {
-      return;
+      return false;
+    }
+
+    var naturalWidth = elements.artwork.naturalWidth;
+    var naturalHeight = elements.artwork.naturalHeight;
+    if (Math.min(naturalWidth, naturalHeight) < MIN_USEFUL_ARTWORK_EDGE) {
+      resetArtworkPresentation();
+      showArtworkPlaceholder();
+      return false;
     }
 
     var renderedWidth = elements.artworkWrap.clientWidth || elements.artwork.clientWidth;
     var renderedHeight = elements.artworkWrap.clientHeight || elements.artwork.clientHeight;
-    var targetWidth = renderedWidth * MIN_SHARP_ARTWORK_DENSITY;
-    var targetHeight = renderedHeight * MIN_SHARP_ARTWORK_DENSITY;
-    var isLowResolution = elements.artwork.naturalWidth < targetWidth || elements.artwork.naturalHeight < targetHeight;
+    if (!renderedWidth || !renderedHeight) {
+      return false;
+    }
 
-    elements.artworkWrap.toggleAttribute("data-now-playing-low-resolution", isLowResolution);
+    var fitScale = Math.min(renderedWidth / naturalWidth, renderedHeight / naturalHeight);
+    var displayedWidth = naturalWidth * fitScale;
+    var displayedHeight = naturalHeight * fitScale;
+    var availableDensity = Math.min(naturalWidth / displayedWidth, naturalHeight / displayedHeight);
+    var isLowResolution = availableDensity < MIN_SHARP_ARTWORK_DENSITY;
+    var isNonSquare = Math.abs((naturalWidth / naturalHeight) - 1) > 0.05;
+
+    resetArtworkPresentation();
+    elements.artworkWrap.toggleAttribute("data-now-playing-contain", isNonSquare);
+
+    if (isLowResolution) {
+      // Keep small upstream covers below the point where browser interpolation
+      // makes them visibly soft. The surrounding branded frame makes the
+      // intentionally inset presentation feel deliberate rather than broken.
+      var sharpScale = Math.min(
+        renderedWidth / naturalWidth,
+        renderedHeight / naturalHeight,
+        1 / MIN_SHARP_ARTWORK_DENSITY
+      );
+      var sharpWidth = Math.max(1, Math.floor(naturalWidth * sharpScale));
+      var sharpHeight = Math.max(1, Math.floor(naturalHeight * sharpScale));
+
+      elements.artworkWrap.style.setProperty("--now-playing-artwork-width", sharpWidth + "px");
+      elements.artworkWrap.style.setProperty("--now-playing-artwork-height", sharpHeight + "px");
+      elements.artworkWrap.setAttribute("data-now-playing-low-resolution", "");
+    }
+
+    elements.artwork.hidden = false;
+    if (elements.placeholder) {
+      elements.placeholder.hidden = true;
+    }
+
+    return true;
+  }
+
+  function loadArtwork(metadata) {
+    if (!metadata.artwork || !elements.artwork) {
+      clearArtwork();
+      return;
+    }
+
+    resetArtworkPresentation();
+    showArtworkPlaceholder();
+
+    var fallbackAttempted = false;
+    elements.artwork.alt = "Album artwork for " + (metadata.track || "the current track") + (metadata.artist ? " by " + metadata.artist : "");
+    elements.artwork.onload = function () {
+      updateArtworkQualityState();
+    };
+    elements.artwork.onerror = function () {
+      if (!fallbackAttempted && metadata.artworkFallback) {
+        fallbackAttempted = true;
+        resetArtworkPresentation();
+        showArtworkPlaceholder();
+        elements.artwork.src = metadata.artworkFallback;
+        return;
+      }
+
+      clearArtwork();
+      // Permit the next metadata poll to retry after a transient image or
+      // network failure even when the artist and track have not changed.
+      lastRendered = "";
+    };
+    elements.artwork.src = metadata.artwork;
   }
 
   function renderMetadata(metadata) {
@@ -351,30 +455,7 @@
     setRow(elements.trackRow, elements.track, metadata.track);
     setRow(elements.albumRow, elements.album, metadata.album);
 
-    if (metadata.artwork && elements.artwork) {
-      elements.artwork.onload = updateArtworkQualityState;
-      elements.artwork.src = metadata.artwork;
-      elements.artwork.alt = "Album artwork for " + (metadata.track || "the current track") + (metadata.artist ? " by " + metadata.artist : "");
-      elements.artwork.hidden = false;
-      updateArtworkQualityState();
-      if (elements.placeholder) {
-        elements.placeholder.hidden = true;
-      }
-    } else {
-      if (elements.artwork) {
-        elements.artwork.hidden = true;
-        elements.artwork.removeAttribute("src");
-        elements.artwork.removeAttribute("srcset");
-        elements.artwork.alt = "";
-        elements.artwork.onload = null;
-        if (elements.artworkWrap) {
-          elements.artworkWrap.removeAttribute("data-now-playing-low-resolution");
-        }
-      }
-      if (elements.placeholder) {
-        elements.placeholder.hidden = false;
-      }
-    }
+    loadArtwork(metadata);
   }
 
   function logQuietly(error) {
@@ -418,4 +499,9 @@
   renderFallback();
   refresh();
   window.setInterval(refresh, POLL_INTERVAL_MS);
+  window.addEventListener("resize", function () {
+    if (elements.artwork && !elements.artwork.hidden) {
+      updateArtworkQualityState();
+    }
+  });
 }());

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -43,7 +43,7 @@
                 data-now-playing
                 data-now-playing-json="https://betelgeuse.nucast.co.uk:2020/json/stream/8062">
                 <div class="listen-live-now-playing__artwork" data-now-playing-artwork-wrap>
-                  <img data-now-playing-artwork alt="" sizes="(min-width: 48rem) 17.5rem, min(100vw, 17.5rem)" decoding="async" hidden>
+                  <img data-now-playing-artwork alt="" decoding="async" hidden>
                   <span class="listen-live-artwork-placeholder" data-now-playing-artwork-placeholder>
                     <span class="listen-live-artwork-avatar">
                       <img src="{{ "/images/sundown-sessions-logo.jpg" | relURL }}" alt="Sundown Sessions" loading="lazy" decoding="async">


### PR DESCRIPTION
## Summary

- cap low-resolution now-playing artwork using its intrinsic dimensions instead of stretching it to the full player frame
- preserve non-square artwork proportions and retain the branded fallback for tiny, missing, or failed images
- prefer higher-resolution artwork variants while falling back to the original URL and retrying transient failures
- document the NuCast source investigation and rendering thresholds

## Root cause

The NuCast feed currently supplies a 185×185 cover image while the Listen Live artwork frame can render at 280×280 CSS pixels. The browser was therefore interpolating the source above its intrinsic size, with a larger effective deficit on high-density displays.

## Impact

Album artwork now renders as an intentional, sharp inset when the source is undersized. Adequately sized artwork still fills the established frame, portrait and landscape artwork is contained proportionally, and playback plus metadata polling remain unchanged.

## Testing

- Hugo 0.146.5 production build with `--printPathWarnings --panicOnWarning`
- `node --check src/assets/js/listen-live-now-playing.js`
- DOM harness covering large square, current 185px NuCast, portrait, tiny, missing, upgraded-URL fallback, and transient retry cases
- live-feed headless browser checks at desktop and 2× mobile viewport sizes
- `npx --offline markdownlint-cli2 docs/listen-live-artwork.md`
- `git diff --check`
- pa11y completed; it continues to report the two existing Blowfish search-modal findings, unrelated to this change

The repository-wide Markdown workflow currently reports 12 pre-existing violations in files outside this PR. The new documentation file passes Markdown lint.

A listener-facing check during an actual Tuesday broadcast remains a post-deployment validation step because NuCast artwork varies by track.

## Accessibility

- [x] I reviewed the affected pages against the WCAG 2.2 AA baseline in `docs/accessibility.md`.
- [x] Keyboard navigation, focus visibility, labels, alternative text, colour contrast, and responsive reflow were considered for the changed areas.
- [x] Automated accessibility checks were run where practical, or any limitations are noted above.

Addresses #724.