### PR TITLE
fix: add about page footer breathing room

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -3702,7 +3702,7 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   flex-direction: column;
   gap: clamp(3.25rem, 7vw, 5.5rem);
   max-width: 66rem;
-  margin-bottom: 5rem;
+  margin-bottom: 7rem;
 }
 
 .about-page > .space-y-6 img {


### PR DESCRIPTION
### Motivation
- Give the About page’s final CTA more visual space above the global footer so the closing section doesn’t feel cramped.

### Description
- Increase `.about-page` bottom margin in `src/assets/css/custom.css` from `5rem` to `7rem` to add ~32px of extra breathing room.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it passed.
- Attempted a Hugo production build with `hugo --source src --printPathWarnings --panicOnWarning --environment production --baseURL https://example.invalid/` but the local environment lacked the `hugo` binary and downloading the CI-pinned release was blocked by the environment proxy, so a full site build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b1fd8906c832db3a0514776e3dcc5)