### PR TITLE
Refine contact submission guidance

### DIFF
--- a/src/content/contact/index.md
+++ b/src/content/contact/index.md
@@ -25,7 +25,9 @@ Sundown Sessions exists to discover great music and share it with people who lov
 
 If you are sending music, include the artist name, track or release title, release date, relevant links, and a short note about the story behind it. Please send a streaming, download or press link rather than attaching files. Bandcamp, SoundCloud, Spotify, YouTube, Dropbox, Google Drive and official website links are all welcome.
 
-Every submission is listened to personally, but not every track can be played or featured. Sundown Sessions is curated by hand, so the final selection depends on the shape of each broadcast, the wider archive and what feels right for after-dark listening.
+**Every submission is listened to personally.** Not every track can be played or featured. Sundown Sessions is curated by hand, so the final selection depends on the shape of each broadcast, the wider archive and what feels right for after-dark listening.
+
+If your music is featured on Sundown Sessions, I will always let you know and I will always share it across the show's channels. The aim is to build lasting relationships with the artists, labels, promoters and listeners who make the show possible.
 
 ## What happens next
 

--- a/src/layouts/shortcodes/contact-explore.html
+++ b/src/layouts/shortcodes/contact-explore.html
@@ -1,9 +1,9 @@
 <nav class="not-prose my-6" aria-label="Continue exploring">
   {{ $links := slice
-    (dict "label" "Shows" "url" "/shows/")
-    (dict "label" "Listen Live" "url" "/listen-live/")
-    (dict "label" "About" "url" "/about/")
-    (dict "label" "Mixcloud / Listen Again" "url" "https://www.mixcloud.com/sundownsessions/")
+    (dict "label" "Browse shows →" "url" "/shows/")
+    (dict "label" "Listen live →" "url" "/listen-live/")
+    (dict "label" "About Sundown Sessions →" "url" "/about/")
+    (dict "label" "Mixcloud / Listen Again →" "url" "https://www.mixcloud.com/sundownsessions/")
   }}
   <ul class="m-0 grid list-none gap-2 p-0 sm:grid-cols-2">
     {{ range $links }}

--- a/src/layouts/shortcodes/form-contact.html
+++ b/src/layouts/shortcodes/form-contact.html
@@ -18,15 +18,16 @@
         <input id="{{ $formID }}-email" name="email" type="email" autocomplete="email" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
       </div>
       <div>
-        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-link">Link</label>
-        <input id="{{ $formID }}-link" name="link" type="text" inputmode="url" autocomplete="url" placeholder="Bandcamp, SoundCloud, Spotify, YouTube, Dropbox, Google Drive or website link" class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
+        <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-link">Listen here</label>
+        <input id="{{ $formID }}-link" name="link" type="text" inputmode="url" autocomplete="url" aria-describedby="{{ $formID }}-link-help" placeholder="Paste a music or website link" class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900" />
+        <p id="{{ $formID }}-link-help" class="mt-2 mb-0 text-sm leading-6 text-neutral-600 dark:text-neutral-400">Share a streaming, download or press link.</p>
       </div>
       <div>
         <label class="mb-2.5 block text-sm font-semibold text-neutral-900 dark:text-neutral" for="{{ $formID }}-message">Message</label>
-        <textarea id="{{ $formID }}-message" name="message" rows="6" required class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900"></textarea>
-        <p class="mt-2 mb-0 text-sm leading-6 text-neutral-600 dark:text-neutral-400">Tell us who you are, what you're sending, and where we can listen.</p>
+        <textarea id="{{ $formID }}-message" name="message" rows="6" required aria-describedby="{{ $formID }}-message-help" class="block w-full rounded-lg border border-neutral-300 bg-white px-4 py-3.5 text-base text-neutral-900 shadow-sm outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-300 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:focus:border-primary-400 dark:focus:ring-primary-900"></textarea>
+        <p id="{{ $formID }}-message-help" class="mt-2 mb-0 text-sm leading-6 text-neutral-600 dark:text-neutral-400">Tell us a little about yourself, your music or your message.</p>
       </div>
-      <div class="flex flex-col gap-4 pt-1 sm:flex-row sm:items-center">
+      <div class="flex flex-col gap-4 pt-3 sm:flex-row sm:items-center">
         <button type="submit" class="contact-form__submit inline-flex items-center justify-center rounded-lg bg-primary-600 px-7 py-3.5 text-sm font-semibold text-white transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-primary-500 dark:hover:bg-primary-400 dark:focus:ring-primary-900">
           <span class="contact-form__button-label">Send message</span>
           <span class="contact-form__spinner" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary

- refine the Contact form’s link and message microcopy
- emphasise that every music submission is listened to personally
- make the notification and channel-sharing commitment explicit
- use more active wording for the Continue exploring links
- associate helper copy with its form controls for assistive technology

## Why

The Contact page’s generic link wording and submission guidance did not fully explain how artists, labels, promoters and listeners should share music or what happens when music is featured. This update makes that journey clearer and reinforces Sundown Sessions’ personal, relationship-led approach.

## Impact

The page retains its existing layout and Blowfish styling while providing clearer submission expectations. The Formspree endpoint, POST method, stable field names and standard HTML controls remain unchanged; no file-upload support is introduced.

## Validation

- production Hugo build completed successfully
- rendered Contact-page HTML checked for the required copy and unchanged Formspree attributes
- `git diff --check` passed

Closes #749