### PR TITLE
fix: refine Show #2 hero copy

### DIFF
--- a/src/content/shows/2/index.md
+++ b/src/content/shows/2/index.md
@@ -2,6 +2,7 @@
 title: 'Show #2: Broadcast 12th June 2024'
 slug: 'featuring-the-receiving-end'
 description: 'featuring The Receiving End'
+heroTeaser: 'Bold reinterpretations lead into guitar-driven discoveries and after-dark atmospheres, with The Receiving End, Chikinki, Air, and Cocteau Twins along the way.'
 summary: 'THE SUNDOWN SESSIONS returns with...
 
 - The Receiving End


### PR DESCRIPTION
## Summary

- replace Show #2's generated artist-list sentence with an authored hero teaser
- retain the featured artist references while presenting them as part of the broadcast's musical journey
- correct the list punctuation with a serial comma

## Why

The previous hero copy was generated directly from legacy summary metadata, which made it read like an automated list rather than an editorial introduction. The new teaser reflects the actual playlist arc from reinterpretations through guitar-led discoveries to atmospheric late-night selections.

## Impact

Show #2 now has a concise, welcoming introduction that matches the editorial tone established on other show pages. No layout or template behaviour changes.

## Testing

- Hugo 0.146.5 production build with `--printPathWarnings --panicOnWarning`
- `npx --offline markdownlint-cli2 src/content/shows/2/index.md`
- `git diff --check`
- desktop and 2× mobile visual checks of the rendered Show #2 hero

The repository-wide Markdown workflow currently reports pre-existing violations in files outside this PR. The changed Show #2 file passes Markdown lint.

## Accessibility

- [x] I reviewed the affected page against the WCAG 2.2 AA baseline in `docs/accessibility.md`.
- [x] Responsive reflow and readability were checked at desktop and mobile widths.
- [x] No interactive behaviour, focus handling, labels, colour, or semantic structure changed.

Closes #720.