### PR TITLE
fix(footer): tighten social link spacing

### DIFF
--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -3,7 +3,7 @@
   {{ if .Site.Params.footer.showMenu | default true }}
     {{ $listenURL := "/listen-live/" | relURL }}
     {{ if or $listenURL .Site.Menus.footer }}
-      <nav class="pb-4 text-base font-medium text-neutral-500 dark:text-neutral-400" aria-label="Footer">
+      <nav class="pb-2 text-base font-medium text-neutral-500 dark:text-neutral-400" aria-label="Footer">
         <ul class="flex list-none flex-wrap justify-center gap-x-5 gap-y-2 p-0 sm:justify-start">
           <li class="flex">
             <a


### PR DESCRIPTION
### Motivation

- Reduce vertical gap between the footer primary navigation and the social icon row so the footer reads as a single cohesive group.

### Description

- Changed the footer menu bottom padding from `pb-4` to `pb-2` in `src/layouts/partials/footer.html`, preserving markup, link order, and accessibility attributes.

### Testing

- Ran `git diff --check` which succeeded; attempted `hugo --source src --environment production --baseURL https://example.invalid/` but the Hugo binary could not be installed in this environment (network/proxy blocked), so the site build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e8825860832d80fce1db56b1e02a)