### PR TITLE
Standardise release date metadata on artist release cards

### DIFF
--- a/src/layouts/partials/artist-featured-releases.html
+++ b/src/layouts/partials/artist-featured-releases.html
@@ -61,7 +61,11 @@
             <span class="release-discover-card__body">
               <span class="release-discover-card__title">{{ $release.Title | emojify }}</span>
               {{ with ($release.Params.releaseDate | default $release.Params.release_date | default $release.Params.releaseType | default $release.Params.release_type) }}
-                <span class="release-discover-card__meta">{{ . }}</span>
+                {{ $releaseMeta := printf "%v" . }}
+                {{ if gt (len (findRE `^[0-9]{4}-[0-9]{2}-[0-9]{2}` $releaseMeta 1)) 0 }}
+                  {{ $releaseMeta = time.Format "2 January 2006" . }}
+                {{ end }}
+                <span class="release-discover-card__meta">{{ $releaseMeta }}</span>
               {{ end }}
             </span>
           </a>


### PR DESCRIPTION
## Summary

- format complete ISO release dates in artist release cards as human-readable editorial dates
- preserve year-only release metadata without inventing a month or day
- keep existing release links and card markup unchanged

## Why

Artist release cards rendered the underlying `releaseDate` value directly. YAML full dates can therefore appear as raw ISO values such as `2017-08-25`, while year-only values appear as `2013`, creating inconsistent presentation within the same section.

The template now detects complete ISO dates and formats them with Hugo as `2 January 2006`. Other metadata, including year-only values, is left unchanged.

## User impact

On the Queens of the Stone Age artist page, `...Like Clockwork` continues to show `2013`, while `Villains` now shows `25 August 2017`.

## Validation

- `hugo --minify --environment production`
- confirmed generated artist card metadata contains `2013` and `25 August 2017`
- confirmed generated artist pages contain no raw `2017-08-25` release-card value
- `git diff --check`

Closes #754