### PR TITLE
fix: polish shows archive cards

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1837,7 +1837,7 @@ label[for]:focus-visible {
 /* Shows archive page: editorial gateway above the broadcast list. */
 
 .shows-archive-intro {
-  margin: 0 0 clamp(2.75rem, 5vw, 3.75rem);
+  margin: 0 0 clamp(3.75rem, 6vw, 5rem);
 }
 
 .shows-archive-intro__copy {
@@ -2003,7 +2003,7 @@ label[for]:focus-visible {
 }
 
 .show-card__number {
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.45rem;
   color: #737373; /* neutral-500 */
   font-size: 0.76rem;
   font-weight: 750;
@@ -2055,7 +2055,7 @@ label[for]:focus-visible {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.32rem 0.55rem;
-  margin-top: 0.72rem;
+  margin-top: 0.82rem;
   color: #525252; /* neutral-600 */
   font-size: 0.88rem;
   line-height: 1.35;
@@ -2092,7 +2092,7 @@ label[for]:focus-visible {
 
 .show-card__summary {
   display: -webkit-box;
-  margin: 0.82rem 0 0;
+  margin: 0.92rem 0 0;
   overflow: hidden;
   color: #404040; /* neutral-700 */
   font-size: 1.02rem;
@@ -2109,7 +2109,7 @@ label[for]:focus-visible {
   position: relative;
   z-index: 1;
   align-self: flex-start;
-  margin-top: 0.95rem;
+  margin-top: 1.05rem;
   color: rgba(var(--color-primary-600), 1);
   font-size: 0.92rem;
   font-weight: 700;
@@ -2181,7 +2181,7 @@ label[for]:focus-visible {
 
   .show-card__meta {
     gap: 0.42rem 0.5rem;
-    margin-top: 0.65rem;
+    margin-top: 0.72rem;
   }
 
   .show-card__meta-item {

--- a/src/layouts/partials/article-link/show-card.html
+++ b/src/layouts/partials/article-link/show-card.html
@@ -92,11 +92,12 @@
 {{ end }}
 {{ $discoverySummary := "" }}
 {{ if gt (len $displayArtists) 0 }}
-  {{ $artistList := delimit $displayArtists ", " }}
+  {{ $discoveryArtists := $displayArtists }}
   {{ if $hasMoreArtists }}
-    {{ $artistList = printf "%s, and more" $artistList }}
+    {{ $discoveryArtists = $discoveryArtists | append "and more" }}
   {{ end }}
-  {{ $discoverySummary = printf "Featuring %s." $artistList }}
+  {{ $artistList := delimit $discoveryArtists ", " " and " }}
+  {{ $discoverySummary = printf "Featuring music from %s." $artistList }}
 {{ else }}
   {{ with .Summary }}
     {{ $discoverySummary = . | plainify | truncate 150 }}

--- a/src/layouts/shows/list.html
+++ b/src/layouts/shows/list.html
@@ -20,7 +20,6 @@
 
   {{ if $datedPages }}
     <div class="shows-archive-list-heading">
-      <p class="shows-archive-kicker">Browse previous shows</p>
       <h2>All Broadcasts</h2>
       <p>Browse every Sundown Sessions programme in chronological order.</p>
     </div>


### PR DESCRIPTION
### Motivation
- Improve the editorial gateway and visual rhythm of the Shows archive so the list reads as a clear continuation from the intro section.
- Make discovery excerpts on show cards read more naturally by emphasising music contributors using a consistent “Featuring music from … and more.” pattern.
- Tweak card spacing to give the show number, metadata, excerpt and CTA slightly more breathing room without altering layout structure.

### Description
- Removed the redundant eyebrow copy above the archive heading in `src/layouts/shows/list.html` so only the `All Broadcasts` heading remains.
- Updated the discovery summary template in `src/layouts/partials/article-link/show-card.html` to build an artist list with a natural conjunction and append an "and more" token when applicable, producing `Featuring music from …` phrasing.
- Adjusted spacing values in `src/assets/css/custom.css` to increase the bottom gap under the archive intro and to slightly increase gaps between the show number, metadata, summary and CTA on cards.
- Changes are limited to `src/layouts/shows/list.html`, `src/layouts/partials/article-link/show-card.html`, and `src/assets/css/custom.css`.

### Testing
- `git diff --check` was run and returned no check errors (passed).
- A local Hugo production build via `hugo --source src --environment production --gc --minify` could not be executed because `hugo` is not installed in the environment (blocked).
- An attempt to run `npx --yes hugo-bin --source src --environment production --gc --minify` was blocked by the npm registry returning `403 Forbidden` for `hugo-bin` (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59e9d40160832d924bf333a20e3f3d)