### PR TITLE
Restore Artist Spotlight metadata link detection and add more Explore Further destinations

### DIFF
--- a/src/layouts/partials/artist-external-links.html
+++ b/src/layouts/partials/artist-external-links.html
@@ -21,11 +21,31 @@
   {{ $platformKey = replace $platformKey " " "-" }}
   {{ $platformKey = replace $platformKey "_" "-" }}
   {{ $platformKey = replace $platformKey "." "" }}
-  {{ $platformKey = replace $platformKey "official-website" "website" }}
-  {{ $platformKey = replace $platformKey "official-site" "website" }}
-  {{ $platformKey = replace $platformKey "apple-music" "apple" }}
-  {{ if or (eq $platformKey "x") (eq $platformKey "x-twitter") }}
+  {{ $urlLower := lower $url }}
+  {{ if or (in $platformKey "website") (in $platformKey "official-site") }}
+    {{ $platformKey = "website" }}
+  {{ else if in $platformKey "apple-music" }}
+    {{ $platformKey = "apple" }}
+  {{ else if or (in $platformKey "x-twitter") (eq $platformKey "x") (in $platformKey "twitter") }}
     {{ $platformKey = "twitter" }}
+  {{ else if or (in $platformKey "facebook") (in $urlLower "facebook.com") }}
+    {{ $platformKey = "facebook" }}
+  {{ else if or (in $platformKey "instagram") (in $urlLower "instagram.com") }}
+    {{ $platformKey = "instagram" }}
+  {{ else if or (in $platformKey "youtube") (in $urlLower "youtube.com") (in $urlLower "youtu.be") }}
+    {{ $platformKey = "youtube" }}
+  {{ else if or (in $platformKey "bandcamp") (in $urlLower "bandcamp.com") }}
+    {{ $platformKey = "bandcamp" }}
+  {{ else if or (in $platformKey "spotify") (in $urlLower "spotify.com") }}
+    {{ $platformKey = "spotify" }}
+  {{ else if or (in $platformKey "discogs") (in $urlLower "discogs.com") }}
+    {{ $platformKey = "discogs" }}
+  {{ else if or (in $platformKey "musicbrainz") (in $urlLower "musicbrainz.org") }}
+    {{ $platformKey = "musicbrainz" }}
+  {{ else if or (in $platformKey "wikipedia") (in $urlLower "wikipedia.org") }}
+    {{ $platformKey = "wikipedia" }}
+  {{ else if or (in $platformKey "bluesky") (in $urlLower "bsky.app") }}
+    {{ $platformKey = "bluesky" }}
   {{ end }}
 
   {{ if and $url (not (index $linksByPlatform $platformKey)) }}
@@ -40,10 +60,12 @@
   (dict "key" "apple" "label" "Apple Music" "icon" "apple")
   (dict "key" "discogs" "label" "Discogs" "icon" "music")
   (dict "key" "musicbrainz" "label" "MusicBrainz" "icon" "music")
+  (dict "key" "wikipedia" "label" "Wikipedia" "icon" "globe")
   (dict "key" "facebook" "label" "Facebook" "icon" "facebook")
   (dict "key" "instagram" "label" "Instagram" "icon" "instagram")
   (dict "key" "youtube" "label" "YouTube" "icon" "youtube")
   (dict "key" "twitter" "label" "X (Twitter)" "icon" "x-twitter")
+  (dict "key" "bluesky" "label" "Bluesky" "icon" "link")
   (dict "key" "vimeo" "label" "Vimeo" "icon" "link")
   (dict "key" "tiktok" "label" "TikTok" "icon" "tiktok")
 }}

--- a/src/layouts/shortcodes/include_content.html
+++ b/src/layouts/shortcodes/include_content.html
@@ -88,11 +88,31 @@
             {{ $platformKey = replace $platformKey " " "-" }}
             {{ $platformKey = replace $platformKey "_" "-" }}
             {{ $platformKey = replace $platformKey "." "" }}
-            {{ $platformKey = replace $platformKey "official-website" "website" }}
-            {{ $platformKey = replace $platformKey "official-site" "website" }}
-            {{ $platformKey = replace $platformKey "apple-music" "apple" }}
-            {{ if or (eq $platformKey "x") (eq $platformKey "x-twitter") (eq $platformKey "twitter") }}
+            {{ $urlLower := lower $url }}
+            {{ if or (in $platformKey "website") (in $platformKey "official-site") }}
+              {{ $platformKey = "website" }}
+            {{ else if in $platformKey "apple-music" }}
+              {{ $platformKey = "apple" }}
+            {{ else if or (in $platformKey "x-twitter") (eq $platformKey "x") (in $platformKey "twitter") }}
               {{ $platformKey = "twitter" }}
