### PR TITLE
fix(website): emphasise show card featured artists

### DIFF
--- a/src/layouts/partials/article-link/card.html
+++ b/src/layouts/partials/article-link/card.html
@@ -102,9 +102,9 @@
         </a>
       </header>
       {{ if $featuredArtist }}
-        <p class="mt-3.5 text-[0.95rem] font-semibold leading-snug text-neutral-800 dark:text-neutral-200">Featuring {{ $featuredArtist }}</p>
+        <p class="mt-4 text-base font-bold leading-snug tracking-tight text-neutral-900 dark:text-neutral-100">Featuring {{ $featuredArtist }}</p>
       {{ end }}
-      <p class="mt-2 text-sm text-neutral-500 dark:text-neutral-400">{{ partial "meta/date.html" .Date }}</p>
+      <p class="mt-2.5 text-sm font-medium text-neutral-500 dark:text-neutral-400">{{ partial "meta/date.html" .Date }}</p>
     {{ else }}
       <header>
         <a


### PR DESCRIPTION
### Motivation
- Increase the visual prominence of the featured artist on homepage/show cards so the artist stands out more clearly below the show title.

### Description
- Update class attributes in `src/layouts/partials/article-link/card.html` to make the "Featuring" line larger, bolder, tighter tracking and higher contrast, and to slightly adjust the spacing and weight of the date metadata while keeping the existing card structure and layout.

### Testing
- Ran `git diff --check` which succeeded, and attempted `hugo --environment production` which could not run because the `hugo` binary is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e44d4e7c832d85dfbc7dcd02f02a)