### PR TITLE
fix: standardise artist page rhythm

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -3546,8 +3546,32 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   margin: -0.35rem 1.25rem 0.9rem;
 }
 
-/* Artist featured tracks: a compact track summary followed by all of its
-   broadcast appearances. */
+/* Artist featured tracks: a lightweight list group that follows the same
+   heading and section rhythm as the surrounding artist discovery content. */
+
+.artist-featured-tracks__list {
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid #d4d4d4; /* neutral-300 */
+  border-radius: 0.75rem;
+  background-color: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  padding: 0;
+  list-style: none;
+}
+
+.dark .artist-featured-tracks__list {
+  border-color: #404040; /* neutral-700 */
+  background-color: rgba(23, 23, 23, 0.8); /* neutral-900/80 */
+}
+
+.artist-featured-tracks__row + .artist-featured-tracks__row {
+  border-top: 1px solid #e5e5e5; /* neutral-200 */
+}
+
+.dark .artist-featured-tracks__row + .artist-featured-tracks__row {
+  border-top-color: #404040; /* neutral-700 */
+}
 
 .artist-featured-track {
   display: grid;
@@ -3632,15 +3656,12 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 
 .artist-featured-track__show-link {
   gap: 0.1rem;
-  padding: 0.7rem 0.8rem;
-  border: 1px solid #e5e5e5; /* neutral-200 */
-  border-radius: 0.5rem;
-  background: #fff;
+  padding: 0.6rem 0;
+  border-top: 1px solid #e5e5e5; /* neutral-200 */
 }
 
 .dark .artist-featured-track__show-link {
   border-color: #404040; /* neutral-700 */
-  background: rgba(23, 23, 23, 0.5); /* neutral-900/50 */
 }
 
 .artist-featured-track__show-link > span:first-child {

--- a/src/layouts/partials/artist-featured-tracks.html
+++ b/src/layouts/partials/artist-featured-tracks.html
@@ -20,9 +20,11 @@
 {{ end }}
 
 {{ if gt (len $tracks) 0 }}
-  <section class="release-featured-shows not-prose" role="region" aria-labelledby="artist-featured-tracks-heading">
-    <h2 id="artist-featured-tracks-heading" class="release-featured-shows__heading">Tracks Featured on Sundown Sessions</h2>
-    <ul class="release-featured-shows__list">
+  <section class="artist-featured-tracks mb-10 not-prose" role="region" aria-labelledby="artist-featured-tracks-heading">
+    <h2 id="artist-featured-tracks-heading" class="mb-4 text-2xl font-bold text-neutral-800 dark:text-neutral-200">
+      Tracks Featured on Sundown Sessions
+    </h2>
+    <ul class="artist-featured-tracks__list">
       {{ range $tracks.ByTitle }}
         {{ $track := . }}
         {{ $trackTitle := lower .Title }}
@@ -56,7 +58,7 @@
           {{ end }}
         {{ end }}
 
-        <li class="release-featured-shows__row">
+        <li class="artist-featured-tracks__row">
           <article class="artist-featured-track">
             <div class="artist-featured-track__details">
               <a class="artist-featured-track__title" href="{{ $track.RelPermalink }}">{{ $track.Title | emojify }}</a>


### PR DESCRIPTION
## Summary

- align the featured-tracks heading and spacing with the other artist-page discovery sections
- present featured tracks as a lightweight list group with consistent borders, radii and dark-mode styling
- simplify broadcast appearances so they no longer appear as visually heavy nested cards

## Why

The artist page used the release featured-shows container for tracks, which boxed the heading and introduced different typography and vertical spacing from neighbouring artist sections. This interrupted the page rhythm and made tracks feel disconnected from the rest of the discovery system.

The updated treatment preserves the hierarchy requested in #756: editorial content remains unboxed, releases and related artists remain image-led, tracks use a lighter list-group, and Explore Further remains a distinct outbound-links card.

## Impact

Artist pages with featured tracks now have consistent section headings and spacing across desktop and mobile, while track and broadcast links remain accessible and visually lighter than image-led cards.

## Validation

- `hugo --environment production --gc --minify`
- `git diff --check`

Closes #756