### PR TITLE
Clarify footer shows archive link

### DIFF
--- a/src/config/_default/menus.toml
+++ b/src/config/_default/menus.toml
@@ -21,8 +21,8 @@
 
 [[footer]]
   identifier = "listen-again"
-  name = "Listen Again"
-  title = "Browse Sundown Sessions shows"
+  name = "Browse Shows"
+  title = "Browse the Sundown Sessions show archive"
   url = "/shows/"
   weight = 10
 


### PR DESCRIPTION
### Motivation
- Replace the ambiguous footer label "Listen Again" with "Browse Shows" so the footer more clearly communicates it links to the show archive.

### Description
- Update `src/config/_default/menus.toml` to change the `[[footer]]` entry with `identifier = "listen-again"` to `name = "Browse Shows"` and `title = "Browse the Sundown Sessions show archive"` while keeping `url = "/shows/"` unchanged.

### Testing
- Verified the change with `rg -n "name = \"Browse Shows\"|title = \"Browse the Sundown Sessions show archive\"|Listen Again" src/config/_default/menus.toml src/layouts/partials/footer.html` and attempted `cd src && hugo --environment production` but `hugo` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e6ce0c94832d8c9df40e599a7bb3)