### PR TITLE
fix: improve release link affordance

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -3183,6 +3183,39 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
   color: rgba(var(--color-primary-300), 1);
 }
 
+/* Release metadata links remain identifiable without hover, including on
+   touch devices, while unlinked values retain their plain-text treatment. */
+
+.release-details__link {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(var(--color-primary-500), 0.45);
+  text-decoration-thickness: 0.08rem;
+  text-underline-offset: 0.16rem;
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+.release-details__link:hover,
+.release-details__link:focus-visible {
+  color: rgba(var(--color-primary-700), 1);
+  text-decoration-color: currentColor;
+}
+
+.release-details__link:focus-visible {
+  border-radius: 0.125rem;
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 0.18rem;
+}
+
+.dark .release-details__link {
+  text-decoration-color: rgba(var(--color-primary-400), 0.5);
+}
+
+.dark .release-details__link:hover,
+.dark .release-details__link:focus-visible {
+  color: rgba(var(--color-primary-300), 1);
+}
+
 .release-hero__metadata {
   display: grid;
   gap: 0.9rem;
@@ -3349,14 +3382,27 @@ details[open] > .artist-biography-read-more .artist-biography-show-less {
 
 .release-artists__name a {
   color: inherit;
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-color: rgba(var(--color-primary-500), 0.4);
+  text-decoration-thickness: 0.08rem;
+  text-underline-offset: 0.125rem;
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
 }
 
 .release-artists__name a:hover,
 .release-artists__name a:focus-visible {
   color: rgba(var(--color-primary-600), 1);
-  text-decoration: underline;
-  text-underline-offset: 0.125rem;
+  text-decoration-color: currentColor;
+}
+
+.release-artists__name a:focus-visible {
+  border-radius: 0.125rem;
+  outline: 2px solid rgba(var(--color-primary-500), 0.75);
+  outline-offset: 0.18rem;
+}
+
+.dark .release-artists__name a {
+  text-decoration-color: rgba(var(--color-primary-400), 0.45);
 }
 
 .dark .release-artists__name a:hover,

--- a/src/layouts/partials/release/artists.html
+++ b/src/layouts/partials/release/artists.html
@@ -19,10 +19,17 @@
     <h2 id="release-artists-heading" class="release-artists__heading">Artist Spotlight</h2>
     <div class="release-artists__list" role="list">
       {{- range $artistCards }}
+        {{- $artist := . -}}
         {{- $artistPage := .page -}}
         <article class="release-artists__item" role="listitem">
           <div class="release-artists__body">
-            <h3 class="release-artists__name">{{ .name | emojify }}</h3>
+            <h3 class="release-artists__name">
+              {{- with $artistPage -}}
+                <a href="{{ .RelPermalink }}">{{ $artist.name | emojify }}</a>
+              {{- else -}}
+                {{ $artist.name | emojify }}
+              {{- end -}}
+            </h3>
             {{- with .summary }}
               <p class="release-artists__summary">{{ . }}</p>
             {{- end }}

--- a/src/layouts/partials/release/metadata-link-list.html
+++ b/src/layouts/partials/release/metadata-link-list.html
@@ -36,7 +36,7 @@
   {{- end -}}
   {{- with $termPage -}}
     <a
-      class="decoration-primary-500 hover:underline hover:underline-offset-2"
+      class="release-details__link"
       href="{{ .RelPermalink }}"
       data-analytics-event="taxonomy_navigation"
       data-analytics-taxonomy="{{ $taxonomyPath }}">{{ $value }}</a>


### PR DESCRIPTION
## Summary

- add a subtle, always-visible underline to linked Release Details taxonomy values
- strengthen metadata-link hover and keyboard-focus states in light and dark mode
- link resolved Artist Spotlight names to their Artist pages while preserving a plain-text fallback
- keep the Release hero artist link as the strongest relationship affordance

## Why

Release metadata and Artist Spotlight names previously relied on hover to communicate interactivity, which made links unclear on first view and ineffective as an affordance on touch devices.

## Impact

Visitors can now identify release-page internal links before interacting with them. Resolved Artist Spotlight headings provide a secondary route to Artist pages without adding a button, icon, or other visual noise. Unlinked metadata and unresolved artists retain their plain-text presentation.

## Validation

- production Hugo build with the CI-pinned Hugo 0.146.5
- generated release HTML inspected for taxonomy and Artist Spotlight URLs
- `node --test tests/js/*.test.cjs` (15 passed)
- `python3 -m unittest tests/test_audit_release_tracklists.py` (3 passed)
- `git diff --check`

Fixes #770