+            {{ else if or (in $platformKey "facebook") (in $urlLower "facebook.com") }}
+              {{ $platformKey = "facebook" }}
+            {{ else if or (in $platformKey "instagram") (in $urlLower "instagram.com") }}
+              {{ $platformKey = "instagram" }}
+            {{ else if or (in $platformKey "youtube") (in $urlLower "youtube.com") (in $urlLower "youtu.be") }}
+              {{ $platformKey = "youtube" }}
+            {{ else if or (in $platformKey "bandcamp") (in $urlLower "bandcamp.com") }}
+              {{ $platformKey = "bandcamp" }}
+            {{ else if or (in $platformKey "spotify") (in $urlLower "spotify.com") }}
+              {{ $platformKey = "spotify" }}
+            {{ else if or (in $platformKey "discogs") (in $urlLower "discogs.com") }}
+              {{ $platformKey = "discogs" }}
+            {{ else if or (in $platformKey "musicbrainz") (in $urlLower "musicbrainz.org") }}
+              {{ $platformKey = "musicbrainz" }}
+            {{ else if or (in $platformKey "wikipedia") (in $urlLower "wikipedia.org") }}
+              {{ $platformKey = "wikipedia" }}
+            {{ else if or (in $platformKey "bluesky") (in $urlLower "bsky.app") }}
+              {{ $platformKey = "bluesky" }}
             {{ end }}
             {{ if eq $platformKey "website" }}
               {{ $label = "Official Website" }}
@@ -112,10 +132,14 @@
       (dict "key" "bandcamp" "label" "Bandcamp" "icon" "music")
       (dict "key" "spotify" "label" "Spotify" "icon" "spotify")
       (dict "key" "apple" "label" "Apple Music" "icon" "apple")
+      (dict "key" "discogs" "label" "Discogs" "icon" "music")
+      (dict "key" "musicbrainz" "label" "MusicBrainz" "icon" "music")
+      (dict "key" "wikipedia" "label" "Wikipedia" "icon" "globe")
       (dict "key" "youtube" "label" "YouTube" "icon" "youtube")
       (dict "key" "facebook" "label" "Facebook" "icon" "facebook")
       (dict "key" "instagram" "label" "Instagram" "icon" "instagram")
       (dict "key" "twitter" "label" "X" "icon" "x-twitter")
+      (dict "key" "bluesky" "label" "Bluesky" "icon" "link")
     }}
     {{ $spotlightLinks := slice }}
     {{ range $destinations }}


### PR DESCRIPTION
### Motivation
- Restore robust detection and normalization of Artist Spotlight / Featured Guest metadata links so legacy `new-tab-link` entries are surfaced as platform-specific destinations. 
- Normalize links by both label and URL to avoid duplicate or missing platform cards for artists and show spotlights. 
- Add a few commonly referenced discovery platforms (Discogs, MusicBrainz, Wikipedia, Bluesky) to the Explore Further card so links already present in content are represented in the UI.

### Description
- Enhances link extraction in `src/layouts/partials/artist-external-links.html` to compute `urlLower` and perform more flexible platform-key normalization (matching label text and URL patterns) before merging into the links-by-platform map. 
- Mirrors the same normalization and destination additions in `src/layouts/shortcodes/include_content.html` so show-level Artist Spotlight extraction and artist pages behave consistently. 
- Adds new Explore Further destination entries for `discogs`, `musicbrainz`, `wikipedia` (uses globe icon), and `bluesky`, and tweaks icon selection to reuse the existing card layout without changing visual markup. 
- Keeps existing card rendering (`components/explore-further.html`) and community invitation intact; changes are limited to platform detection and destination lists.

### Testing
- Attempted a site build with `hugo --source src --destination ../public`, which failed because `hugo` is not installed in the execution environment. 
- Ran automated template inspections (`rg`/`sed`/script checks) to confirm the new normalization logic and destination entries are present in both modified files, and those checks succeeded. 
- No other automated CI/unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f2734b08832d95a240fea5ea6f73)