### PR TITLE
fix: recover interrupted live streams

### DIFF
--- a/.github/workflows/test-listen-live-player.yml
+++ b/.github/workflows/test-listen-live-player.yml
@@ -1,0 +1,37 @@
+name: Test Listen Live Player
+
+on:
+  pull_request:
+    paths:
+      - src/assets/js/listen-live-player.js
+      - src/layouts/listen-live/**
+      - src/layouts/partials/listen-live/**
+      - tests/js/**
+      - .github/workflows/test-listen-live-player.yml
+  push:
+    branches:
+      - main
+    paths:
+      - src/assets/js/listen-live-player.js
+      - src/layouts/listen-live/**
+      - src/layouts/partials/listen-live/**
+      - tests/js/**
+      - .github/workflows/test-listen-live-player.yml
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source using v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
+        with:
+          node-version: 22
+
+      - name: Test live player recovery
+        run: node --test tests/js/*.test.cjs

--- a/.github/workflows/validate-hugo-content.yml
+++ b/.github/workflows/validate-hugo-content.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - src/content/**
       - src/layouts/**
+      - src/assets/**
       - src/config/**
       - .github/workflows/validate-hugo-content.yml
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - src/content/**
       - src/layouts/**
+      - src/assets/**
       - src/config/**
       - .github/workflows/validate-hugo-content.yml
 

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -351,6 +351,54 @@ label[for]:focus-visible {
   width: 100%;
 }
 
+.listen-live-player__feedback {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 0.85rem;
+  margin-top: 0.65rem;
+}
+
+.listen-live-player__connection-status {
+  margin: 0;
+  color: var(--ss-color-midnight);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.listen-live-player__retry {
+  min-height: 2.75rem;
+  border: 1px solid currentColor;
+  border-radius: 0.5rem;
+  background: var(--ss-color-surface);
+  padding: 0.62rem 0.9rem;
+  color: var(--ss-color-midnight);
+  font-size: 0.88rem;
+  font-weight: 750;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.listen-live-player__retry:hover {
+  color: var(--ss-color-twilight);
+}
+
+.listen-live-player__retry:focus-visible {
+  outline-color: var(--ss-color-twilight);
+}
+
+.dark .listen-live-player__connection-status {
+  color: var(--ss-color-muted);
+}
+
+.dark .listen-live-player__retry {
+  color: #f6f1ea;
+}
+
+.listen-live-player__retry[hidden] {
+  display: none;
+}
+
 .listen-live-player-shell {
   display: grid;
   gap: clamp(1.25rem, 3.5vw, 2.5rem);

--- a/src/assets/js/listen-live-player.js
+++ b/src/assets/js/listen-live-player.js
@@ -1,0 +1,609 @@
+(function (root, factory) {
+  "use strict";
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory;
+  } else if (root && root.document) {
+    factory(root).init();
+  }
+}(typeof window !== "undefined" ? window : this, function (windowObject) {
+  "use strict";
+
+  var DEFAULT_RETRY_DELAYS_MS = [1000, 2000, 5000, 10000, 20000, 30000];
+  var DEFAULT_BUFFER_GRACE_MS = 12000;
+  var DEFAULT_CONNECT_TIMEOUT_MS = 20000;
+  var DEFAULT_PROGRESS_INTERVAL_MS = 5000;
+  var DEFAULT_PROGRESS_STALL_MS = 20000;
+  var DEFAULT_STABLE_PLAYBACK_MS = 30000;
+
+  function optionNumber(options, name, fallback) {
+    return options && typeof options[name] === "number" ? options[name] : fallback;
+  }
+
+  function createController(rootElement, options) {
+    var settings = options || {};
+    var clock = settings.clock || windowObject;
+    var now = settings.now || function () {
+      return Date.now();
+    };
+    var retryDelays = settings.retryDelaysMs || DEFAULT_RETRY_DELAYS_MS;
+    var bufferGraceMs = optionNumber(settings, "bufferGraceMs", DEFAULT_BUFFER_GRACE_MS);
+    var connectTimeoutMs = optionNumber(settings, "connectTimeoutMs", DEFAULT_CONNECT_TIMEOUT_MS);
+    var progressIntervalMs = optionNumber(settings, "progressIntervalMs", DEFAULT_PROGRESS_INTERVAL_MS);
+    var progressStallMs = optionNumber(settings, "progressStallMs", DEFAULT_PROGRESS_STALL_MS);
+    var stablePlaybackMs = optionNumber(settings, "stablePlaybackMs", DEFAULT_STABLE_PLAYBACK_MS);
+    var documentObject = windowObject.document;
+    var navigatorObject = windowObject.navigator || {};
+    var audio = rootElement && rootElement.querySelector("[data-listen-live-player-audio]");
+    var source = audio && audio.querySelector("source");
+    var status = rootElement && rootElement.querySelector("[data-listen-live-player-status]");
+    var retryButton = rootElement && rootElement.querySelector("[data-listen-live-player-retry]");
+    var canonicalStreamUrl = rootElement && rootElement.getAttribute("data-stream-url");
+
+    var wantsPlayback = false;
+    var interactionRequired = false;
+    var internalReload = false;
+    var suspended = false;
+    var generation = 0;
+    var retryIndex = 0;
+    var retryTimerId = null;
+    var bufferTimerId = null;
+    var connectTimerId = null;
+    var progressTimerId = null;
+    var stableTimerId = null;
+    var lastMediaTime = null;
+    var noProgressSince = null;
+    var hasObservedProgress = false;
+    var lastProgressAt = null;
+    var bufferStartMediaTime = null;
+    var currentState = "";
+    var listeners = [];
+
+    if (!audio || !status || !canonicalStreamUrl) {
+      return null;
+    }
+
+    function addListener(target, eventName, handler) {
+      if (!target || !target.addEventListener) {
+        return;
+      }
+
+      target.addEventListener(eventName, handler);
+      listeners.push({
+        target: target,
+        eventName: eventName,
+        handler: handler
+      });
+    }
+
+    function clearTimer(timerName) {
+      var timerId;
+
+      if (timerName === "retry") {
+        timerId = retryTimerId;
+        retryTimerId = null;
+      } else if (timerName === "buffer") {
+        timerId = bufferTimerId;
+        bufferTimerId = null;
+      } else if (timerName === "connect") {
+        timerId = connectTimerId;
+        connectTimerId = null;
+      } else if (timerName === "progress") {
+        timerId = progressTimerId;
+        progressTimerId = null;
+      } else {
+        timerId = stableTimerId;
+        stableTimerId = null;
+      }
+
+      if (timerId !== null) {
+        if (timerName === "progress") {
+          clock.clearInterval(timerId);
+        } else {
+          clock.clearTimeout(timerId);
+        }
+      }
+    }
+
+    function resetProgressWatchdog() {
+      clearTimer("progress");
+      lastMediaTime = null;
+      noProgressSince = null;
+      hasObservedProgress = false;
+      lastProgressAt = null;
+    }
+
+    function clearRecoveryTimers() {
+      clearTimer("retry");
+      clearTimer("buffer");
+      clearTimer("connect");
+      clearTimer("stable");
+      resetProgressWatchdog();
+    }
+
+    function setRetryButton(show, label) {
+      if (!retryButton) {
+        return;
+      }
+
+      if (show) {
+        retryButton.textContent = label || "Resume live stream";
+        retryButton.hidden = false;
+        return;
+      }
+
+      if (documentObject.activeElement === retryButton && typeof audio.focus === "function") {
+        audio.focus();
+      }
+      retryButton.hidden = true;
+    }
+
+    function setState(state, message, showRetry, retryLabel) {
+      rootElement.setAttribute("data-player-state", state);
+
+      if (currentState !== state || status.textContent !== message) {
+        status.textContent = message;
+        currentState = state;
+      }
+
+      setRetryButton(Boolean(showRetry), retryLabel);
+    }
+
+    function isOffline() {
+      return navigatorObject.onLine === false;
+    }
+
+    function showOffline() {
+      setState(
+        "offline",
+        "You’re offline. We’ll reconnect when your internet connection returns.",
+        false
+      );
+    }
+
+    function showInteractionRequired() {
+      setState(
+        "interaction-required",
+        "Your browser needs you to restart playback. Select Resume live stream to continue.",
+        true,
+        "Resume live stream"
+      );
+    }
+
+    function makeReconnectUrl() {
+      var separator;
+
+      if (windowObject.URL) {
+        try {
+          var url = new windowObject.URL(canonicalStreamUrl, windowObject.location && windowObject.location.href);
+          url.searchParams.set("ss-reconnect", String(now()) + "-" + String(generation));
+          return url.href;
+        } catch (error) {
+          // Fall through to the string form for older browsers.
+        }
+      }
+
+      separator = canonicalStreamUrl.indexOf("?") === -1 ? "?" : "&";
+      return canonicalStreamUrl + separator + "ss-reconnect=" + encodeURIComponent(String(now()) + "-" + String(generation));
+    }
+
+    function stopPlaybackIntent() {
+      wantsPlayback = false;
+      interactionRequired = false;
+      internalReload = false;
+      suspended = false;
+      retryIndex = 0;
+      generation += 1;
+      clearRecoveryTimers();
+      setState("idle", "Press play to listen live.", false);
+    }
+
+    function handlePlayFailure(error, attemptGeneration) {
+      var errorName;
+
+      if (attemptGeneration !== generation || !wantsPlayback) {
+        return;
+      }
+
+      internalReload = false;
+      clearTimer("connect");
+      errorName = error && error.name ? error.name : "";
+
+      if (errorName === "NotAllowedError") {
+        interactionRequired = true;
+        clearRecoveryTimers();
+        showInteractionRequired();
+        return;
+      }
+
+      scheduleRecovery(false);
+    }
+
+    function startConnectTimeout(attemptGeneration) {
+      clearTimer("connect");
+      connectTimerId = clock.setTimeout(function () {
+        connectTimerId = null;
+
+        if (attemptGeneration !== generation || !wantsPlayback) {
+          return;
+        }
+
+        internalReload = false;
+        scheduleRecovery(false);
+      }, connectTimeoutMs);
+    }
+
+    function attemptRecovery(showConnectingState) {
+      var attemptGeneration;
+      var playResult;
+      var reconnectUrl;
+
+      clearTimer("retry");
+
+      if (!wantsPlayback || interactionRequired) {
+        return;
+      }
+
+      if (isOffline()) {
+        showOffline();
+        return;
+      }
+
+      generation += 1;
+      attemptGeneration = generation;
+      internalReload = true;
+      reconnectUrl = makeReconnectUrl();
+      if (showConnectingState) {
+        setState("connecting", "Connecting to the live stream…", false);
+      }
+
+      try {
+        if (source) {
+          source.setAttribute("src", reconnectUrl);
+        } else {
+          audio.setAttribute("src", reconnectUrl);
+        }
+
+        audio.load();
+        playResult = audio.play();
+      } catch (error) {
+        internalReload = false;
+        handlePlayFailure(error, attemptGeneration);
+        return;
+      }
+
+      startConnectTimeout(attemptGeneration);
+
+      if (playResult && typeof playResult.then === "function") {
+        playResult.then(function () {
+          if (attemptGeneration === generation) {
+            internalReload = false;
+          }
+        }, function (error) {
+          handlePlayFailure(error, attemptGeneration);
+        });
+      } else {
+        clock.setTimeout(function () {
+          if (attemptGeneration === generation) {
+            internalReload = false;
+          }
+        }, 0);
+      }
+    }
+
+    function scheduleRecovery(immediate, message) {
+      var delayMs;
+
+      if (!wantsPlayback || interactionRequired || suspended) {
+        return;
+      }
+
+      if (isOffline()) {
+        generation += 1;
+        internalReload = false;
+        clearRecoveryTimers();
+        showOffline();
+        return;
+      }
+
+      if (retryTimerId !== null) {
+        return;
+      }
+
+      generation += 1;
+      internalReload = false;
+      clearTimer("buffer");
+      clearTimer("connect");
+      clearTimer("stable");
+      resetProgressWatchdog();
+
+      if (immediate) {
+        delayMs = 0;
+      } else {
+        delayMs = retryDelays[Math.min(retryIndex, retryDelays.length - 1)];
+        retryIndex += 1;
+      }
+
+      setState(
+        "retrying",
+        message || "Connection interrupted. Reconnecting automatically…",
+        false
+      );
+      retryTimerId = clock.setTimeout(function () {
+        retryTimerId = null;
+        attemptRecovery(false);
+      }, delayMs);
+    }
+
+    function startBufferGrace() {
+      if (!wantsPlayback || interactionRequired || suspended || bufferTimerId !== null) {
+        return;
+      }
+
+      if (isOffline()) {
+        showOffline();
+        return;
+      }
+
+      bufferStartMediaTime = Number.isFinite(Number(audio.currentTime)) ? Number(audio.currentTime) : null;
+      bufferTimerId = clock.setTimeout(function () {
+        var currentMediaTime = Number(audio.currentTime);
+
+        bufferTimerId = null;
+        if (bufferStartMediaTime !== null && Number.isFinite(currentMediaTime) &&
+            currentMediaTime > bufferStartMediaTime + 0.05) {
+          setState("playing", "Live stream playing.", false);
+          return;
+        }
+
+        scheduleRecovery(false);
+      }, bufferGraceMs);
+    }
+
+    function sampleProgress() {
+      var mediaTime;
+      var sampleTime;
+
+      if (!wantsPlayback || audio.paused || internalReload) {
+        lastMediaTime = null;
+        noProgressSince = null;
+        return;
+      }
+
+      mediaTime = Number(audio.currentTime);
+      if (!Number.isFinite(mediaTime)) {
+        lastMediaTime = null;
+        noProgressSince = null;
+        return;
+      }
+
+      sampleTime = now();
+      if (lastMediaTime === null || mediaTime > lastMediaTime + 0.05) {
+        if (lastMediaTime !== null) {
+          hasObservedProgress = true;
+          lastProgressAt = sampleTime;
+          clearTimer("buffer");
+          if (retryTimerId !== null) {
+            clearTimer("retry");
+            setState("playing", "Live stream playing.", false);
+          }
+        }
+        noProgressSince = null;
+      } else if (hasObservedProgress && noProgressSince === null) {
+        noProgressSince = sampleTime;
+      } else if (hasObservedProgress && sampleTime - noProgressSince >= progressStallMs) {
+        noProgressSince = null;
+        scheduleRecovery(false);
+      }
+
+      lastMediaTime = mediaTime;
+    }
+
+    function startProgressWatchdog() {
+      resetProgressWatchdog();
+      lastMediaTime = Number.isFinite(Number(audio.currentTime)) ? Number(audio.currentTime) : null;
+      progressTimerId = clock.setInterval(sampleProgress, progressIntervalMs);
+    }
+
+    function handlePlay() {
+      var wasInternalReload = internalReload;
+
+      wantsPlayback = true;
+      internalReload = false;
+      clearTimer("retry");
+      clearTimer("buffer");
+
+      if (suspended) {
+        return;
+      }
+
+      interactionRequired = false;
+      if (isOffline()) {
+        clearTimer("connect");
+        showOffline();
+        return;
+      }
+
+      if (!wasInternalReload) {
+        retryIndex = 0;
+        generation += 1;
+        startConnectTimeout(generation);
+        setState("connecting", "Connecting to the live stream…", false);
+      }
+    }
+
+    function handlePlaying() {
+      if (!wantsPlayback || suspended) {
+        return;
+      }
+
+      if (isOffline()) {
+        showOffline();
+        return;
+      }
+
+      interactionRequired = false;
+      internalReload = false;
+      clearTimer("retry");
+      clearTimer("buffer");
+      clearTimer("connect");
+      clearTimer("stable");
+      setState("playing", "Live stream playing.", false);
+      startProgressWatchdog();
+
+      stableTimerId = clock.setTimeout(function () {
+        stableTimerId = null;
+        if (hasObservedProgress && lastProgressAt !== null &&
+            now() - lastProgressAt <= progressIntervalMs * 2) {
+          retryIndex = 0;
+        }
+      }, stablePlaybackMs);
+    }
+
+    function handlePause() {
+      if (wantsPlayback && audio.ended) {
+        return;
+      }
+
+      stopPlaybackIntent();
+    }
+
+    function handleCanPlay() {
+      clearTimer("buffer");
+    }
+
+    function handleError() {
+      var mediaErrorCode = audio.error && audio.error.code;
+
+      if (!wantsPlayback) {
+        return;
+      }
+
+      if (internalReload && mediaErrorCode === 1) {
+        return;
+      }
+
+      scheduleRecovery(false);
+    }
+
+    function handleEnded() {
+      if (wantsPlayback) {
+        scheduleRecovery(false);
+      }
+    }
+
+    function handleOffline() {
+      if (!wantsPlayback) {
+        return;
+      }
+
+      generation += 1;
+      internalReload = false;
+      clearRecoveryTimers();
+      showOffline();
+    }
+
+    function handleOnline() {
+      if (!wantsPlayback) {
+        return;
+      }
+
+      if (interactionRequired) {
+        showInteractionRequired();
+        return;
+      }
+
+      scheduleRecovery(true, "Internet connection restored. Reconnecting…");
+    }
+
+    function handleRetry() {
+      wantsPlayback = true;
+      interactionRequired = false;
+      suspended = false;
+      retryIndex = 0;
+      generation += 1;
+      clearRecoveryTimers();
+      attemptRecovery(true);
+    }
+
+    function handlePageHide() {
+      if (!wantsPlayback) {
+        return;
+      }
+
+      suspended = true;
+      generation += 1;
+      internalReload = false;
+      clearRecoveryTimers();
+    }
+
+    function handlePageShow(event) {
+      if (!suspended || !wantsPlayback || (event && event.persisted === false)) {
+        suspended = false;
+        return;
+      }
+
+      suspended = false;
+      scheduleRecovery(true);
+    }
+
+    function destroy() {
+      generation += 1;
+      clearRecoveryTimers();
+      listeners.forEach(function (listener) {
+        listener.target.removeEventListener(listener.eventName, listener.handler);
+      });
+      listeners = [];
+      rootElement.removeAttribute("data-player-initialised");
+    }
+
+    rootElement.setAttribute("data-player-initialised", "true");
+    setState("idle", "Press play to listen live.", false);
+
+    addListener(audio, "play", handlePlay);
+    addListener(audio, "playing", handlePlaying);
+    addListener(audio, "pause", handlePause);
+    addListener(audio, "canplay", handleCanPlay);
+    addListener(audio, "waiting", startBufferGrace);
+    addListener(audio, "stalled", startBufferGrace);
+    addListener(audio, "error", handleError);
+    addListener(audio, "ended", handleEnded);
+    addListener(retryButton, "click", handleRetry);
+    addListener(windowObject, "offline", handleOffline);
+    addListener(windowObject, "online", handleOnline);
+    addListener(windowObject, "pagehide", handlePageHide);
+    addListener(windowObject, "pageshow", handlePageShow);
+
+    return {
+      destroy: destroy
+    };
+  }
+
+  function init() {
+    var controllers = [];
+    var roots;
+
+    if (!windowObject.document || !windowObject.document.querySelectorAll) {
+      return controllers;
+    }
+
+    roots = windowObject.document.querySelectorAll("[data-listen-live-player]");
+    for (var index = 0; index < roots.length; index += 1) {
+      if (roots[index].getAttribute("data-player-initialised") === "true") {
+        continue;
+      }
+
+      var controller = createController(roots[index]);
+      if (controller) {
+        controllers.push(controller);
+      }
+    }
+
+    return controllers;
+  }
+
+  return {
+    createController: createController,
+    init: init
+  };
+}));

--- a/src/assets/js/listen-live-schedule.js
+++ b/src/assets/js/listen-live-schedule.js
@@ -65,7 +65,7 @@
     }
 
     playerBadge.setAttribute("data-broadcast-state", live ? "live" : "off-air");
-    playerBadge.setAttribute("aria-label", live ? "Live stream status: live now" : "Live stream status: station stream available");
+    playerBadge.setAttribute("aria-label", live ? "Broadcast status: live now" : "Broadcast status: no live show; station stream available");
     playerBadgeLabel.textContent = live ? "Live Now" : "Station Stream";
   }
 

--- a/src/layouts/listen-live/single.html
+++ b/src/layouts/listen-live/single.html
@@ -33,9 +33,10 @@
             </header>
 
             <section class="listen-live-live" aria-labelledby="listen-live-player-heading">
-              <p class="listen-live-status" data-live-player-badge data-broadcast-state="off-air" aria-label="Live stream status">
+              <h2 id="listen-live-player-heading" class="sr-only">Listen to Sundown Sessions live</h2>
+              <p class="listen-live-status" data-live-player-badge data-broadcast-state="off-air" aria-label="Broadcast status: no live show; station stream available">
                 <span class="listen-live-status__dot" aria-hidden="true"></span>
-                <span id="listen-live-player-heading" data-live-player-badge-label>Station Stream</span>
+                <span data-live-player-badge-label>Station Stream</span>
               </p>
 
               <div
@@ -120,6 +121,13 @@
     </section>
   </article>
 
+  {{ with resources.Get "js/listen-live-player.js" }}
+    {{ $playerJS := . | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
+    <script
+      defer
+      src="{{ $playerJS.RelPermalink }}"
+      integrity="{{ $playerJS.Data.Integrity }}"></script>
+  {{ end }}
   {{ with resources.Get "js/listen-live-now-playing.js" }}
     {{ $nowPlayingJS := . | resources.Minify | resources.Fingerprint (site.Params.fingerprintAlgorithm | default "sha512") }}
     <script

--- a/src/layouts/partials/listen-live/player.html
+++ b/src/layouts/partials/listen-live/player.html
@@ -1,9 +1,26 @@
 {{ $streamURL := .src | default "https://betelgeuse.nucast.co.uk:8062/stream" }}
-{{ $streamType := .type | default "audio/mpeg" }}
+{{ $streamType := .type }}
 
-<div class="listen-live-player">
-  <audio controls preload="none" aria-label="Sundown Sessions live stream">
-    <source src="{{ $streamURL }}" type="{{ $streamType }}">
+<div
+  class="listen-live-player"
+  data-listen-live-player
+  data-player-state="idle"
+  data-stream-url="{{ $streamURL }}">
+  <audio controls preload="none" aria-label="Sundown Sessions live stream" data-listen-live-player-audio>
+    <source src="{{ $streamURL }}"{{ with $streamType }} type="{{ . }}"{{ end }}>
     Your browser does not support the audio element.
   </audio>
+  <div class="listen-live-player__feedback">
+    <p
+      class="listen-live-player__connection-status"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-listen-live-player-status>Press play to listen live.</p>
+    <button
+      class="listen-live-player__retry"
+      type="button"
+      data-listen-live-player-retry
+      hidden>Resume live stream</button>
+  </div>
 </div>

--- a/tests/js/listen-live-player.test.cjs
+++ b/tests/js/listen-live-player.test.cjs
@@ -1,0 +1,503 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const createPlayer = require("../../src/assets/js/listen-live-player.js");
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(name, handler) {
+    const handlers = this.listeners.get(name) || [];
+    handlers.push(handler);
+    this.listeners.set(name, handlers);
+  }
+
+  removeEventListener(name, handler) {
+    const handlers = this.listeners.get(name) || [];
+    this.listeners.set(name, handlers.filter((candidate) => candidate !== handler));
+  }
+
+  dispatch(name, properties = {}) {
+    const event = { type: name, ...properties };
+    const handlers = this.listeners.get(name) || [];
+    handlers.slice().forEach((handler) => handler(event));
+  }
+}
+
+class FakeElement extends FakeEventTarget {
+  constructor() {
+    super();
+    this.attributes = new Map();
+    this.children = new Map();
+    this.hidden = false;
+    this.textContent = "";
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
+  querySelector(selector) {
+    return this.children.get(selector) || null;
+  }
+}
+
+class FakeAudio extends FakeElement {
+  constructor(source, documentObject) {
+    super();
+    this.children.set("source", source);
+    this.documentObject = documentObject;
+    this.currentTime = 0;
+    this.ended = false;
+    this.error = null;
+    this.loadCalls = 0;
+    this.paused = true;
+    this.playCalls = 0;
+    this.playImplementation = null;
+  }
+
+  focus() {
+    this.documentObject.activeElement = this;
+  }
+
+  load() {
+    this.loadCalls += 1;
+    this.paused = true;
+  }
+
+  play() {
+    this.playCalls += 1;
+
+    if (this.playImplementation) {
+      return this.playImplementation();
+    }
+
+    this.paused = false;
+    this.dispatch("play");
+    return Promise.resolve();
+  }
+}
+
+class FakeClock {
+  constructor() {
+    this.currentTime = 0;
+    this.nextId = 1;
+    this.tasks = new Map();
+  }
+
+  clearInterval(id) {
+    this.tasks.delete(id);
+  }
+
+  clearTimeout(id) {
+    this.tasks.delete(id);
+  }
+
+  setInterval(callback, delay) {
+    return this.addTask(callback, delay, delay);
+  }
+
+  setTimeout(callback, delay) {
+    return this.addTask(callback, delay, null);
+  }
+
+  pendingTimeoutDelays() {
+    return Array.from(this.tasks.values())
+      .filter((task) => task.interval === null)
+      .map((task) => task.time - this.currentTime)
+      .sort((left, right) => left - right);
+  }
+
+  addTask(callback, delay, interval) {
+    const id = this.nextId;
+    this.nextId += 1;
+    this.tasks.set(id, {
+      callback,
+      interval,
+      time: this.currentTime + delay
+    });
+    return id;
+  }
+
+  tick(duration) {
+    const targetTime = this.currentTime + duration;
+
+    while (true) {
+      let nextId = null;
+      let nextTask = null;
+
+      for (const [id, task] of this.tasks) {
+        if (task.time <= targetTime &&
+            (!nextTask || task.time < nextTask.time ||
+              (task.time === nextTask.time && id < nextId))) {
+          nextId = id;
+          nextTask = task;
+        }
+      }
+
+      if (!nextTask) {
+        break;
+      }
+
+      this.currentTime = nextTask.time;
+      this.tasks.delete(nextId);
+      if (nextTask.interval !== null) {
+        this.tasks.set(nextId, {
+          ...nextTask,
+          time: nextTask.time + nextTask.interval
+        });
+      }
+      nextTask.callback();
+    }
+
+    this.currentTime = targetTime;
+  }
+}
+
+function createHarness() {
+  const clock = new FakeClock();
+  const documentObject = {
+    activeElement: null,
+    hidden: false,
+    querySelectorAll: () => []
+  };
+  const windowObject = new FakeEventTarget();
+  const root = new FakeElement();
+  const source = new FakeElement();
+  const status = new FakeElement();
+  const retryButton = new FakeElement();
+  const audio = new FakeAudio(source, documentObject);
+
+  windowObject.document = documentObject;
+  windowObject.location = { href: "https://sundownsessions.co.uk/listen-live/" };
+  windowObject.navigator = { onLine: true };
+  windowObject.URL = URL;
+  windowObject.clearInterval = clock.clearInterval.bind(clock);
+  windowObject.clearTimeout = clock.clearTimeout.bind(clock);
+  windowObject.setInterval = clock.setInterval.bind(clock);
+  windowObject.setTimeout = clock.setTimeout.bind(clock);
+
+  root.setAttribute("data-stream-url", "https://radio.example.test/stream?mount=main");
+  root.children.set("[data-listen-live-player-audio]", audio);
+  root.children.set("[data-listen-live-player-status]", status);
+  root.children.set("[data-listen-live-player-retry]", retryButton);
+
+  const api = createPlayer(windowObject);
+  const controller = api.createController(root, {
+    bufferGraceMs: 12000,
+    clock,
+    connectTimeoutMs: 20000,
+    now: () => clock.currentTime,
+    progressIntervalMs: 5000,
+    progressStallMs: 20000,
+    retryDelaysMs: [1000, 2000, 5000, 10000, 20000, 30000],
+    stablePlaybackMs: 30000
+  });
+
+  return {
+    audio,
+    clock,
+    controller,
+    root,
+    retryButton,
+    source,
+    status,
+    windowObject
+  };
+}
+
+function startPlayback(harness) {
+  harness.audio.paused = false;
+  harness.audio.dispatch("play");
+  harness.audio.dispatch("playing");
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+test("initialisation does not start playback", () => {
+  const harness = createHarness();
+
+  assert.ok(harness.controller);
+  assert.equal(harness.audio.loadCalls, 0);
+  assert.equal(harness.audio.playCalls, 0);
+  assert.equal(harness.root.getAttribute("data-player-state"), "idle");
+  assert.equal(harness.status.textContent, "Press play to listen live.");
+  assert.equal(harness.retryButton.hidden, true);
+});
+
+test("browser bootstrap initialises each player only once", () => {
+  const harness = createHarness();
+  harness.controller.destroy();
+  harness.windowObject.document.querySelectorAll = () => [harness.root];
+  const api = createPlayer(harness.windowObject);
+
+  assert.equal(api.init().length, 1);
+  assert.equal(api.init().length, 0);
+
+  harness.audio.paused = false;
+  harness.audio.dispatch("play");
+  assert.equal(harness.root.getAttribute("data-player-state"), "connecting");
+});
+
+test("brief buffering is tolerated and playing cancels recovery", () => {
+  const harness = createHarness();
+
+  startPlayback(harness);
+  harness.audio.dispatch("waiting");
+  harness.clock.tick(11000);
+
+  assert.equal(harness.audio.loadCalls, 0);
+  assert.equal(harness.root.getAttribute("data-player-state"), "playing");
+
+  harness.audio.currentTime = 5;
+  harness.audio.dispatch("playing");
+  harness.clock.tick(30000);
+
+  assert.equal(harness.audio.loadCalls, 0);
+  assert.equal(harness.root.getAttribute("data-player-state"), "playing");
+});
+
+test("a prolonged stall opens a fresh connection after the grace period", () => {
+  const harness = createHarness();
+
+  startPlayback(harness);
+  harness.audio.dispatch("stalled");
+  harness.clock.tick(12000);
+
+  assert.equal(harness.root.getAttribute("data-player-state"), "retrying");
+  assert.match(harness.status.textContent, /Reconnecting automatically/);
+  assert.equal(harness.audio.loadCalls, 0);
+
+  harness.clock.tick(1000);
+
+  assert.equal(harness.audio.loadCalls, 1);
+  assert.equal(harness.audio.playCalls, 1);
+  assert.match(harness.source.getAttribute("src"), /mount=main&ss-reconnect=/);
+});
+
+test("an initial connection that hangs is recovered automatically", () => {
+  const harness = createHarness();
+
+  harness.audio.paused = false;
+  harness.audio.dispatch("play");
+  harness.clock.tick(20000);
+
+  assert.equal(harness.root.getAttribute("data-player-state"), "retrying");
+  assert.match(harness.status.textContent, /Reconnecting automatically/);
+
+  harness.clock.tick(1000);
+
+  assert.equal(harness.audio.loadCalls, 1);
+  assert.equal(harness.audio.playCalls, 1);
+});
+
+test("the progress watchdog recovers a frozen stream after progress was observed", () => {
+  const harness = createHarness();
+
+  startPlayback(harness);
+  harness.audio.currentTime = 5;
+  harness.clock.tick(5000);
+  harness.clock.tick(25000);
+
+  assert.equal(harness.root.getAttribute("data-player-state"), "retrying");
+  assert.match(harness.status.textContent, /Reconnecting automatically/);
+});
+
+test("a browser with a constant live-stream timeline is not force-reloaded", () => {
+  const harness = createHarness();
+
+  startPlayback(harness);
+  harness.clock.tick(120000);
+
+  assert.equal(harness.audio.loadCalls, 0);
+  assert.equal(harness.root.getAttribute("data-player-state"), "playing");
+});
+
+test("duplicate failure events share one retry and use capped backoff", async () => {
+  const harness = createHarness();
+  const failures = [];
+  const retryDelays = [];
+
+  startPlayback(harness);
+  harness.audio.playImplementation = () => {
+    const error = new Error("network unavailable");
+    error.name = "NetworkError";
+    failures.push(error);
+    return Promise.reject(error);
+  };
+
+  harness.audio.dispatch("error");
+  harness.audio.dispatch("ended");
+  harness.audio.dispatch("error");
+  retryDelays.push(harness.clock.pendingTimeoutDelays()[0]);
+  harness.clock.tick(1000);
+  await flushPromises();
+  retryDelays.push(harness.clock.pendingTimeoutDelays()[0]);
+
+  for (const delay of [2000, 5000, 10000, 20000, 30000, 30000]) {
+    harness.clock.tick(delay);
+    await flushPromises();
+    retryDelays.push(harness.clock.pendingTimeoutDelays()[0]);
+  }
+
+  assert.equal(harness.audio.playCalls, 7);
+  assert.deepEqual(retryDelays, [1000, 2000, 5000, 10000, 20000, 30000, 30000, 30000]);
+  assert.equal(failures.length, 7);
+});
+
+test("an intentional pause cancels pending and future automatic recovery", () => {
+  const harness = createHarness();
+
+  startPlayback(harness);
+  harness.audio.error = { code: 2 };
+  harness.audio.dispatch("error");
+  harness.audio.paused = true;
+  harness.audio.dispatch("pause");
+  harness.clock.tick(60000);
+
+  harness.windowObject.dispatch("online");
+  harness.audio.dispatch("error");
+  harness.clock.tick(60000);
+
+  assert.equal(harness.audio.loadCalls, 0);
+  assert.equal(harness.audio.playCalls, 0);
+  assert.equal(harness.root.getAttribute("data-player-state"), "idle");
+});
+
+test("the automatic pause at the natural end retains recovery intent", () => {
+  const harness = createHarness();
+
+  startPlayback(harness);
+  harness.audio.paused = true;
+  harness.audio.ended = true;
+  harness.audio.dispatch("pause");
+  harness.audio.dispatch("ended");
+  harness.clock.tick(1000);
+
+  assert.equal(harness.audio.loadCalls, 1);
+  assert.equal(harness.audio.playCalls, 1);
+});
+
+test("offline waits, then reconnects immediately when the network returns", () => {
+  const harness = createHarness();
+
+  startPlayback(harness);
+  harness.windowObject.navigator.onLine = false;
+  harness.windowObject.dispatch("offline");
+  harness.clock.tick(60000);
+
+  assert.equal(harness.audio.loadCalls, 0);
+  assert.equal(harness.root.getAttribute("data-player-state"), "offline");
+
+  harness.windowObject.navigator.onLine = true;
+  harness.windowObject.dispatch("online");
+  harness.clock.tick(0);
+
+  assert.equal(harness.audio.loadCalls, 1);
+  assert.equal(harness.audio.playCalls, 1);
+});
+
+test("pressing play while offline waits for the online event", () => {
+  const harness = createHarness();
+
+  harness.windowObject.navigator.onLine = false;
+  harness.audio.paused = false;
+  harness.audio.dispatch("play");
+  harness.clock.tick(60000);
+
+  assert.equal(harness.root.getAttribute("data-player-state"), "offline");
+  assert.equal(harness.audio.loadCalls, 0);
+
+  harness.windowObject.navigator.onLine = true;
+  harness.windowObject.dispatch("online");
+  harness.clock.tick(0);
+
+  assert.equal(harness.audio.loadCalls, 1);
+});
+
+test("a blocked scripted play exposes a user-gesture retry without looping", async () => {
+  const harness = createHarness();
+  const notAllowed = new Error("user activation required");
+  notAllowed.name = "NotAllowedError";
+
+  startPlayback(harness);
+  harness.audio.playImplementation = () => Promise.reject(notAllowed);
+  harness.audio.dispatch("error");
+  harness.clock.tick(1000);
+  await flushPromises();
+  harness.clock.tick(60000);
+
+  assert.equal(harness.audio.playCalls, 1);
+  assert.equal(harness.root.getAttribute("data-player-state"), "interaction-required");
+  assert.equal(harness.retryButton.hidden, false);
+  assert.match(harness.status.textContent, /needs you to restart playback/);
+
+  harness.audio.playImplementation = null;
+  harness.retryButton.dispatch("click");
+  await flushPromises();
+
+  assert.equal(harness.audio.playCalls, 2);
+  assert.equal(harness.root.getAttribute("data-player-state"), "connecting");
+  assert.equal(harness.retryButton.hidden, true);
+});
+
+test("an offline transition preserves an autoplay-blocked resume prompt", async () => {
+  const harness = createHarness();
+  const notAllowed = new Error("user activation required");
+  notAllowed.name = "NotAllowedError";
+
+  startPlayback(harness);
+  harness.audio.playImplementation = () => Promise.reject(notAllowed);
+  harness.audio.dispatch("error");
+  harness.clock.tick(1000);
+  await flushPromises();
+
+  harness.windowObject.navigator.onLine = false;
+  harness.windowObject.dispatch("offline");
+  assert.equal(harness.root.getAttribute("data-player-state"), "offline");
+  assert.equal(harness.retryButton.hidden, true);
+
+  harness.windowObject.navigator.onLine = true;
+  harness.windowObject.dispatch("online");
+
+  assert.equal(harness.root.getAttribute("data-player-state"), "interaction-required");
+  assert.equal(harness.retryButton.hidden, false);
+  assert.equal(harness.audio.playCalls, 1);
+});
+
+test("a late play rejection cannot restart after a deliberate pause", async () => {
+  const harness = createHarness();
+  let rejectPlay;
+
+  startPlayback(harness);
+  harness.audio.playImplementation = () => new Promise((resolve, reject) => {
+    rejectPlay = reject;
+  });
+  harness.audio.dispatch("error");
+  harness.clock.tick(1000);
+
+  harness.audio.paused = true;
+  harness.audio.dispatch("pause");
+  const lateError = new Error("late failure");
+  lateError.name = "NetworkError";
+  rejectPlay(lateError);
+  await flushPromises();
+  harness.clock.tick(60000);
+
+  assert.equal(harness.audio.playCalls, 1);
+  assert.equal(harness.audio.loadCalls, 1);
+  assert.equal(harness.root.getAttribute("data-player-state"), "idle");
+});


### PR DESCRIPTION
## Summary

- remove the misleading `audio/mpeg` source hint so browsers can use the stream's actual AAC response
- add guarded recovery for initial connection hangs, prolonged buffering, frozen playback, media errors, unexpected endings, network transitions, and page lifecycle changes
- retry with capped 1/2/5/10/20/30-second backoff while preserving an intentional Pause
- catch scripted `play()` rejections and expose an accessible Resume control when browser autoplay policy requires another user gesture
- add focused recovery tests and CI coverage for player JavaScript assets

## Why

A listener reported that the live player could cut out and remain silent indefinitely. The page previously used a bare native `<audio>` element with no handling for dropped or stalled long-running stream connections. It also labelled the AAC stream as MP3.

This change keeps the native controls while adding recovery around them, so a transient interruption no longer requires someone to notice the silence and manually restart playback.

## Testing

- `node --test tests/js/*.test.cjs` — 15 tests passed
- `node --check src/assets/js/listen-live-player.js`
- Hugo 0.146.5 production build with `--printPathWarnings --panicOnWarning` — passed
- verified NuCast accepts cache-busted reconnect URLs and continues returning stream data
- ran Pa11y across the configured pages; `/listen-live/` reported only the same two pre-existing global search-modal findings seen across the site, with no player-specific regression

## Accessibility

- [x] I reviewed the affected pages against the WCAG 2.2 AA baseline in `docs/accessibility.md`.
- [x] Keyboard navigation, focus visibility, labels, alternative text, colour contrast, and responsive reflow were considered for the changed areas.
- [x] Automated accessibility checks were run where practical, or any limitations are noted above.
