### PR TITLE
fix: correct Villains external link

### DIFF
--- a/src/content/releases/q/queens-of-the-stone-age/villains/index.md
+++ b/src/content/releases/q/queens-of-the-stone-age/villains/index.md
@@ -64,4 +64,4 @@ Villains is the seventh studio album by Queens of the Stone Age, released on 25 
 
 ## External Links
 
-- {{< new-tab-link "[Discogs](https://www.discogs.com/master/1344012-Queens-Of-The-Stone-Age-Villains)" >}}
+- {{< new-tab-link "[Discogs](https://www.discogs.com/master/1226820-Queens-Of-The-Stone-Age-Villains)" >}}


### PR DESCRIPTION
## Summary

- correct the Discogs master ID on the Queens of the Stone Age *Villains* release page
- preserve the Discogs label and service icon rendered by the shared Explore Further component
- leave the catalogue's other valid Discogs release link unchanged

## Root cause

The release page contained a one-off incorrect Discogs master ID (`1344012`). The shared release-page generation and enrichment paths were not responsible for the mismatch. MusicBrainz identifies master `1226820` as the correct Discogs destination for *Villains*.

## Impact

Visitors now reach the intended Queens of the Stone Age release instead of an unrelated Discogs master page.

## Validation

- built the production Hugo site successfully
- confirmed the rendered Explore Further entry links to Discogs master `1226820`
- confirmed the rendered label and icon are both Discogs
- ran `python3 -m unittest discover -s tests -p 'test_*.py'`
- ran `git diff --check`

Closes #767