### PR TITLE
Refine homepage supporting copy

### DIFF
--- a/src/content/_index.md
+++ b/src/content/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Sundown Sessions"
 strapline: "Alternative Music After Dark"
-description: "Alternative music, exclusive tracks, artist interviews, and carefully curated playlists."
+description: "Discover alternative music after dark through exclusive tracks, artist interviews, and hand-curated playlists that help you find your next favourite sound."
 cascade:
     featured_image: '/images/sundown-sessions-banner.png'
 ---


### PR DESCRIPTION
### Motivation
- Make the homepage description more outcome-focused and discovery-oriented so visitors understand what they gain from exploring Sundown Sessions.

### Description
- Replace the `description` front-matter in `src/content/_index.md` with: "Discover alternative music after dark through exclusive tracks, artist interviews, and hand-curated playlists that help you find your next favourite sound." 

### Testing
- Ran `git diff --check` (no issues) and attempted `hugo --source src --destination ../public --minify`, which could not be run because `hugo` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e987dbac832da8b03f56645edbcd)