### PR TITLE
Align Show #2 show notes with editorial standard

### DIFF
--- a/src/content/shows/2/discussion-points.md
+++ b/src/content/shows/2/discussion-points.md
@@ -1,16 +1,38 @@
 ---
 purpose: discussion-points
 ---
-- _Royal Blood_ 
-  - {{< new-tab-link "[Touring](https://twitter.com/royalblooduk/status/1777244995059118447/photo/2)" >}} to mark the 10th anniversary of **_Royal Blood_**
-- _White Lies_
-  - Gigs lined up in {{< new-tab-link "[July](https://www.seetickets.com/tour/white-lies)" >}}
-- _The Doors_
-  - {{< new-tab-link "[The Doors: Dance On Fire (VHS)](https://www.amazon.co.uk/Doors-Dance-Fire-VHS/dp/B00004R67N)" >}}
-- _IST IST_
-  - Their 4th album **_Light A Bigger Fire_** will be released on 20th September - available to {{< new-tab-link "[pre-order here](https://www.ististmusic.com/)" >}}
-- _Nick Cave & The Bad Seeds_
-  - The new album **_Wild God_** will be released on 30 August - available to {{< new-tab-link "[pre-order here](https://linktr.ee/nickcave)" >}}
-  - {{< new-tab-link "[The Wild God Tour - UK & Europe 2024](https://www.nickcave.com/tour-dates/)" >}}
-- _The Cult_
-  - {{< new-tab-link "[8424 Tour (UK Leg)](https://x.com/officialcult/status/1783137338777886916/photo/1)" >}}
+
+### [Royal Blood](/artists/r/royal-blood/)
+
+The duo celebrated a decade since their self-titled debut by taking the album back on the road.
+
+- {{< new-tab-link "[Tour: Royal Blood 10th anniversary dates (2024)](https://twitter.com/royalblooduk/status/1777244995059118447/photo/2)" >}}
+
+### [White Lies](/artists/w/white-lies/)
+
+- {{< new-tab-link "[Tour: White Lies live dates - July 2024](https://www.seetickets.com/tour/white-lies)" >}}
+
+### [The Doors](/artists/t/the-doors/)
+
+The *Dance on Fire* collection brings together performance footage, promotional films and archive material from the band.
+
+- {{< new-tab-link "[Video: The Doors - Dance on Fire (VHS)](https://www.amazon.co.uk/Doors-Dance-Fire-VHS/dp/B00004R67N)" >}}
+
+### [IST IST](/artists/i/ist-ist/)
+
+The Manchester group followed *Architecture* with their fourth album, *Light A Bigger Fire*.
+
+- {{< new-tab-link "[Release: IST IST - Light A Bigger Fire - 20 September 2024](https://www.ististmusic.com/)" >}}
+
+### [Nick Cave & The Bad Seeds](/artists/n/nick-cave-the-bad-seeds/)
+
+*Wild God* opened a new chapter for the band, accompanied by an extensive UK and European tour.
+
+- {{< new-tab-link "[Release: Nick Cave & The Bad Seeds - Wild God - 30 August 2024](https://linktr.ee/nickcave)" >}}
+- {{< new-tab-link "[Tour: Wild God UK & Europe dates (2024)](https://www.nickcave.com/tour-dates/)" >}}
+
+### [The Cult](/artists/t/the-cult/)
+
+The 8424 tour looked back across four decades of the band's music.
+
+- {{< new-tab-link "[Tour: The Cult 8424 UK dates (2024)](https://x.com/officialcult/status/1783137338777886916/photo/1)" >}}


### PR DESCRIPTION
## Summary

- organise Show #2 notes into artist-led sections matching Show #1
- add concise editorial context and internal artist links
- standardise external reference labels and add relevant 2024 dates
- preserve every existing external reference

## Why

Show #2 used a flat nested list with context-dependent link labels, so it did not meet the editorial and structural standard established by Show #1. This update makes the notes easier to scan and positions them as curated further reading.

## Impact

Listeners can navigate directly to artist pages and understand each external reference without relying on surrounding context. The implementation remains Markdown-first and uses the existing Hugo shortcodes.

## Validation

- `hugo --environment production` with the repository-pinned Hugo 0.146.5
- generated Show #2 HTML inspected for revised sections and links
- `git diff --check`

Closes #721