### PR TITLE
fix: connect featured tracks to broadcasts

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -3546,6 +3546,123 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   margin: -0.35rem 1.25rem 0.9rem;
 }
 
+/* Artist featured tracks: a compact track summary followed by all of its
+   broadcast appearances. */
+
+.artist-featured-track {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.artist-featured-track__details,
+.artist-featured-track__broadcasts,
+.artist-featured-track__show-link {
+  display: flex;
+  flex-direction: column;
+}
+
+.artist-featured-track__details,
+.artist-featured-track__broadcasts {
+  gap: 0.2rem;
+}
+
+.artist-featured-track__title,
+.artist-featured-track__show-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.artist-featured-track__title {
+  width: fit-content;
+  color: #171717; /* neutral-900 */
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.dark .artist-featured-track__title {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.artist-featured-track__title:hover,
+.artist-featured-track__title:focus-visible,
+.artist-featured-track__show-link:hover span:first-child,
+.artist-featured-track__show-link:focus-visible span:first-child {
+  color: rgba(var(--color-primary-600), 1);
+  text-decoration: underline;
+}
+
+.dark .artist-featured-track__title:hover,
+.dark .artist-featured-track__title:focus-visible,
+.dark .artist-featured-track__show-link:hover span:first-child,
+.dark .artist-featured-track__show-link:focus-visible span:first-child {
+  color: rgba(var(--color-primary-400), 1);
+}
+
+.artist-featured-track__title:focus-visible,
+.artist-featured-track__show-link:focus-visible {
+  border-radius: 0.2rem;
+  outline: 2px solid rgba(var(--color-primary-600), 1);
+  outline-offset: 0.2rem;
+}
+
+.artist-featured-track__release,
+.artist-featured-track__label,
+.artist-featured-track__show-link time {
+  color: #737373; /* neutral-500 */
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.dark .artist-featured-track__release,
+.dark .artist-featured-track__label,
+.dark .artist-featured-track__show-link time {
+  color: #a3a3a3; /* neutral-400 */
+}
+
+.artist-featured-track__appearances {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0.2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.artist-featured-track__show-link {
+  gap: 0.1rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  border-radius: 0.5rem;
+  background: #fff;
+}
+
+.dark .artist-featured-track__show-link {
+  border-color: #404040; /* neutral-700 */
+  background: rgba(23, 23, 23, 0.5); /* neutral-900/50 */
+}
+
+.artist-featured-track__show-link > span:first-child {
+  color: #262626; /* neutral-800 */
+  font-weight: 650;
+}
+
+.dark .artist-featured-track__show-link > span:first-child {
+  color: #e5e5e5; /* neutral-200 */
+}
+
+.artist-featured-track__cta {
+  margin-top: 0.25rem;
+  color: rgba(var(--color-primary-600), 1);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.dark .artist-featured-track__cta {
+  color: rgba(var(--color-primary-400), 1);
+}
+
 /* Release discovery: responsive onward recommendations for non-sequential
    release pages. Artwork is contained so sleeve art is never cropped. */
 
@@ -3690,6 +3807,11 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 
   .release-featured-shows__date {
     flex: none;
+  }
+
+  .artist-featured-track {
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.4fr);
+    align-items: start;
   }
 
   .release-discover-more__grid {

--- a/src/layouts/partials/artist-featured-tracks.html
+++ b/src/layouts/partials/artist-featured-tracks.html
@@ -1,7 +1,9 @@
-{{/* Tracks connected to an artist through track front matter. */}}
+{{/* Tracks connected to an artist through track front matter, together with
+     every broadcast in whose playlist or track guide they appear. */}}
 
 {{ $artistKey := lower (urlize .Title) }}
 {{ $tracks := slice }}
+{{ $shows := where site.RegularPages "Section" "shows" }}
 
 {{ range where site.RegularPages "Section" "tracks" }}
   {{ $track := . }}
@@ -21,14 +23,66 @@
   <section class="release-featured-shows not-prose" role="region" aria-labelledby="artist-featured-tracks-heading">
     <h2 id="artist-featured-tracks-heading" class="release-featured-shows__heading">Tracks Featured on Sundown Sessions</h2>
     <ul class="release-featured-shows__list">
-      {{ range first 12 ($tracks.ByTitle) }}
-        <li class="release-featured-shows__row">
-          <a class="release-featured-shows__link" href="{{ .RelPermalink }}">
-            <span class="release-featured-shows__title">{{ .Title | emojify }}</span>
-            {{ with .Params.release }}
-              <span class="release-featured-shows__date">{{ . }}</span>
+      {{ range $tracks.ByTitle }}
+        {{ $track := . }}
+        {{ $trackTitle := lower .Title }}
+        {{ $trackArtist := .Params.artist | default .Params.artists | default "" }}
+        {{ if reflect.IsSlice $trackArtist }}{{ $trackArtist = delimit $trackArtist " " }}{{ end }}
+        {{ $trackArtist = lower (printf "%v" $trackArtist) }}
+        {{ $appearances := slice }}
+
+        {{ range $shows }}
+          {{ $show := . }}
+          {{ $showText := .RawContent }}
+          {{ with .File }}
+            {{ $showDir := path.Dir (replace .Path "\\" "/") }}
+            {{ range slice "playlist.md" "playlist" "track-info.md" "track-info" }}
+              {{ $includedPath := printf "content/%s/%s" $showDir . }}
+              {{ if fileExists $includedPath }}
+                {{ $showText = printf "%s\n%s" $showText (readFile $includedPath) }}
+              {{ end }}
             {{ end }}
-          </a>
+          {{ end }}
+          {{ $showText = lower $showText }}
+          {{ $matched := false }}
+          {{ range split $showText "\n" }}
+            {{ $line := . }}
+            {{ if and (not $matched) (in $line $trackArtist) (in $line $trackTitle) }}
+              {{ $matched = true }}
+            {{ end }}
+          {{ end }}
+          {{ if $matched }}
+            {{ $appearances = $appearances | append $show }}
+          {{ end }}
+        {{ end }}
+
+        <li class="release-featured-shows__row">
+          <article class="artist-featured-track">
+            <div class="artist-featured-track__details">
+              <a class="artist-featured-track__title" href="{{ $track.RelPermalink }}">{{ $track.Title | emojify }}</a>
+              {{ with .Params.release }}
+                <span class="artist-featured-track__release">from {{ . }}</span>
+              {{ end }}
+            </div>
+            {{ if gt (len $appearances) 0 }}
+              <div class="artist-featured-track__broadcasts">
+                <span class="artist-featured-track__label">Featured on:</span>
+                <ul class="artist-featured-track__appearances">
+                  {{ range $appearances.ByDate.Reverse }}
+                    <li>
+                      <a class="artist-featured-track__show-link" href="{{ .RelPermalink }}">
+                        <span>{{ partial "release/show-card-title.html" . }}</span>
+                        {{ if not .Date.IsZero }}
+                          <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date | time.Format (site.Params.dateFormat | default "2 January 2006") }}</time>
+                        {{ end }}
+                        <span class="artist-featured-track__cta">View Broadcast <span aria-hidden="true">→</span></span>
+                      </a>
+                    </li>
+                  {{ end }}
+                </ul>
+              </div>
+            {{ end }}
+          </article>
         </li>
       {{ end }}
     </ul>


### PR DESCRIPTION
## Summary

- derive each featured track's broadcast appearances from existing show playlists and track guides
- display the broadcast title or number, human-readable date, and direct show link
- group multiple appearances beneath one track and retain existing track and release context
- add responsive, keyboard-accessible styling compatible with the existing Blowfish list treatment

## Why

Artist pages identified tracks played on Sundown Sessions but did not show where they were broadcast. This left visitors without a route back into the core show archive.

## Root cause

The artist featured-tracks partial only rendered track front matter. It did not resolve those tracks against show playlist or track-guide content, and it limited the result to 12 tracks.

## Validation

- `hugo --environment production --renderToMemory --quiet`
- `git diff --check`
- verified the rendered Queens of the Stone Age example includes Sundown Sessions #1, 5 June 2024, and its broadcast link

Closes #757