### PR TITLE
fix: refine shows archive cards

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1918,13 +1918,13 @@ label[for]:focus-visible {
 }
 
 .shows-archive-list {
-  gap: 0.85rem;
+  gap: 1.35rem;
 }
 
 .article-link--show-card {
   position: relative;
   display: flex;
-  min-height: 11.75rem;
+  min-height: 10.75rem;
   overflow: hidden;
   border: 1px solid #d4d4d4; /* neutral-300 */
   border-radius: 0.75rem;
@@ -1957,7 +1957,7 @@ label[for]:focus-visible {
 
 .show-card__image-link {
   display: block;
-  flex: 0 0 clamp(11rem, 24.5vw, 14.75rem);
+  flex: 0 0 clamp(10rem, 23%, 13rem);
   align-self: stretch;
   overflow: hidden;
   background: #f5f5f5; /* neutral-100 */
@@ -1972,7 +1972,7 @@ label[for]:focus-visible {
   display: block;
   width: 100%;
   height: 100%;
-  min-height: 11.75rem;
+  min-height: 10.75rem;
 }
 
 .show-card__image {
@@ -1999,7 +1999,7 @@ label[for]:focus-visible {
   flex: 1 1 auto;
   flex-direction: column;
   justify-content: center;
-  padding: clamp(1.15rem, 2.4vw, 1.55rem) clamp(1.2rem, 3vw, 1.85rem);
+  padding: clamp(0.85rem, 2vw, 1.05rem) clamp(1.2rem, 3vw, 1.85rem);
 }
 
 .show-card__number {
@@ -2095,8 +2095,8 @@ label[for]:focus-visible {
   margin: 0.82rem 0 0;
   overflow: hidden;
   color: #404040; /* neutral-700 */
-  font-size: 0.95rem;
-  line-height: 1.52;
+  font-size: 1.02rem;
+  line-height: 1.5;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
@@ -2111,8 +2111,8 @@ label[for]:focus-visible {
   align-self: flex-start;
   margin-top: 0.95rem;
   color: rgba(var(--color-primary-600), 1);
-  font-size: 0.88rem;
-  font-weight: 650;
+  font-size: 0.92rem;
+  font-weight: 700;
   line-height: 1.2;
   text-decoration: none;
   transition: color 180ms ease;

--- a/src/layouts/partials/article-link/show-card.html
+++ b/src/layouts/partials/article-link/show-card.html
@@ -53,7 +53,7 @@
 {{ if gt (len $titleParts) 1 }}
   {{ $rawShowLabel := index $titleParts 0 }}
   {{ $showLabel = $rawShowLabel }}
-  {{ $showLabel = replaceRE `(?i)^show\s*#` "Broadcast #" $showLabel }}
+  {{ $showLabel = replaceRE `(?i)^broadcast\s*#` "Show #" $showLabel }}
   {{ $showTitle = strings.TrimPrefix (printf "%s: " $rawShowLabel) .Title | emojify }}
 {{ end }}
 


### PR DESCRIPTION
### Motivation
- Improve the visual balance and readability of the Shows archive list by reducing the dominance of artwork and giving the text column more room.
- Tighten per-card vertical sizing while increasing spacing between cards to make the archive feel less dense.
- Make the eyebrow label wording consistent by converting legacy `Broadcast #n` prefixes to `Show #n`.

### Description
- Adjusted `src/assets/css/custom.css` to increase `.shows-archive-list` gap, reduce `.article-link--show-card` `min-height`, shrink the artwork column (`.show-card__image-link` flex/min-height) and reduce `.show-card__content` padding.
- Increased excerpt prominence by raising `.show-card__summary` font-size/line-height and strengthened the CTA with larger `font-size` and heavier `font-weight` in `.show-card__cta`.
- Updated `src/layouts/partials/article-link/show-card.html` to replace `Broadcast #` prefixes with `Show #` via `replaceRE` so displayed eyebrow labels are `Show #n` while preserving the main title.
- This change aims to close issue `#742` by refining card proportions and label wording.

### Testing
- Ran `git diff --check` which completed without errors.
- Attempted `hugo --environment production --source src --destination /tmp/sundown-sessions-public` but the command could not run because `hugo` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59e25f02f8832d9cb146c67ed24937)