### PR TITLE
Refresh release editorial summaries

### DIFF
--- a/.github/agents/sundown-content-editor.agent.md
+++ b/.github/agents/sundown-content-editor.agent.md
@@ -19,6 +19,21 @@ Deliver high-quality content updates across `src/content/`, preserving repositor
 - Keep edits tightly scoped to the requested content task.
 - Write all new human-facing text in British English.
 
+## Release Editorial Style
+
+Treat the `## About` section of a release page as editorial copy, not a
+restatement of its front matter.
+
+- Lead with why the release matters, what makes it distinctive, or the most
+  useful route into it.
+- Use a warm, knowledgeable, independent voice and keep the summary concise.
+- Add verified creative context only where it helps explain the release's
+  sound, significance, reception, or place in the artist's wider story.
+- Do not open with the release date, label, format, track count, duration, or
+  an encyclopaedic definition such as “X is the nth album by Y”.
+- Do not invent context or copy third-party descriptions. Leave an explicit
+  editorial-review note when reliable context is unavailable.
+
 ## Do Not Use When
 
 - The task is primarily a .NET implementation, refactor, or test-fix activity in `automation/dotnet/`.

--- a/scripts/generate-missing-release-pages.ps1
+++ b/scripts/generate-missing-release-pages.ps1
@@ -475,8 +475,28 @@ function New-ReleasePageContent {
         $trackText = " Featured tracks include " + (($trackNames | Select-Object -First 3) -join ", ") + "."
     }
 
-    $dateText = if ($releaseDate) { " released in $releaseDate" } else { "" }
-    [void]$builder.AppendLine(("{0} is a release by {1}{2}. It has been featured on {3} Sundown Sessions show{4}.{5}" -f $Candidate.Title, $Candidate.Artist, $dateText, $showCount, $(if ($showCount -eq 1) { "" } else { "s" }), $trackText))
+    if ($trackNames.Count -eq 1) {
+        [void]$builder.AppendLine(("*{0}* earns its place in the Sundown Sessions catalogue through “{1}”, a selection that offers a direct route into {2}'s work." -f $Candidate.Title, $trackNames[0], $Candidate.Artist))
+        [void]$builder.AppendLine()
+        [void]$builder.AppendLine(("Heard in the context of the full release, “{0}” is an invitation to explore beyond the track featured on the show." -f $trackNames[0]))
+    }
+    elseif ($trackNames.Count -gt 1) {
+        $quotedTracks = @($trackNames | Select-Object -First 3 | ForEach-Object { "“$_”" })
+        $selection = if ($quotedTracks.Count -eq 2) {
+            $quotedTracks -join " and "
+        }
+        else {
+            (($quotedTracks[0..($quotedTracks.Count - 2)] -join ", ") + " and " + $quotedTracks[-1])
+        }
+        [void]$builder.AppendLine(("*{0}* has supplied Sundown Sessions with {1}, giving more than one way into {2}'s work." -f $Candidate.Title, $selection, $Candidate.Artist))
+        [void]$builder.AppendLine()
+        [void]$builder.AppendLine("Together, those choices point beyond isolated favourites towards the character of the wider release.")
+    }
+    else {
+        [void]$builder.AppendLine(("*{0}* offers a further route into {1}'s catalogue and the wider story told across their recordings." -f $Candidate.Title, $Candidate.Artist))
+        [void]$builder.AppendLine()
+        [void]$builder.AppendLine("This summary is intentionally provisional: add verified creative context before publishing the release page.")
+    }
     [void]$builder.AppendLine()
 
     if (-not ($Metadata -and $Metadata.Tracks.Count -gt 0) -and $trackNames.Count -gt 0) {

--- a/src/content/releases/1/10000-maniacs/in-my-tribe/index.md
+++ b/src/content/releases/1/10000-maniacs/in-my-tribe/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1987 XE"
 ---
 ## About
 
-In My Tribe is the third studio album by Jamestown, New York alternative rock band 10,000 Maniacs, released on Elektra Records in 1987. Produced by Peter Asher, it was the band's commercial breakthrough, featuring Natalie Merchant's charismatic vocals and the band's thoughtful, acoustic-influenced jangle pop. The album includes covers of Cat Stevens' 'Peace Train' and an original version of 'Like the Weather'.
+Produced by Peter Asher, *In My Tribe* was the band's commercial breakthrough, featuring Natalie Merchant's charismatic vocals and the band's thoughtful, acoustic-influenced jangle pop.
+
+The album includes covers of Cat Stevens' 'Peace Train' and an original version of 'Like the Weather'.

--- a/src/content/releases/a/a-house/call-me-blue/index.md
+++ b/src/content/releases/a/a-house/call-me-blue/index.md
@@ -25,4 +25,6 @@ tracklist_edition: "1989 GB"
 ---
 ## About
 
-Call Me Blue is a studio album by Irish indie rock band A House, released independently in 2020 as a comeback project. A House were an important act on the late-1980s and early-1990s UK and Irish indie scene, known for their melodic guitar pop and dry wit. Call Me Blue marked their return to recording after a long hiatus.
+Call Me Blue marked their return to recording after a long hiatus.
+
+A House were an important act on the late-1980s and early-1990s UK and Irish indie scene, known for their melodic guitar pop and dry wit.

--- a/src/content/releases/a/a-projection/in-a-different-light/index.md
+++ b/src/content/releases/a/a-projection/in-a-different-light/index.md
@@ -49,4 +49,4 @@ tracklist_edition: "2022-11-18 SE"
 ---
 ## About
 
-In A Different Light is a studio album by Edinburgh post-punk band A Projection, released in 2022. The band draw on the influence of Joy Division, The Chameleons, and early Factory Records bands to create a brooding, atmospheric sound characterised by dark guitar lines and intense, searching vocals.
+The band draw on the influence of Joy Division, The Chameleons, and early Factory Records bands to create a brooding, atmospheric sound characterised by dark guitar lines and intense, searching vocals.

--- a/src/content/releases/a/a/nothing/index.md
+++ b/src/content/releases/a/a/nothing/index.md
@@ -22,4 +22,4 @@ tracklist_edition: "2002 GB"
 ---
 ## About
 
-Nothing is the second studio album by British pop punk band A, released on London Records in 2002. The band from High Wycombe built a devoted following on the UK rock circuit during the early 2000s with their energetic, hook-driven songs.
+The band from High Wycombe built a devoted following on the UK rock circuit during the early 2000s with their energetic, hook-driven songs.

--- a/src/content/releases/a/acdc/back-in-black/index.md
+++ b/src/content/releases/a/acdc/back-in-black/index.md
@@ -19,4 +19,6 @@ tracklist_edition: "1980 PT"
 ---
 ## About
 
-Back in Black is the seventh studio album by Australian hard rock band AC/DC, released in 1980. It topped the UK Albums Chart and is the second best-selling album in music history, selling an estimated 50 million copies worldwide. Recorded as a tribute to former vocalist Bon Scott, who died in February 1980, the album introduced Brian Johnson and is regarded as one of the defining records of hard rock.
+Recorded as a tribute to former vocalist Bon Scott, who died in February 1980, *Back in Black* introduced Brian Johnson and is regarded as one of the defining records of hard rock.
+
+It topped the UK Albums Chart and is the second best-selling album in music history, selling an estimated 50 million copies worldwide.

--- a/src/content/releases/a/acdc/high-voltage/index.md
+++ b/src/content/releases/a/acdc/high-voltage/index.md
@@ -42,4 +42,6 @@ tracklist_edition: "1976 PT"
 ---
 ## About
 
-High Voltage is the second studio album by Australian hard rock band AC/DC, released internationally on EMI Records in 1976. The album draws together tracks from the band's first two Australian studio albums, Highway to Hell predecessor T.N.T. and their self-titled debut. It marked their introduction to European audiences and established the blueprint for their thunderous, riff-driven hard rock.
+*High Voltage* marked their introduction to European audiences and established the blueprint for their thunderous, riff-driven hard rock.
+
+The album draws together tracks from the band's first two Australian studio albums, Highway to Hell predecessor T.N.T. and their self-titled debut.

--- a/src/content/releases/a/adam-and-the-ants/john-peel-session/index.md
+++ b/src/content/releases/a/adam-and-the-ants/john-peel-session/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-John Peel Session is a release by Adam & The Ants released in 1979. It has been featured on 1 Sundown Sessions show. Featured tracks include Ligotage.
+*John Peel Session* earns its place in the Sundown Sessions catalogue through “Ligotage”, a selection that offers a direct route into Adam & The Ants's work.
+
+Heard in the context of the full release, “Ligotage” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Ligotage
-
-

--- a/src/content/releases/a/adam-ant/vive-le-rock/index.md
+++ b/src/content/releases/a/adam-ant/vive-le-rock/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "1985 GB"
 ---
 ## About
 
-Vive Le Rock is a release by Adam Ant released in 1985-09-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Miss Thing.
+*Vive Le Rock* earns its place in the Sundown Sessions catalogue through “Miss Thing”, a selection that offers a direct route into Adam Ant's work.
 
-
+Heard in the context of the full release, “Miss Thing” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/a/adam-the-ants/dirk-wears-white-sox/index.md
+++ b/src/content/releases/a/adam-the-ants/dirk-wears-white-sox/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1979-11-30 GB"
 ---
 ## About
 
-Dirk Wears White Sox is the debut studio album by London post-punk band Adam & the Ants, released on Do It Records in 1979. It reached number two on the UK Albums Chart on its 2004 remaster release and is an influential document of the UK post-punk scene, predating the band's subsequent commercial breakthrough with the tribal pop of Kings of the Wild Frontier. The album showcases a rawer, darker side of Adam Ant's songwriting.
+*Dirk Wears White Sox* reached number two on the UK Albums Chart on its 2004 remaster release and is an influential document of the UK post-punk scene, predating the band's subsequent commercial breakthrough with the tribal pop of Kings of the Wild Frontier.
+
+The album showcases a rawer, darker side of Adam Ant's songwriting.

--- a/src/content/releases/a/aimee-mann/im-with-stupid/index.md
+++ b/src/content/releases/a/aimee-mann/im-with-stupid/index.md
@@ -52,10 +52,10 @@ tracklist_edition: "1995 US Columbia House club edition"
 ---
 ## About
 
-I'm With Stupid is a release by Aimee Mann released in 1995. It has been featured on 1 Sundown Sessions show. Featured tracks include Sugarcoated.
+*I'm With Stupid* earns its place in the Sundown Sessions catalogue through “Sugarcoated”, a selection that offers a direct route into Aimee Mann's work.
+
+Heard in the context of the full release, “Sugarcoated” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Sugarcoated
-
-

--- a/src/content/releases/a/aimee-mann/whatever/index.md
+++ b/src/content/releases/a/aimee-mann/whatever/index.md
@@ -52,4 +52,6 @@ tracklist_edition: "1993 GB"
 ---
 ## About
 
-Whatever is the debut solo studio album by American singer-songwriter Aimee Mann, released on Imago Records in 1993. Produced by Jon Brion and Brad Jones, it established Mann's distinctive gift for melancholy, richly crafted pop songs infused with literate, emotionally frank lyrics. The album was well received critically and helped establish her reputation as one of the most gifted songwriters of her generation.
+Produced by Jon Brion and Brad Jones, *Whatever* established Mann's distinctive gift for melancholy, richly crafted pop songs infused with literate, emotionally frank lyrics.
+
+The album was well received critically and helped establish her reputation as one of the most gifted songwriters of her generation.

--- a/src/content/releases/a/air-traffic/fractured-life/index.md
+++ b/src/content/releases/a/air-traffic/fractured-life/index.md
@@ -61,6 +61,6 @@ tracklist_edition: "2007-07-02 XE"
 ---
 ## About
 
-Fractured Life is a release by Air Traffic released in 2007-07-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Shooting Star.
+*Fractured Life* earns its place in the Sundown Sessions catalogue through “Shooting Star”, a selection that offers a direct route into Air Traffic's work.
 
-
+Heard in the context of the full release, “Shooting Star” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/a/air/moon-safari/index.md
+++ b/src/content/releases/a/air/moon-safari/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1998 US"
 ---
 ## About
 
-Moon Safari is the debut studio album by French electronic duo Air (Nicolas Godin and Jean-Benoît Dunckel), released on Virgin Records in 1998. It reached number six on the UK Albums Chart and became one of the defining records of late-1990s French electronica. The album's lush, lounge-influenced production created a dreamy, cinematic atmosphere that resonated with a wide international audience.
+*Moon Safari* reached number six on the UK Albums Chart and became one of the defining records of late-1990s French electronica.
+
+The album's lush, lounge-influenced production created a dreamy, cinematic atmosphere that resonated with a wide international audience.

--- a/src/content/releases/a/alice-cooper/billion-dollar-babies/index.md
+++ b/src/content/releases/a/alice-cooper/billion-dollar-babies/index.md
@@ -26,6 +26,6 @@ tracklist_edition: "1973 DE"
 ---
 ## About
 
-Billion Dollar Babies is a release by Alice Cooper released in 1973. It has been featured on 1 Sundown Sessions show. Featured tracks include No More Mr. Nice Guy.
+*Billion Dollar Babies* earns its place in the Sundown Sessions catalogue through “No More Mr. Nice Guy”, a selection that offers a direct route into Alice Cooper's work.
 
-
+Heard in the context of the full release, “No More Mr. Nice Guy” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/a/alphabeat/fantastic-six/index.md
+++ b/src/content/releases/a/alphabeat/fantastic-six/index.md
@@ -28,10 +28,10 @@ tracklist_edition: "2007-11-26 GB"
 ---
 ## About
 
-Fantastic Six is a release by Alphabeat released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include Fantastic Six.
+*Fantastic Six* earns its place in the Sundown Sessions catalogue through “Fantastic Six”, a selection that offers a direct route into Alphabeat's work.
+
+Heard in the context of the full release, “Fantastic Six” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Fantastic Six
-
-

--- a/src/content/releases/a/altered-images/happy-birthday/index.md
+++ b/src/content/releases/a/altered-images/happy-birthday/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "1981 GB"
 ---
 ## About
 
-Happy Birthday is the debut studio album by Glasgow post-punk band Altered Images, released on Epic Records in 1981. It reached number 26 on the UK Albums Chart and announced the band as one of the most distinctive acts of the early post-punk era, fronted by Clare Grogan's playful yet idiosyncratic vocal style. The album was produced by Steve Severin of Siouxsie and the Banshees.
+*Happy Birthday* reached number 26 on the UK Albums Chart and announced the band as one of the most distinctive acts of the early post-punk era, fronted by Clare Grogan's playful yet idiosyncratic vocal style.
+
+The album was produced by Steve Severin of Siouxsie and the Banshees.

--- a/src/content/releases/a/angelfish/angelfish/index.md
+++ b/src/content/releases/a/angelfish/angelfish/index.md
@@ -56,6 +56,6 @@ tracklist_edition: "1993 DE"
 ---
 ## About
 
-Angelfish is a release by Angelfish released in 1993. It has been featured on 2 Sundown Sessions shows. Featured tracks include Mummy Can't Drive, Suffocate Me.
+*Angelfish* has supplied Sundown Sessions with “Mummy Can't Drive” and “Suffocate Me”, giving more than one way into Angelfish's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/a/aphex-twin/selected-ambient-works-85-92/index.md
+++ b/src/content/releases/a/aphex-twin/selected-ambient-works-85-92/index.md
@@ -65,4 +65,6 @@ tracklist_edition: "1992 BE"
 ---
 ## About
 
-Selected Ambient Works 85-92 is the debut studio album by Cornish electronic music artist Aphex Twin (Richard D. James), released on Apollo Records in 1992. It is one of the most celebrated electronic albums ever recorded, presenting a collection of melodic, beat-driven compositions that blend ambient music, techno, and acid house. The album established Aphex Twin as one of the most creative and idiosyncratic figures in electronic music.
+*Selected Ambient Works 85-92* established Aphex Twin as one of the most creative and idiosyncratic figures in electronic music.
+
+It is one of the most celebrated electronic albums ever recorded, presenting a collection of melodic, beat-driven compositions that blend ambient music, techno, and acid house.

--- a/src/content/releases/a/associates/sulk/index.md
+++ b/src/content/releases/a/associates/sulk/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1982 DE"
 ---
 ## About
 
-Sulk is the second studio album by Dundee art-pop duo Associates, released in 1982. It reached number 10 on the UK Albums Chart and is widely considered their masterpiece, showcasing Billy Mackenzie's extraordinary five-octave vocal range alongside Alan Rankine's inventive production. The album includes the singles 'Party Fears Two' and '18 Carat Love Affair'.
+*Sulk* includes the singles 'Party Fears Two' and '18 Carat Love Affair'.
+
+It reached number 10 on the UK Albums Chart and is widely considered their masterpiece, showcasing Billy Mackenzie's extraordinary five-octave vocal range alongside Alan Rankine's inventive production.

--- a/src/content/releases/a/attic-lights/friday-night-lights/index.md
+++ b/src/content/releases/a/attic-lights/friday-night-lights/index.md
@@ -48,6 +48,6 @@ tracklist_edition: "2008-10-13 GB"
 ---
 ## About
 
-Friday Night Lights is a release by Attic Lights released in 2008-10-13. It has been featured on 1 Sundown Sessions show. Featured tracks include The Dirty Thirst.
+*Friday Night Lights* earns its place in the Sundown Sessions catalogue through “The Dirty Thirst”, a selection that offers a direct route into Attic Lights's work.
 
-
+Heard in the context of the full release, “The Dirty Thirst” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/a/autechre/incunabula/index.md
+++ b/src/content/releases/a/autechre/incunabula/index.md
@@ -57,4 +57,6 @@ tracklist_edition: "1993 GB Reversed cover"
 ---
 ## About
 
-Incunabula is the debut studio album by Manchester electronic music duo Autechre (Rob Brown and Sean Booth), released on Warp Records in 1993. The album is a founding document of intelligent dance music (IDM), blending ambient textures with intricate drum programming. It established Autechre as one of the most inventive and uncompromising electronic music acts of their generation.
+*Incunabula* established Autechre as one of the most inventive and uncompromising electronic music acts of their generation.
+
+The album is a founding document of intelligent dance music (IDM), blending ambient textures with intricate drum programming.

--- a/src/content/releases/a/aztec-camera/high-land-hard-rain/index.md
+++ b/src/content/releases/a/aztec-camera/high-land-hard-rain/index.md
@@ -45,4 +45,4 @@ tracklist_edition: "1983 ES"
 ---
 ## About
 
-High Land, Hard Rain is the debut studio album by Glaswegian indie pop songwriter Roddy Frame, recording as Aztec Camera, released on Rough Trade Records in 1983. It reached number 22 on the UK Albums Chart and announced Frame as one of the most gifted lyricists and guitarists of his generation, blending folk, jazz, and new wave influences into a series of emotionally acute songs.
+*High Land, Hard Rain* reached number 22 on the UK Albums Chart and announced Frame as one of the most gifted lyricists and guitarists of his generation, blending folk, jazz, and new wave influences into a series of emotionally acute songs.

--- a/src/content/releases/a/aztec-camera/knife/index.md
+++ b/src/content/releases/a/aztec-camera/knife/index.md
@@ -38,4 +38,6 @@ tracklist_edition: "1984 DE \"target\" disc, made in West Germany"
 ---
 ## About
 
-Knife is the second studio album by Aztec Camera, Roddy Frame's songwriting vehicle, released on WEA Records in 1984. It reached number 14 on the UK Albums Chart and was produced by Mark Knopfler of Dire Straits. The album finds Frame moving towards a more polished, MOR-influenced sound while retaining the melodic sophistication of his debut High Land, Hard Rain.
+*Knife* finds Frame moving towards a more polished, MOR-influenced sound while retaining the melodic sophistication of his debut High Land, Hard Rain.
+
+It reached number 14 on the UK Albums Chart and was produced by Mark Knopfler of Dire Straits.

--- a/src/content/releases/a/aztec-camera/love/index.md
+++ b/src/content/releases/a/aztec-camera/love/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-Love is the third studio album by Aztec Camera, released on WEA Records in 1987. It reached number 10 on the UK Albums Chart and saw Roddy Frame pursue a more polished, orchestrated, and commercial sound. The album features lush string arrangements and showcases Frame's gift for melody on tracks such as 'Deep and Wide and Tall'.
+*Love* features lush string arrangements and showcases Frame's gift for melody on tracks such as 'Deep and Wide and Tall'.
+
+It reached number 10 on the UK Albums Chart and saw Roddy Frame pursue a more polished, orchestrated, and commercial sound.

--- a/src/content/releases/b/bad-company/bad-company/index.md
+++ b/src/content/releases/b/bad-company/bad-company/index.md
@@ -38,4 +38,4 @@ tracklist_edition: "1974 GB"
 ---
 ## About
 
-Bad Company is the self-titled debut studio album by the British hard rock supergroup Bad Company, released on Island Records in 1974. It reached number three on the UK Albums Chart and includes the classic tracks 'Can't Get Enough' and the title track, establishing the band as one of the dominant rock acts of the mid-1970s on both sides of the Atlantic.
+*Bad Company* reached number three on the UK Albums Chart and includes the classic tracks 'Can't Get Enough' and the title track, establishing the band as one of the dominant rock acts of the mid-1970s on both sides of the Atlantic.

--- a/src/content/releases/b/bad-manners/ska-n-b/index.md
+++ b/src/content/releases/b/bad-manners/ska-n-b/index.md
@@ -49,10 +49,10 @@ tracklist_edition: "1980-04 GB"
 ---
 ## About
 
-Ska 'N' B is a release by Bad Manners released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include Ne-Ne, Na-Na, Na-Na, Nu-Nu.
+*Ska 'N' B* has supplied Sundown Sessions with “Ne-Ne”, “Na-Na”, “Na-Na” and “Nu-Nu”, giving more than one way into Bad Manners's work.
+
+Together, those choices point beyond isolated favourites towards the character of the wider release.
 
 ## Tracks Featured on Sundown Sessions
 
 - Ne-Ne, Na-Na, Na-Na, Nu-Nu
-
-

--- a/src/content/releases/b/balaam-and-the-angel/forces-of-evil-ep/index.md
+++ b/src/content/releases/b/balaam-and-the-angel/forces-of-evil-ep/index.md
@@ -25,10 +25,10 @@ tracklist_edition: "2024-10-25 GB"
 ---
 ## About
 
-Forces of Evil EP is a release by Balaam And The Angel released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Forces of Evil.
+*Forces of Evil EP* earns its place in the Sundown Sessions catalogue through “Forces of Evil”, a selection that offers a direct route into Balaam And The Angel's work.
+
+Heard in the context of the full release, “Forces of Evil” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Forces of Evil
-
-

--- a/src/content/releases/b/balaam-and-the-angel/live-free-or-die/index.md
+++ b/src/content/releases/b/balaam-and-the-angel/live-free-or-die/index.md
@@ -62,6 +62,6 @@ tracklist_edition: "1988 US"
 ---
 ## About
 
-Live Free Or Die is a release by Balaam And The Angel released in 1988. It has been featured on 2 Sundown Sessions shows. Featured tracks include I Feel Love, I'll Show You Something Special.
+*Live Free Or Die* has supplied Sundown Sessions with “I Feel Love” and “I'll Show You Something Special”, giving more than one way into Balaam And The Angel's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/b/balaam-and-the-angel/the-greatest-story-ever-told/index.md
+++ b/src/content/releases/b/balaam-and-the-angel/the-greatest-story-ever-told/index.md
@@ -58,6 +58,6 @@ tracklist_edition: "1986 GB"
 ---
 ## About
 
-The Greatest Story Ever Told is a release by Balaam And The Angel released in 1986. It has been featured on 1 Sundown Sessions show. Featured tracks include The Wave.
+*The Greatest Story Ever Told* earns its place in the Sundown Sessions catalogue through “The Wave”, a selection that offers a direct route into Balaam And The Angel's work.
 
-
+Heard in the context of the full release, “The Wave” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/b/bauhaus/go-away-white/index.md
+++ b/src/content/releases/b/bauhaus/go-away-white/index.md
@@ -58,6 +58,6 @@ tracklist_edition: "2008 None"
 ---
 ## About
 
-Go Away White is a release by Bauhaus released in 2008-03-03. It has been featured on 2 Sundown Sessions shows. Featured tracks include International Bullet Proof Talent, Too Much 21st Century.
+*Go Away White* has supplied Sundown Sessions with “International Bullet Proof Talent” and “Too Much 21st Century”, giving more than one way into Bauhaus's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/b/bauhaus/in-the-flat-field/index.md
+++ b/src/content/releases/b/bauhaus/in-the-flat-field/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1980 CA"
 ---
 ## About
 
-In the Flat Field is the debut studio album by Northampton gothic rock band Bauhaus, released on 4AD in 1980. It reached number 72 on the UK Albums Chart and is regarded as a foundational document of gothic rock, combining Daniel Ash's angular guitar work with Peter Murphy's dramatic vocals and a dark, cavernous production aesthetic. The album established Bauhaus as one of the most important British post-punk bands.
+*In the Flat Field* established Bauhaus as one of the most important British post-punk bands.
+
+It reached number 72 on the UK Albums Chart and is regarded as a foundational document of gothic rock, combining Daniel Ash's angular guitar work with Peter Murphy's dramatic vocals and a dark, cavernous production aesthetic.

--- a/src/content/releases/b/bauhaus/the-skys-gone-out/index.md
+++ b/src/content/releases/b/bauhaus/the-skys-gone-out/index.md
@@ -51,4 +51,6 @@ tracklist_edition: "1982 GB"
 ---
 ## About
 
-The Sky's Gone Out is the third studio album by gothic rock pioneers Bauhaus, released on Beggars Banquet in 1982. It reached number four on the UK Albums Chart and is regarded as a landmark record in the development of gothic rock. The album includes their acclaimed cover of David Bowie's 'Ziggy Stardust', which was released as a single and reached number 15 in the UK.
+*The Sky's Gone Out* reached number four on the UK Albums Chart and is regarded as a landmark record in the development of gothic rock.
+
+The album includes their acclaimed cover of David Bowie's 'Ziggy Stardust', which was released as a single and reached number 15 in the UK.

--- a/src/content/releases/b/beats-international/let-them-eat-bingo/index.md
+++ b/src/content/releases/b/beats-international/let-them-eat-bingo/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1990 FR"
 ---
 ## About
 
-Let Them Eat Bingo is the debut studio album by Brighton dance-pop act Beats International, Norman Cook's project before he became Fatboy Slim, released on Go! Discs in 1990. It topped the UK Albums Chart, driven by the international number-one hit 'Dub Be Good to Me'. The album blends hip-hop, house, and pop in an irresistible mix that made Cook one of the hottest producers in Britain.
+*Let Them Eat Bingo* blends hip-hop, house, and pop in an irresistible mix that made Cook one of the hottest producers in Britain.
+
+It topped the UK Albums Chart, driven by the international number-one hit 'Dub Be Good to Me'.

--- a/src/content/releases/b/becky-becky/art-school-dancing/index.md
+++ b/src/content/releases/b/becky-becky/art-school-dancing/index.md
@@ -29,11 +29,12 @@ tracks:
 ---
 ## About
 
-Art School Dancing is a release by Becky Becky released in 2015. It has been featured on 3 Sundown Sessions shows. Featured tracks include Champagne on Christmas Day, House of the Black Madonna (live), Sparrow.
+*Art School Dancing* has supplied Sundown Sessions with “Champagne on Christmas Day”, “House of the Black Madonna (live)” and “Sparrow”, giving more than one way into Becky Becky's work.
+
+Together, those choices point beyond isolated favourites towards the character of the wider release.
 
 ## Tracks Featured on Sundown Sessions
 
 - Champagne on Christmas Day
 - House of the Black Madonna (live)
 - Sparrow
-

--- a/src/content/releases/b/becky-becky/good-morning-midnight/index.md
+++ b/src/content/releases/b/becky-becky/good-morning-midnight/index.md
@@ -50,6 +50,6 @@ tracklist_edition: "2014-05-01 XW"
 ---
 ## About
 
-Good Morning, Midnight is a release by Becky Becky released in 2014-05-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Tigers Are Better-Looking.
+*Good Morning, Midnight* earns its place in the Sundown Sessions catalogue through “Tigers Are Better-Looking”, a selection that offers a direct route into Becky Becky's work.
 
-
+Heard in the context of the full release, “Tigers Are Better-Looking” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/b/big-brother-and-the-holding-company/cheap-thrills/index.md
+++ b/src/content/releases/b/big-brother-and-the-holding-company/cheap-thrills/index.md
@@ -34,4 +34,6 @@ tracklist_edition: "1968 US mono"
 ---
 ## About
 
-Cheap Thrills is the second studio album by San Francisco psychedelic rock band Big Brother and the Holding Company, released on Columbia Records in 1968. It is best known as the vehicle that introduced Janis Joplin to a mass audience, featuring her ferocious, emotionally uninhibited vocal performances on 'Piece of My Heart' and 'Ball and Chain'. The album topped the US charts for eight weeks.
+*Cheap Thrills* is best known as the vehicle that introduced Janis Joplin to a mass audience, featuring her ferocious, emotionally uninhibited vocal performances on 'Piece of My Heart' and 'Ball and Chain'.
+
+The album topped the US charts for eight weeks.

--- a/src/content/releases/b/big-country/the-crossing/index.md
+++ b/src/content/releases/b/big-country/the-crossing/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1983 DE Made in Germany, without PG 900"
 ---
 ## About
 
-The Crossing is a release by Big Country released in 1983-07-19. It has been featured on 1 Sundown Sessions show. Featured tracks include The Storm.
+*The Crossing* earns its place in the Sundown Sessions catalogue through “The Storm”, a selection that offers a direct route into Big Country's work.
 
-
+Heard in the context of the full release, “The Storm” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/b/big-country/why-the-long-face/index.md
+++ b/src/content/releases/b/big-country/why-the-long-face/index.md
@@ -61,4 +61,4 @@ tracklist_edition: "1995 US"
 ---
 ## About
 
-Why the Long Face is a studio album by Scottish rock band Big Country, released on Cooking Vinyl in 1995. The album was recorded during a period of transition for the band and features their signature blend of anthemic guitar rock, characterised by Stuart Adamson's use of guitar to create a sound reminiscent of bagpipes.
+*Why the Long Face* was recorded during a period of transition for the band and features their signature blend of anthemic guitar rock, characterised by Stuart Adamson's use of guitar to create a sound reminiscent of bagpipes.

--- a/src/content/releases/b/billie-eilish/no-time-to-die/index.md
+++ b/src/content/releases/b/billie-eilish/no-time-to-die/index.md
@@ -28,6 +28,6 @@ tracklist_edition: "2020-02-13 XW 24-Bit 44.1 kHz"
 ---
 ## About
 
-No Time To Die is a release by Billie Eilish released in 2020-02-13. It has been featured on 1 Sundown Sessions show. Featured tracks include No Time To Die.
+*No Time To Die* earns its place in the Sundown Sessions catalogue through “No Time To Die”, a selection that offers a direct route into Billie Eilish's work.
 
-
+Heard in the context of the full release, “No Time To Die” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/b/billy-bragg/brewing-up-with-billy-bragg/index.md
+++ b/src/content/releases/b/billy-bragg/brewing-up-with-billy-bragg/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1984 GB"
 ---
 ## About
 
-Brewing Up with Billy Bragg is the second studio album by Barking singer-songwriter Billy Bragg, released on Go! Discs in 1984. It reached number 16 on the UK Albums Chart and built on the stark, solo electric guitar and vocal sound of his debut Life's a Riot with Spy vs Spy. The album confirms Bragg's status as one of the most compelling and politically engaged songwriters of the 1980s.
+*Brewing Up with Billy Bragg* confirms Bragg's status as one of the most compelling and politically engaged songwriters of the 1980s.
+
+It reached number 16 on the UK Albums Chart and built on the stark, solo electric guitar and vocal sound of his debut Life's a Riot with Spy vs Spy.

--- a/src/content/releases/b/billy-mackenzie/transmission-impossible/index.md
+++ b/src/content/releases/b/billy-mackenzie/transmission-impossible/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "2004 GB"
 ---
 ## About
 
-Transmission Impossible is a release by Billy Mackenzie released in 2004. It has been featured on 1 Sundown Sessions show. Featured tracks include Never Turn Your Back On Mother Earth.
+*Transmission Impossible* earns its place in the Sundown Sessions catalogue through “Never Turn Your Back On Mother Earth”, a selection that offers a direct route into Billy Mackenzie's work.
 
-
+Heard in the context of the full release, “Never Turn Your Back On Mother Earth” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/b/bjork/debut/index.md
+++ b/src/content/releases/b/bjork/debut/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1993 GB limited edition"
 ---
 ## About
 
-Debut is the first solo studio album by Icelandic singer Björk, released on One Little Indian Records in 1993. It reached number three on the UK Albums Chart and established her as one of the most inventive and distinctive pop artists of her generation. Produced by Nellee Hooper, the album blends house, jazz, and pop, and features the singles 'Human Behaviour' and 'Venus as a Boy'.
+*Debut* reached number three on the UK Albums Chart and established her as one of the most inventive and distinctive pop artists of her generation.
+
+Produced by Nellee Hooper, the album blends house, jazz, and pop, and features the singles 'Human Behaviour' and 'Venus as a Boy'.

--- a/src/content/releases/b/bjork/post/index.md
+++ b/src/content/releases/b/bjork/post/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1995 ZA"
 ---
 ## About
 
-Post is the second solo studio album by Icelandic singer Björk, released on One Little Indian Records in 1995. It reached number two on the UK Albums Chart and represents the full flowering of her post-Iceland-debut vision, encompassing dance, orchestral pop, industrial music, and intimate folk. Produced with collaborators including Tricky, Howie B, and Nellee Hooper, it includes the UK singles 'Army of Me' and 'Hyperballad'.
+*Post* reached number two on the UK Albums Chart and represents the full flowering of her post-Iceland-debut vision, encompassing dance, orchestral pop, industrial music, and intimate folk.
+
+Produced with collaborators including Tricky, Howie B, and Nellee Hooper, it includes the UK singles 'Army of Me' and 'Hyperballad'.

--- a/src/content/releases/b/black-sabbath/black-sabbath/index.md
+++ b/src/content/releases/b/black-sabbath/black-sabbath/index.md
@@ -35,4 +35,6 @@ tracklist_edition: "1970 DE"
 ---
 ## About
 
-Black Sabbath is the self-titled debut studio album by Birmingham heavy metal band Black Sabbath, released on Vertigo Records in 1970. It reached number eight on the UK Albums Chart and is universally regarded as the founding document of heavy metal music. The title track and 'The Wizard' established the template of doom-laden, distorted guitar riffs and occult imagery that would define the genre.
+*Black Sabbath* reached number eight on the UK Albums Chart and is universally regarded as the founding document of heavy metal music.
+
+The title track and 'The Wizard' established the template of doom-laden, distorted guitar riffs and occult imagery that would define the genre.

--- a/src/content/releases/b/black-sabbath/paranoid/index.md
+++ b/src/content/releases/b/black-sabbath/paranoid/index.md
@@ -20,4 +20,6 @@ tracklist_edition: "1970 GB"
 ---
 ## About
 
-Paranoid is the second studio album by Birmingham heavy metal band Black Sabbath, released on Vertigo Records in 1970. It topped the UK Albums Chart and is one of the best-selling heavy metal albums of all time, featuring the iconic title track, 'Iron Man', and 'War Pigs'. The album cemented Black Sabbath's status as the originators of heavy metal and remains one of the most influential records ever made.
+*Paranoid* cemented Black Sabbath's status as the originators of heavy metal and remains one of the most influential records ever made.
+
+It topped the UK Albums Chart and is one of the best-selling heavy metal albums of all time, featuring the iconic title track, 'Iron Man', and 'War Pigs'.

--- a/src/content/releases/b/black/wonderful-life/index.md
+++ b/src/content/releases/b/black/wonderful-life/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1987 US"
 ---
 ## About
 
-Wonderful Life is a release by Black released in 1987-09-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Blue.
+*Wonderful Life* earns its place in the Sundown Sessions catalogue through “Blue”, a selection that offers a direct route into Black's work.
 
-
+Heard in the context of the full release, “Blue” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/b/blodwyn-pig/ahead-rings-out/index.md
+++ b/src/content/releases/b/blodwyn-pig/ahead-rings-out/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1969 US"
 ---
 ## About
 
-Ahead Rings Out is the debut studio album by British blues rock band Blodwyn Pig, released on Chrysalis Records in 1969. It reached number nine on the UK Albums Chart and is a fine document of the British blues boom, featuring guitarist Mick Abrahams, formerly of Jethro Tull. The album blends heavy blues riffs with jazz-influenced improvisations.
+*Ahead Rings Out* blends heavy blues riffs with jazz-influenced improvisations.
+
+It reached number nine on the UK Albums Chart and is a fine document of the British blues boom, featuring guitarist Mick Abrahams, formerly of Jethro Tull.

--- a/src/content/releases/b/blondie/parallel-lines/index.md
+++ b/src/content/releases/b/blondie/parallel-lines/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1978 PT"
 ---
 ## About
 
-Parallel Lines is the third studio album by New York new wave band Blondie, released on Chrysalis Records in 1978. It topped the UK Albums Chart and remains one of the best-selling albums of the era, spawning the global number-one single 'Heart of Glass'. The album perfectly blends punk, pop, and disco influences, and is regarded as a landmark of the new wave genre.
+*Parallel Lines* perfectly blends punk, pop, and disco influences, and is regarded as a landmark of the new wave genre.
+
+It topped the UK Albums Chart and remains one of the best-selling albums of the era, spawning the global number-one single 'Heart of Glass'.

--- a/src/content/releases/b/blue-oyster-cult/agents-of-fortune/index.md
+++ b/src/content/releases/b/blue-oyster-cult/agents-of-fortune/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1976 GB"
 ---
 ## About
 
-Agents of Fortune is the fourth studio album by New York rock band Blue Öyster Cult, released on Columbia Records in 1976. The album includes 'Don't Fear the Reaper', one of the most celebrated rock songs of the decade, and represents the band's commercial peak. The record showcases their eclectic blend of hard rock, progressive rock, and occult imagery.
+*Agents Of Fortune* showcases their eclectic blend of hard rock, progressive rock, and occult imagery.
+
+The album includes 'Don't Fear the Reaper', one of the most celebrated rock songs of the decade, and represents the band's commercial peak.

--- a/src/content/releases/b/buffalo-springfield/buffalo-springfield-again/index.md
+++ b/src/content/releases/b/buffalo-springfield/buffalo-springfield-again/index.md
@@ -43,4 +43,4 @@ tracklist_edition: "1967 US mono, Indianapolis pressing"
 ---
 ## About
 
-Buffalo Springfield Again is the second studio album by Canadian-American folk rock band Buffalo Springfield, released on Atco Records in 1967. It is considered their finest work, showcasing the diverse songwriting talents of Neil Young, Stephen Stills, and Richie Furay across a collection of psychedelic folk rock, country rock, and orchestrated pop.
+*Buffalo Springfield Again* is considered their finest work, showcasing the diverse songwriting talents of Neil Young, Stephen Stills, and Richie Furay across a collection of psychedelic folk rock, country rock, and orchestrated pop.

--- a/src/content/releases/b/buzzcocks/a-different-kind-of-tension/index.md
+++ b/src/content/releases/b/buzzcocks/a-different-kind-of-tension/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1979-09 GB"
 ---
 ## About
 
-A Different Kind of Tension is the third studio album by Manchester punk band Buzzcocks, released on United Artists Records in 1979. It reached number 26 on the UK Albums Chart and represents the band at their most experimental, expanding beyond the buzzsaw punk pop of their earlier work into more melodically and rhythmically complex territory. It was their final studio album until the 1990s.
+*A Different Kind of Tension* was their final studio album until the 1990s.
+
+It reached number 26 on the UK Albums Chart and represents the band at their most experimental, expanding beyond the buzzsaw punk pop of their earlier work into more melodically and rhythmically complex territory.

--- a/src/content/releases/c/cabaret-voltaire/mix-up/index.md
+++ b/src/content/releases/c/cabaret-voltaire/mix-up/index.md
@@ -40,4 +40,6 @@ tracklist_edition: "1979 GB"
 ---
 ## About
 
-Mix-Up is the debut studio album by Sheffield industrial and electronic band Cabaret Voltaire, released on Rough Trade Records in 1979. The album is a landmark of the industrial and post-punk movements, combining tape loops, electronic noise, and found sound with confrontational political and surreal imagery. It had a profound influence on the subsequent development of electronic body music and EBM.
+*Mix-Up* is a landmark of the industrial and post-punk movements, combining tape loops, electronic noise, and found sound with confrontational political and surreal imagery.
+
+It had a profound influence on the subsequent development of electronic body music and EBM.

--- a/src/content/releases/c/cast/all-change/index.md
+++ b/src/content/releases/c/cast/all-change/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1995-10-16 GB"
 ---
 ## About
 
-All Change is the debut studio album by Liverpool indie rock band Cast, released on Polydor Records in 1995. It reached number seven on the UK Albums Chart and marked a confident debut from the band led by former La's bassist John Power. The album blends Merseybeat influences with a modern Britpop sensibility across a set of consistently melodic guitar-pop songs.
+*All Change* blends Merseybeat influences with a modern Britpop sensibility across a set of consistently melodic guitar-pop songs.
+
+It reached number seven on the UK Albums Chart and marked a confident debut from the band led by former La's bassist John Power.

--- a/src/content/releases/c/catatonia/international-velvet/index.md
+++ b/src/content/releases/c/catatonia/international-velvet/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1998 US"
 ---
 ## About
 
-International Velvet is the second studio album by Welsh indie rock band Catatonia, released on Blanco y Negro Records in 1998. It debuted at number one on the UK Albums Chart, becoming one of the best-selling Welsh albums of all time. The album includes the anthemic single 'Mulder and Scully' and the rousing title track, and is widely regarded as a defining record of late-1990s British indie music.
+*International Velvet* includes the anthemic single 'Mulder and Scully' and the rousing title track, and is widely regarded as a defining record of late-1990s British indie music.
+
+It debuted at number one on the UK Albums Chart, becoming one of the best-selling Welsh albums of all time.

--- a/src/content/releases/c/chikinki/brace-brace/index.md
+++ b/src/content/releases/c/chikinki/brace-brace/index.md
@@ -64,4 +64,6 @@ tracklist_edition: "2007-11-23 DE"
 ---
 ## About
 
-*Brace Brace* is an album by Bristol band Chikinki, released by Urban Cow in 2007. “You Said” had appeared as a single in May 2006 before finding a home on the album; Show #2 uses the album relationship while retaining that earlier single context in its track note. The record is a useful route into the band's wiry, rhythm-led alternative rock.
+*Brace Brace* is a useful route into the band's wiry, rhythm-led alternative rock.
+
+“You Said” had appeared as a single in May 2006 before finding a home on the album; Show #2 uses the album relationship while retaining that earlier single context in its track note.

--- a/src/content/releases/c/chris-isaak/chris-isaak/index.md
+++ b/src/content/releases/c/chris-isaak/chris-isaak/index.md
@@ -56,6 +56,6 @@ tracklist_edition: "1986-12 US"
 ---
 ## About
 
-Chris Isaak is a release by Chris Isaak released in 1986-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Heart Full of Soul.
+*Chris Isaak* earns its place in the Sundown Sessions catalogue through “Heart Full of Soul”, a selection that offers a direct route into Chris Isaak's work.
 
-
+Heard in the context of the full release, “Heart Full of Soul” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/c/christina-perri/lovestrong/index.md
+++ b/src/content/releases/c/christina-perri/lovestrong/index.md
@@ -69,6 +69,6 @@ tracklist_edition: "2011 GB"
 ---
 ## About
 
-lovestrong. is a release by Christina Perri released in 2011-01-01. It has been featured on 1 Sundown Sessions show. Featured tracks include jar of hearts.
+*lovestrong.* earns its place in the Sundown Sessions catalogue through “jar of hearts”, a selection that offers a direct route into Christina Perri's work.
 
-
+Heard in the context of the full release, “jar of hearts” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/c/cigarettes-after-sex/k/index.md
+++ b/src/content/releases/c/cigarettes-after-sex/k/index.md
@@ -26,6 +26,6 @@ tracklist_edition: "2016-11-15 XW"
 ---
 ## About
 
-K. is a release by Cigarettes After Sex released in 2016-11-15. It has been featured on 1 Sundown Sessions show. Featured tracks include K..
+*K.* earns its place in the Sundown Sessions catalogue through “K.”, a selection that offers a direct route into Cigarettes After Sex's work.
 
-
+Heard in the context of the full release, “K.” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/c/clear-light/clear-light/index.md
+++ b/src/content/releases/c/clear-light/clear-light/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1967 US"
 ---
 ## About
 
-Clear Light is the self-titled debut and only studio album by Los Angeles psychedelic rock band Clear Light, released on Elektra Records in 1967. The album features a raw, guitar-driven psychedelic sound, and was produced by Paul Rothchild, who also worked with The Doors. The band were a noteworthy act in the late-1960s LA psychedelic scene.
+*Clear Light* features a raw, guitar-driven psychedelic sound, and was produced by Paul Rothchild, who also worked with The Doors.
+
+The band were a noteworthy act in the late-1960s LA psychedelic scene.

--- a/src/content/releases/c/cocteau-twins/tiny-dynamine/index.md
+++ b/src/content/releases/c/cocteau-twins/tiny-dynamine/index.md
@@ -31,4 +31,4 @@ tracklist_edition: "1985-10-01 XW"
 ---
 ## About
 
-Tiny Dynamine is an EP by Scottish dream pop band Cocteau Twins, released on 4AD in 1985. Alongside its companion release Echoes in a Shallow Bay, it represents the duo at their most ethereal and diaphanous, showcasing Elizabeth Fraser's extraordinary voice alongside Robin Guthrie's shimmering guitar textures.
+Alongside its companion release Echoes in a Shallow Bay, *Tiny Dynamine* represents the duo at their most ethereal and diaphanous, showcasing Elizabeth Fraser's extraordinary voice alongside Robin Guthrie's shimmering guitar textures.

--- a/src/content/releases/c/cosmic-rough-riders/enjoy-the-melodic-sunshine/index.md
+++ b/src/content/releases/c/cosmic-rough-riders/enjoy-the-melodic-sunshine/index.md
@@ -70,6 +70,6 @@ tracklist_edition: "2000 GB"
 ---
 ## About
 
-Enjoy the Melodic Sunshine is a release by Cosmic Rough Riders released in 2000-11-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Revolution (In the Summertime?).
+*Enjoy the Melodic Sunshine* earns its place in the Sundown Sessions catalogue through “Revolution (In the Summertime?)”, a selection that offers a direct route into Cosmic Rough Riders's work.
 
-
+Heard in the context of the full release, “Revolution (In the Summertime?)” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/c/country-joe-and-the-fish/electric-music-for-the-mind-and-body/index.md
+++ b/src/content/releases/c/country-joe-and-the-fish/electric-music-for-the-mind-and-body/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1967-04 US"
 ---
 ## About
 
-Electric Music for the Mind and Body is the debut studio album by Berkeley psychedelic rock band Country Joe and the Fish, released on Vanguard Records in 1967. The album is a landmark of San Francisco psychedelia, blending blues, folk, and experimental music with politically charged lyrics. It captures the spirit of the late-1960s counterculture with remarkable energy and clarity.
+*Electric Music for the Mind and Body* is a landmark of San Francisco psychedelia, blending blues, folk, and experimental music with politically charged lyrics.
+
+It captures the spirit of the late-1960s counterculture with remarkable energy and clarity.

--- a/src/content/releases/c/cousteaux/cousteau/index.md
+++ b/src/content/releases/c/cousteaux/cousteau/index.md
@@ -46,9 +46,10 @@ tracklist_edition: "2000 US"
 ---
 ## About
 
-Cousteau is a release by CousteauX released in 2000. It has been featured on 1 Sundown Sessions show. Featured tracks include Last Good Day Of The Year.
+*Cousteau* earns its place in the Sundown Sessions catalogue through “Last Good Day Of The Year”, a selection that offers a direct route into CousteauX's work.
+
+Heard in the context of the full release, “Last Good Day Of The Year” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Last Good Day Of The Year
-

--- a/src/content/releases/c/cream/disraeli-gears/index.md
+++ b/src/content/releases/c/cream/disraeli-gears/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1967 DE"
 ---
 ## About
 
-Disraeli Gears is the second studio album by British blues rock supergroup Cream, released on Reaction Records in 1967. It reached number five on the UK Albums Chart and includes 'Sunshine of Your Love' and 'Strange Brew', two of the band's most celebrated tracks. The album is a landmark of psychedelic blues rock and showcases the extraordinary interplay between Eric Clapton, Jack Bruce, and Ginger Baker.
+*Disraeli Gears* is a landmark of psychedelic blues rock and showcases the extraordinary interplay between Eric Clapton, Jack Bruce, and Ginger Baker.
+
+It reached number five on the UK Albums Chart and includes 'Sunshine of Your Love' and 'Strange Brew', two of the band's most celebrated tracks.

--- a/src/content/releases/c/creedence-clearwater-revival/cosmos-factory/index.md
+++ b/src/content/releases/c/creedence-clearwater-revival/cosmos-factory/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1970 SE"
 ---
 ## About
 
-Cosmo's Factory is the fifth studio album by Californian rock band Creedence Clearwater Revival, released on Fantasy Records in 1970. It topped the US Billboard 200 and includes some of John Fogerty's most celebrated compositions: 'Up Around the Bend', 'Run Through the Jungle', 'Who'll Stop the Rain', and a 12-minute rendition of 'I Heard It Through the Grapevine'. The album is regarded as the band's artistic peak.
+*Cosmo's Factory* is regarded as the band's artistic peak.
+
+It topped the US Billboard 200 and includes some of John Fogerty's most celebrated compositions: 'Up Around the Bend', 'Run Through the Jungle', 'Who'll Stop the Rain', and a 12-minute rendition of 'I Heard It Through the Grapevine'.

--- a/src/content/releases/c/creedence-clearwater-revival/creedence-clearwater-revival-expanded-edition/index.md
+++ b/src/content/releases/c/creedence-clearwater-revival/creedence-clearwater-revival-expanded-edition/index.md
@@ -49,10 +49,10 @@ tracklist_edition: "2008 XW expanded edition"
 ---
 ## About
 
-Creedence Clearwater Revival (Expanded Edition) is a release by Creedence Clearwater Revival released in 1968. It has been featured on 1 Sundown Sessions show. Featured tracks include I Put A Spell On You.
+*Creedence Clearwater Revival (Expanded Edition)* earns its place in the Sundown Sessions catalogue through “I Put A Spell On You”, a selection that offers a direct route into Creedence Clearwater Revival's work.
+
+Heard in the context of the full release, “I Put A Spell On You” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - I Put A Spell On You
-
-

--- a/src/content/releases/d/dark-hearts/talk-to-me-of-poison/index.md
+++ b/src/content/releases/d/dark-hearts/talk-to-me-of-poison/index.md
@@ -16,9 +16,10 @@ tracks:
 ---
 ## About
 
-Talk to Me of Poison is a release by Dark Hearts released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Talk to Me of Poison.
+*Talk to Me of Poison* earns its place in the Sundown Sessions catalogue through “Talk to Me of Poison”, a selection that offers a direct route into Dark Hearts's work.
+
+Heard in the context of the full release, “Talk to Me of Poison” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Talk to Me of Poison
-

--- a/src/content/releases/d/dave-edmunds/repeat-when-necessary/index.md
+++ b/src/content/releases/d/dave-edmunds/repeat-when-necessary/index.md
@@ -58,6 +58,6 @@ tracklist_edition: "1979 US"
 ---
 ## About
 
-Repeat When Necessary is a release by Dave Edmunds released in 1979-06-08. It has been featured on 2 Sundown Sessions shows. Featured tracks include Crawling From The Wreckage, Girls Talk.
+*Repeat When Necessary* has supplied Sundown Sessions with “Crawling From The Wreckage” and “Girls Talk”, giving more than one way into Dave Edmunds's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/d/dave-gahan/paper-monsters-u-s-version/index.md
+++ b/src/content/releases/d/dave-gahan/paper-monsters-u-s-version/index.md
@@ -81,10 +81,10 @@ tracklist_edition: "2003 US"
 ---
 ## About
 
-Paper Monsters (U.S. Version) is a release by Dave Gahan released in 2003. It has been featured on 1 Sundown Sessions show. Featured tracks include Dirty Sticky Floors.
+*Paper Monsters (U.S. Version)* earns its place in the Sundown Sessions catalogue through “Dirty Sticky Floors”, a selection that offers a direct route into Dave Gahan's work.
+
+Heard in the context of the full release, “Dirty Sticky Floors” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Dirty Sticky Floors
-
-

--- a/src/content/releases/d/david-bowie/aladdin-sane/index.md
+++ b/src/content/releases/d/david-bowie/aladdin-sane/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1973 US"
 ---
 ## About
 
-Aladdin Sane is the sixth studio album by David Bowie, released on RCA Records in 1973. It topped the UK Albums Chart on release and is sometimes described as 'Ziggy goes to America', documenting the band's experiences on their first North American tour. The album features the iconic lightning-bolt cover image and includes 'The Jean Genie' and 'Drive-in Saturday'.
+*Aladdin Sane* features the iconic lightning-bolt cover image and includes 'The Jean Genie' and 'Drive-in Saturday'.
+
+It topped the UK Albums Chart on release and is sometimes described as 'Ziggy goes to America', documenting the band's experiences on their first North American tour.

--- a/src/content/releases/d/david-bowie/best-of-bowie/index.md
+++ b/src/content/releases/d/david-bowie/best-of-bowie/index.md
@@ -70,4 +70,4 @@ tracklist_edition: "2002 IT"
 ---
 ## About
 
-Best of Bowie is a double-disc compilation album covering David Bowie's extensive catalogue from 1969 to 2002, released on EMI Records in 2002. It remains one of the most comprehensive and commercially successful Bowie compilations, serving as an accessible introduction to one of pop music's most enduring and innovative artists.
+*Best of Bowie* remains one of the most comprehensive and commercially successful Bowie compilations, serving as an accessible introduction to one of pop music's most enduring and innovative artists.

--- a/src/content/releases/d/david-bowie/diamond-dogs/index.md
+++ b/src/content/releases/d/david-bowie/diamond-dogs/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1974-05 US"
 ---
 ## About
 
-Diamond Dogs is the eighth studio album by David Bowie, released on RCA Records in 1974. It topped the UK Albums Chart and was inspired by George Orwell's Nineteen Eighty-Four, presenting a dystopian concept album of post-apocalyptic rock. It was the last Bowie album to feature the Spiders from Mars' guitarist Mick Ronson, and includes the title track and 'Rebel Rebel'.
+*Diamond Dogs* was the last Bowie album to feature the Spiders from Mars' guitarist Mick Ronson, and includes the title track and 'Rebel Rebel'.
+
+It topped the UK Albums Chart and was inspired by George Orwell's Nineteen Eighty-Four, presenting a dystopian concept album of post-apocalyptic rock.

--- a/src/content/releases/d/david-bowie/heroes/index.md
+++ b/src/content/releases/d/david-bowie/heroes/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1977 GB"
 ---
 ## About
 
-Heroes is the twelfth studio album by David Bowie, released on RCA Records in 1977. It reached number three on the UK Albums Chart and is the centrepiece of the celebrated 'Berlin Trilogy', recorded at Hansa Studios with Brian Eno and Tony Visconti. The title track is widely regarded as one of the greatest songs ever written, and the album as a whole is a landmark of art rock and ambient music.
+The title track is widely regarded as one of the greatest songs ever written, and the album as a whole is a landmark of art rock and ambient music.
+
+It reached number three on the UK Albums Chart and is the centrepiece of the celebrated 'Berlin Trilogy', recorded at Hansa Studios with Brian Eno and Tony Visconti.

--- a/src/content/releases/d/david-bowie/laughing-with-liza/index.md
+++ b/src/content/releases/d/david-bowie/laughing-with-liza/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "2023-05-05 XW"
 ---
 ## About
 
-Laughing with Liza is a release by David Bowie released in 2023. It has been featured on 1 Sundown Sessions show. Featured tracks include The Laughing Gnome.
+*Laughing with Liza* earns its place in the Sundown Sessions catalogue through “The Laughing Gnome”, a selection that offers a direct route into David Bowie's work.
+
+Heard in the context of the full release, “The Laughing Gnome” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - The Laughing Gnome
-
-

--- a/src/content/releases/d/david-bowie/lets-dance/index.md
+++ b/src/content/releases/d/david-bowie/lets-dance/index.md
@@ -20,4 +20,6 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-Let's Dance is the fifteenth studio album by David Bowie, released on EMI America Records in 1983. It topped the UK Albums Chart and became his best-selling studio album, spawning three international hits: 'Let's Dance', 'China Girl', and 'Modern Love'. Produced by Nile Rodgers, it marked a significant commercial breakthrough and introduced Bowie to a whole new mainstream audience.
+Produced by Nile Rodgers, *Let's Dance* marked a significant commercial breakthrough and introduced Bowie to a whole new mainstream audience.
+
+It topped the UK Albums Chart and became his best-selling studio album, spawning three international hits: 'Let's Dance', 'China Girl', and 'Modern Love'.

--- a/src/content/releases/d/david-bowie/low/index.md
+++ b/src/content/releases/d/david-bowie/low/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1977 JP"
 ---
 ## About
 
-Low is the eleventh studio album by David Bowie, released on RCA Records in 1977. It reached number two on the UK Albums Chart and was the first of the 'Berlin Trilogy', co-produced with Brian Eno and Tony Visconti. Side one features experimental, fragmented pop songs, while side two is dominated by abstract, largely instrumental pieces. The album is regarded as one of the most influential records of the late 20th century.
+*Low* is regarded as one of the most influential records of the late 20th century.
+
+It reached number two on the UK Albums Chart and was the first of the 'Berlin Trilogy', co-produced with Brian Eno and Tony Visconti. Side one features experimental, fragmented pop songs, while side two is dominated by abstract, largely instrumental pieces.

--- a/src/content/releases/d/david-bowie/scary-monsters-and-super-creeps/index.md
+++ b/src/content/releases/d/david-bowie/scary-monsters-and-super-creeps/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1980 ES"
 ---
 ## About
 
-Scary Monsters (and Super Creeps) is the fourteenth studio album by David Bowie, released on RCA Records in 1980. It topped the UK Albums Chart and is widely regarded as the final great statement of his classic period. The album features the UK number-one single 'Ashes to Ashes' and 'Fashion', with a sound shaped by Robert Fripp's abrasive guitar work.
+*Scary Monsters (and Super Creeps)* topped the UK Albums Chart and is widely regarded as the final great statement of his classic period.
+
+The album features the UK number-one single 'Ashes to Ashes' and 'Fashion', with a sound shaped by Robert Fripp's abrasive guitar work.

--- a/src/content/releases/d/david-bowie/station-to-station/index.md
+++ b/src/content/releases/d/david-bowie/station-to-station/index.md
@@ -32,4 +32,6 @@ tracklist_edition: "1976 IT"
 ---
 ## About
 
-Station to Station is the tenth studio album by David Bowie, released on RCA Records in 1976. It reached number five on the UK Albums Chart and introduced the 'Thin White Duke' persona, blending funk, electronic influences, and Bowie's increasingly fragile state of mind into a taut, unsettling masterpiece. It is considered one of the most important albums of his career.
+*Station to Station* reached number five on the UK Albums Chart and introduced the 'Thin White Duke' persona, blending funk, electronic influences, and Bowie's increasingly fragile state of mind into a taut, unsettling masterpiece.
+
+It is considered one of the most important albums of his career.

--- a/src/content/releases/d/david-bowie/the-rise-and-fall-of-ziggy-stardust-and-the-spiders-from-mars/index.md
+++ b/src/content/releases/d/david-bowie/the-rise-and-fall-of-ziggy-stardust-and-the-spiders-from-mars/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1972 GB 7E & 4E runouts"
 ---
 ## About
 
-The Rise and Fall of Ziggy Stardust and the Spiders from Mars is the fifth studio album by David Bowie, released on RCA Records in 1972. It reached number five on the UK Albums Chart and introduced one of rock music's most iconic alter egos: Ziggy Stardust, an androgynous alien rock star. The album is a cornerstone of the glam rock era and one of the most celebrated records in popular music history.
+*The Rise and Fall of Ziggy Stardust and the Spiders from Mars* reached number five on the UK Albums Chart and introduced one of rock music's most iconic alter egos: Ziggy Stardust, an androgynous alien rock star.
+
+The album is a cornerstone of the glam rock era and one of the most celebrated records in popular music history.

--- a/src/content/releases/d/david-bowie/young-americans/index.md
+++ b/src/content/releases/d/david-bowie/young-americans/index.md
@@ -20,4 +20,6 @@ tracklist_edition: "1975 GB"
 ---
 ## About
 
-Young Americans is the ninth studio album by David Bowie, released on RCA Records in 1975. It reached number two on the UK Albums Chart and marked a dramatic stylistic departure into 'plastic soul', recorded in Philadelphia with a host of session musicians including a young Luther Vandross. The album spawned Bowie's first US number-one single with 'Fame', co-written with John Lennon.
+*Young Americans* reached number two on the UK Albums Chart and marked a dramatic stylistic departure into 'plastic soul', recorded in Philadelphia with a host of session musicians including a young Luther Vandross.
+
+The album spawned Bowie's first US number-one single with 'Fame', co-written with John Lennon.

--- a/src/content/releases/d/david-latto/geordie-munro/index.md
+++ b/src/content/releases/d/david-latto/geordie-munro/index.md
@@ -22,7 +22,9 @@ duration: "3:05"
 ---
 ## About
 
-Geordie Munro is a release by David Latto released in 2022. It has been featured on 3 Sundown Sessions shows. Featured tracks include Geordie Munro.
+*Geordie Munro* earns its place in the Sundown Sessions catalogue through “Geordie Munro”, a selection that offers a direct route into David Latto's work.
+
+Heard in the context of the full release, “Geordie Munro” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 

--- a/src/content/releases/d/dean-martin/dino-the-essential-dean-martin/index.md
+++ b/src/content/releases/d/dean-martin/dino-the-essential-dean-martin/index.md
@@ -115,6 +115,6 @@ tracklist_edition: "2004 AU"
 ---
 ## About
 
-Dino: The Essential Dean Martin is a release by Dean Martin released in 2004-01-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Return To Me.
+*Dino: The Essential Dean Martin* earns its place in the Sundown Sessions catalogue through “Return To Me”, a selection that offers a direct route into Dean Martin's work.
 
-
+Heard in the context of the full release, “Return To Me” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/death-cult/ghost-dance/index.md
+++ b/src/content/releases/d/death-cult/ghost-dance/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "1996 US"
 ---
 ## About
 
-Ghost Dance is a release by Death Cult released in 1996. It has been featured on 1 Sundown Sessions show. Featured tracks include A Flower In The Desert.
+*Ghost Dance* earns its place in the Sundown Sessions catalogue through “A Flower In The Desert”, a selection that offers a direct route into Death Cult's work.
 
-
+Heard in the context of the full release, “A Flower In The Desert” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/death-in-vegas/edgar-card-sampler/index.md
+++ b/src/content/releases/d/death-in-vegas/edgar-card-sampler/index.md
@@ -36,6 +36,6 @@ tracklist_edition: "2002-12-18 None"
 ---
 ## About
 
-Edgar Card Sampler is a release by Death In Vegas released in 2002-12-18. It has been featured on 1 Sundown Sessions show. Featured tracks include So You Say You Lost Your Baby.
+*Edgar Card Sampler* earns its place in the Sundown Sessions catalogue through “So You Say You Lost Your Baby”, a selection that offers a direct route into Death In Vegas's work.
 
-
+Heard in the context of the full release, “So You Say You Lost Your Baby” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/deep-purple/deep-purple-in-rock/index.md
+++ b/src/content/releases/d/deep-purple/deep-purple-in-rock/index.md
@@ -35,4 +35,6 @@ tracklist_edition: "1970 JP"
 ---
 ## About
 
-Deep Purple in Rock is the fourth studio album by Hertfordshire hard rock band Deep Purple, released on Harvest Records in 1970. It reached number four on the UK Albums Chart and marks the beginning of the band's classic Mk II era with Ian Gillan and Roger Glover. The album is widely regarded as one of the foundational hard rock albums, featuring the monumental 'Child in Time'.
+*Deep Purple in Rock* is widely regarded as one of the foundational hard rock albums, featuring the monumental 'Child in Time'.
+
+It reached number four on the UK Albums Chart and marks the beginning of the band's classic Mk II era with Ian Gillan and Roger Glover.

--- a/src/content/releases/d/deep-purple/fireball/index.md
+++ b/src/content/releases/d/deep-purple/fireball/index.md
@@ -35,4 +35,6 @@ tracklist_edition: "1971 DK"
 ---
 ## About
 
-Fireball is the fourth studio album by Hertfordshire hard rock band Deep Purple, released on Harvest Records in 1971. It topped the UK Albums Chart, marking the commercial peak of the band's classic Mk II line-up. The album blends heavy, riff-driven rock with jazz-inflected improvisation, featuring some of the most powerful playing of Ian Gillan, Roger Glover, Ritchie Blackmore, Jon Lord, and Ian Paice's career together.
+*Fireball* blends heavy, riff-driven rock with jazz-inflected improvisation, featuring some of the most powerful playing of Ian Gillan, Roger Glover, Ritchie Blackmore, Jon Lord, and Ian Paice's career together.
+
+It topped the UK Albums Chart, marking the commercial peak of the band's classic Mk II line-up.

--- a/src/content/releases/d/def-leppard/pyromania/index.md
+++ b/src/content/releases/d/def-leppard/pyromania/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1983 PT"
 ---
 ## About
 
-Pyromania is the third studio album by Sheffield hard rock band Def Leppard, released on Mercury Records in 1983. It reached number 18 on the UK Albums Chart but became a massive commercial success in the United States, where it spent 92 weeks on the Billboard 200. Produced by Robert John 'Mutt' Lange, the album's polished, anthemic sound defined the template for 1980s hard rock.
+*Pyromania* reached number 18 on the UK Albums Chart but became a massive commercial success in the United States, where it spent 92 weeks on the Billboard 200.
+
+Produced by Robert John 'Mutt' Lange, the album's polished, anthemic sound defined the template for 1980s hard rock.

--- a/src/content/releases/d/del-shannon/handy-man/index.md
+++ b/src/content/releases/d/del-shannon/handy-man/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1964 US"
 ---
 ## About
 
-Handy Man is a studio album by American rock and roll singer Del Shannon, released on Amy Records in 1964. It includes Del Shannon's version of 'Handy Man', originally written by Otis Blackwell and performed by Jimmy Jones, whose version had reached number two on the Billboard Hot 100 in 1960. Shannon's take on the track reached number 22 in the UK Singles Chart.
+Shannon's take on the track reached number 22 in the UK Singles Chart.
+
+It includes Del Shannon's version of 'Handy Man', originally written by Otis Blackwell and performed by Jimmy Jones, whose version had reached number two on the Billboard Hot 100 in 1960.

--- a/src/content/releases/d/del-shannon/rock-on/index.md
+++ b/src/content/releases/d/del-shannon/rock-on/index.md
@@ -55,6 +55,6 @@ tracklist_edition: "1991 DE"
 ---
 ## About
 
-Rock On! is a release by Del Shannon released in 1991. It has been featured on 1 Sundown Sessions show. Featured tracks include Lost In A Memory.
+*Rock On!* earns its place in the Sundown Sessions catalogue through “Lost In A Memory”, a selection that offers a direct route into Del Shannon's work.
 
-
+Heard in the context of the full release, “Lost In A Memory” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/del-shannon/runaway-the-very-best-of-del-shannon/index.md
+++ b/src/content/releases/d/del-shannon/runaway-the-very-best-of-del-shannon/index.md
@@ -108,6 +108,6 @@ tracklist_edition: "2002-01-22 US"
 ---
 ## About
 
-Runaway: The Very Best Of Del Shannon is a release by Del Shannon released in 2002-01-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Runaway.
+*Runaway: The Very Best Of Del Shannon* earns its place in the Sundown Sessions catalogue through “Runaway”, a selection that offers a direct route into Del Shannon's work.
 
-
+Heard in the context of the full release, “Runaway” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/delays/you-see-colours/index.md
+++ b/src/content/releases/d/delays/you-see-colours/index.md
@@ -56,6 +56,6 @@ tracklist_edition: "2006-03-06 GB"
 ---
 ## About
 
-You See Colours is a release by Delays released in 2006-03-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Valentine.
+*You See Colours* earns its place in the Sundown Sessions catalogue through “Valentine”, a selection that offers a direct route into Delays's work.
 
-
+Heard in the context of the full release, “Valentine” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/depeche-mode/speak-and-spell/index.md
+++ b/src/content/releases/d/depeche-mode/speak-and-spell/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1981-10-05 GB"
 ---
 ## About
 
-Speak & Spell is a release by Depeche Mode released in 1981-10-05. It has been featured on 1 Sundown Sessions show. Featured tracks include New Life.
+*Speak & Spell* earns its place in the Sundown Sessions catalogue through “New Life”, a selection that offers a direct route into Depeche Mode's work.
 
-
+Heard in the context of the full release, “New Life” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/dexys-midnight-runners/too-rye-ay/index.md
+++ b/src/content/releases/d/dexys-midnight-runners/too-rye-ay/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1982 NL"
 ---
 ## About
 
-Too-Rye-Ay is the second studio album by Birmingham soul pop group Dexys Midnight Runners, released on Mercury Records in 1982. It reached number two on the UK Albums Chart and included the worldwide number-one hit 'Come On Eileen'. The album showcased the band's new Celtic soul sound, combining fiddles, accordions, and Kevin Rowland's passionate, raw vocal style.
+*Too-Rye-Ay* showcased the band's new Celtic soul sound, combining fiddles, accordions, and Kevin Rowland's passionate, raw vocal style.
+
+It reached number two on the UK Albums Chart and included the worldwide number-one hit 'Come On Eileen'.

--- a/src/content/releases/d/dio/the-last-in-line/index.md
+++ b/src/content/releases/d/dio/the-last-in-line/index.md
@@ -20,4 +20,6 @@ tracklist_edition: "1984 NL"
 ---
 ## About
 
-The Last in Line is the second studio album by American heavy metal band Dio, released on Vertigo Records in 1984. It reached number four on the UK Albums Chart, making it one of the most successful heavy metal albums of the year in Britain. Led by the extraordinary vocal power of Ronnie James Dio, the album builds on the success of Holy Diver and further established the band as one of the premier heavy metal acts of the era.
+Led by the extraordinary vocal power of Ronnie James Dio, *The Last in Line* builds on the success of Holy Diver and further established the band as one of the premier heavy metal acts of the era.
+
+It reached number four on the UK Albums Chart, making it one of the most successful heavy metal albums of the year in Britain.

--- a/src/content/releases/d/donovan/greatest-hitsa-and-more/index.md
+++ b/src/content/releases/d/donovan/greatest-hitsa-and-more/index.md
@@ -73,10 +73,10 @@ tracklist_edition: "1989-09-18 GB"
 ---
 ## About
 
-Greatest Hitsâ€¦ and More is a release by Donovan released in 1989. It has been featured on 1 Sundown Sessions show. Featured tracks include Hurdy Gurdy Man.
+*Greatest Hitsâ€¦ and More* earns its place in the Sundown Sessions catalogue through “Hurdy Gurdy Man”, a selection that offers a direct route into Donovan's work.
+
+Heard in the context of the full release, “Hurdy Gurdy Man” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Hurdy Gurdy Man
-
-

--- a/src/content/releases/d/doves/some-cities/index.md
+++ b/src/content/releases/d/doves/some-cities/index.md
@@ -68,4 +68,6 @@ tracklist_edition: "2005 XE special edition"
 ---
 ## About
 
-Some Cities is the third studio album by Manchester indie rock trio Doves, released on Heavenly Recordings in 2005. It debuted at number one on the UK Albums Chart and was nominated for the Mercury Prize. The album reflects the band's expansive, emotionally resonant sound, built on layer upon layer of guitars, keyboards, and Andy Williams' powerful drumming.
+*Some Cities* reflects the band's expansive, emotionally resonant sound, built on layer upon layer of guitars, keyboards, and Andy Williams' powerful drumming.
+
+It debuted at number one on the UK Albums Chart and was nominated for the Mercury Prize.

--- a/src/content/releases/d/dr-feelgood/the-ua-years/index.md
+++ b/src/content/releases/d/dr-feelgood/the-ua-years/index.md
@@ -85,10 +85,10 @@ tracklist_edition: "1989 GB"
 ---
 ## About
 
-The UA Years is a release by Dr Feelgood released in 1989. It has been featured on 1 Sundown Sessions show. Featured tracks include Roxette.
+*The UA Years* earns its place in the Sundown Sessions catalogue through “Roxette”, a selection that offers a direct route into Dr Feelgood's work.
+
+Heard in the context of the full release, “Roxette” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Roxette
-
-

--- a/src/content/releases/d/dragons/here-are-the-roses/index.md
+++ b/src/content/releases/d/dragons/here-are-the-roses/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "2007-05-30 GB"
 ---
 ## About
 
-Here Are The Roses is a release by Dragons released in 2007-05-30. It has been featured on 1 Sundown Sessions show. Featured tracks include Condition.
+*Here Are The Roses* earns its place in the Sundown Sessions catalogue through “Condition”, a selection that offers a direct route into Dragons's work.
 
-
+Heard in the context of the full release, “Condition” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/d/duran-duran/duran-duran/index.md
+++ b/src/content/releases/d/duran-duran/duran-duran/index.md
@@ -100,6 +100,6 @@ tracklist_edition: "1993 GB The Wedding Album"
 ---
 ## About
 
-Duran Duran is a release by Duran Duran released in 1993-02-11. It has been featured on 1 Sundown Sessions show. Featured tracks include Planet Earth.
+*Duran Duran* earns its place in the Sundown Sessions catalogue through “Planet Earth”, a selection that offers a direct route into Duran Duran's work.
 
-
+Heard in the context of the full release, “Planet Earth” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/echo-the-bunnymen/porcupine/index.md
+++ b/src/content/releases/e/echo-the-bunnymen/porcupine/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1983 XE"
 ---
 ## About
 
-Porcupine is the third studio album by Liverpool post-punk band Echo & the Bunnymen, released on Korova Records in 1983. It reached number two on the UK Albums Chart and marked a more expansive, widescreen sound compared to their earlier work. The album features some of Ian McCulloch's most evocative vocal performances alongside Will Sergeant's increasingly ambitious guitar work.
+*Porcupine* reached number two on the UK Albums Chart and marked a more expansive, widescreen sound compared to their earlier work.
+
+The album features some of Ian McCulloch's most evocative vocal performances alongside Will Sergeant's increasingly ambitious guitar work.

--- a/src/content/releases/e/echo-the-bunnymen/the-best-of-echo-the-bunnymen/index.md
+++ b/src/content/releases/e/echo-the-bunnymen/the-best-of-echo-the-bunnymen/index.md
@@ -64,4 +64,4 @@ tracklist_edition: "2007 None"
 ---
 ## About
 
-The Best of Echo & the Bunnymen is a comprehensive compilation covering the Liverpool post-punk band's extensive catalogue, released on Rhino Records in 2006. It traces the band's evolution from their jagged, atmospheric debut through the lush orchestrations of Ocean Rain, and includes their celebrated cover of 'People Are Strange' from the soundtrack to The Lost Boys (1987).
+*The Best of Echo & The Bunnymen* traces the band's evolution from their jagged, atmospheric debut through the lush orchestrations of Ocean Rain, and includes their celebrated cover of 'People Are Strange' from the soundtrack to The Lost Boys (1987).

--- a/src/content/releases/e/echobelly/on/index.md
+++ b/src/content/releases/e/echobelly/on/index.md
@@ -52,4 +52,6 @@ tracklist_edition: "1995 JP"
 ---
 ## About
 
-On is the second studio album by London indie rock band Echobelly, released on Fauve Records in 1995. The album built on the promise of their debut Everyone's Got One and featured the singles 'King of the Kerb' and 'Great Things'. Frontwoman Sonya Aurora Madan was one of the most visible South Asian voices in 1990s British indie music.
+*On* built on the promise of their debut Everyone's Got One and featured the singles 'King of the Kerb' and 'Great Things'.
+
+Frontwoman Sonya Aurora Madan was one of the most visible South Asian voices in 1990s British indie music.

--- a/src/content/releases/e/einstrzende-neubauten/silence-is-sexy/index.md
+++ b/src/content/releases/e/einstrzende-neubauten/silence-is-sexy/index.md
@@ -74,4 +74,6 @@ tracklist_edition: "2000-04-03 GB"
 ---
 ## About
 
-Silence Is Sexy is the ninth studio album by Berlin industrial band Einstürzende Neubauten, released on Mute Records in 2000. The album represents a more introspective and meditative phase in the band's development, trading some of their characteristic sonic violence for a more abstract, refined approach. It is regarded as one of their most accessible and emotionally complex works.
+*Silence is Sexy* is regarded as one of their most accessible and emotionally complex works.
+
+The album represents a more introspective and meditative phase in the band's development, trading some of their characteristic sonic violence for a more abstract, refined approach.

--- a/src/content/releases/e/elastica/elastica/index.md
+++ b/src/content/releases/e/elastica/elastica/index.md
@@ -98,4 +98,6 @@ tracklist_edition: "1995 AU Geffen, Tours de Force"
 ---
 ## About
 
-Elastica is the self-titled debut studio album by London indie rock band Elastica, released on Deceptive Records in 1995. It debuted at number one on the UK Albums Chart, selling a then-record 111,000 copies in its first week. The album's angular, compact post-punk songs became a defining sound of mid-1990s Britpop, despite controversy over their resemblance to Wire and The Stranglers.
+*Elastica*'s angular, compact post-punk songs became a defining sound of mid-1990s Britpop, despite controversy over their resemblance to Wire and The Stranglers.
+
+It debuted at number one on the UK Albums Chart, selling a then-record 111,000 copies in its first week.

--- a/src/content/releases/e/electric-light-orchestra/discovery/index.md
+++ b/src/content/releases/e/electric-light-orchestra/discovery/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1979 GB white shell"
 ---
 ## About
 
-Discovery is a release by Electric Light Orchestra released in 1979-05-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Don't Bring Me Down.
+*Discovery* earns its place in the Sundown Sessions catalogue through “Don't Bring Me Down”, a selection that offers a direct route into Electric Light Orchestra's work.
 
-
+Heard in the context of the full release, “Don't Bring Me Down” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/electric-light-orchestra/electric-light-orchestra/index.md
+++ b/src/content/releases/e/electric-light-orchestra/electric-light-orchestra/index.md
@@ -35,6 +35,6 @@ tracklist_edition: "1984 XG"
 ---
 ## About
 
-Electric Light Orchestra is a release by Electric Light Orchestra released in 1984. It has been featured on 1 Sundown Sessions show. Featured tracks include 10538 Overture.
+*Electric Light Orchestra* earns its place in the Sundown Sessions catalogue through “10538 Overture”, a selection that offers a direct route into Electric Light Orchestra's work.
 
-
+Heard in the context of the full release, “10538 Overture” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/electric-light-orchestra/out-of-the-blue/index.md
+++ b/src/content/releases/e/electric-light-orchestra/out-of-the-blue/index.md
@@ -93,6 +93,6 @@ tracklist_edition: "1977 DE"
 ---
 ## About
 
-Out of the Blue is a release by Electric Light Orchestra released in 1977-10-28. It has been featured on 1 Sundown Sessions show. Featured tracks include Mr. Blue Sky.
+*Out of the Blue* earns its place in the Sundown Sessions catalogue through “Mr. Blue Sky”, a selection that offers a direct route into Electric Light Orchestra's work.
 
-
+Heard in the context of the full release, “Mr. Blue Sky” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/electric-light-orchestra/secret-messages/index.md
+++ b/src/content/releases/e/electric-light-orchestra/secret-messages/index.md
@@ -24,6 +24,6 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-Secret Messages is a release by Electric Light Orchestra released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Four Little Diamonds.
+*Secret Messages* earns its place in the Sundown Sessions catalogue through “Four Little Diamonds”, a selection that offers a direct route into Electric Light Orchestra's work.
 
-
+Heard in the context of the full release, “Four Little Diamonds” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/electric-light-orchestra/time/index.md
+++ b/src/content/releases/e/electric-light-orchestra/time/index.md
@@ -57,4 +57,6 @@ tracklist_edition: "1989 AU"
 ---
 ## About
 
-Time is the eighth studio album by Birmingham rock group Electric Light Orchestra, released on Jet Records in 1981. It reached number one on the UK Albums Chart and presented a futuristic, synthesiser-heavy sound that marked a significant departure from the string-laden arrangements of their earlier work. The album spawned the hit single 'Hold On Tight'.
+*Time* reached number one on the UK Albums Chart and presented a futuristic, synthesiser-heavy sound that marked a significant departure from the string-laden arrangements of their earlier work.
+
+The album spawned the hit single 'Hold On Tight'.

--- a/src/content/releases/e/electric-six/fire/index.md
+++ b/src/content/releases/e/electric-six/fire/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "2003 AU"
 ---
 ## About
 
-Fire is a release by Electric Six released in 2003-05-19. It has been featured on 1 Sundown Sessions show. Featured tracks include Synthesizer.
+*Fire* earns its place in the Sundown Sessions catalogue through “Synthesizer”, a selection that offers a direct route into Electric Six's work.
 
-
+Heard in the context of the full release, “Synthesizer” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/elvis-costello-the-attractions/this-years-model/index.md
+++ b/src/content/releases/e/elvis-costello-the-attractions/this-years-model/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1978 GB"
 ---
 ## About
 
-This Year's Model is the second studio album by Elvis Costello & the Attractions, released on Radar Records in 1978. It reached number four on the UK Albums Chart and is widely regarded as one of the finest albums to emerge from the new wave movement. The album features a fierce, sardonic energy, with Costello's acerbic wordplay matched by the Attractions' tightly coiled playing.
+*This Year's Model* reached number four on the UK Albums Chart and is widely regarded as one of the finest albums to emerge from the new wave movement.
+
+The album features a fierce, sardonic energy, with Costello's acerbic wordplay matched by the Attractions' tightly coiled playing.

--- a/src/content/releases/e/elvis-costello/my-aim-is-true/index.md
+++ b/src/content/releases/e/elvis-costello/my-aim-is-true/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "1977-07-22 GB"
 ---
 ## About
 
-My Aim Is True is a release by Elvis Costello released in 1977-07-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Watching The Detectives.
+*My Aim Is True* earns its place in the Sundown Sessions catalogue through “Watching The Detectives”, a selection that offers a direct route into Elvis Costello's work.
 
-
+Heard in the context of the full release, “Watching The Detectives” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/ennio-morricone/the-good-the-bad-and-the-ugly/index.md
+++ b/src/content/releases/e/ennio-morricone/the-good-the-bad-and-the-ugly/index.md
@@ -48,11 +48,11 @@ tracklist_edition: "1968-10 GB"
 ---
 ## About
 
-The Good, The Bad and The Ugly is a release by Ennio Morricone released in 1966. It has been featured on 2 Sundown Sessions shows. Featured tracks include The Ecstasy Of Gold, The Good, The Bad and The Ugly.
+*The Good, The Bad and The Ugly* has supplied Sundown Sessions with “The Ecstasy Of Gold”, “The Good” and “The Bad and The Ugly”, giving more than one way into Ennio Morricone's work.
+
+Together, those choices point beyond isolated favourites towards the character of the wider release.
 
 ## Tracks Featured on Sundown Sessions
 
 - The Ecstasy Of Gold
 - The Good, The Bad and The Ugly
-
-

--- a/src/content/releases/e/eric-clapton/journeyman/index.md
+++ b/src/content/releases/e/eric-clapton/journeyman/index.md
@@ -61,6 +61,6 @@ tracklist_edition: "1989 CA Columbia House edition"
 ---
 ## About
 
-Journeyman is a release by Eric Clapton released in 1989-10-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Bad Love.
+*Journeyman* earns its place in the Sundown Sessions catalogue through “Bad Love”, a selection that offers a direct route into Eric Clapton's work.
 
-
+Heard in the context of the full release, “Bad Love” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/e/everything-but-the-girl/eden/index.md
+++ b/src/content/releases/e/everything-but-the-girl/eden/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1984-06-04 GB"
 ---
 ## About
 
-Eden is the debut studio album by Hull duo Everything But the Girl — Tracey Thorn and Ben Watt — released on Blanco y Negro Records in 1984. It reached number 14 on the UK Albums Chart and established their sophisticated, bossa nova-inflected sound. The album is characterised by Thorn's beautifully restrained vocal performances and the pair's collectively mature, understated musical sensibility.
+*Eden* reached number 14 on the UK Albums Chart and established their sophisticated, bossa nova-inflected sound.
+
+The album is characterised by Thorn's beautifully restrained vocal performances and the pair's collectively mature, understated musical sensibility.

--- a/src/content/releases/e/extreme/iii-sides-to-every-story/index.md
+++ b/src/content/releases/e/extreme/iii-sides-to-every-story/index.md
@@ -68,6 +68,6 @@ tracklist_edition: "1992 US Club Edition"
 ---
 ## About
 
-III Sides To Every Story is a release by Extreme released in 1992-08-20. It has been featured on 2 Sundown Sessions shows. Featured tracks include Rest In Peace.
+*III Sides To Every Story* earns its place in the Sundown Sessions catalogue through “Rest In Peace”, a selection that offers a direct route into Extreme's work.
 
-
+Heard in the context of the full release, “Rest In Peace” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/f/fabienne-delsol/on-my-mind/index.md
+++ b/src/content/releases/f/fabienne-delsol/on-my-mind/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "2010-09-06 GB"
 ---
 ## About
 
-On My Mind is a release by Fabienne DelSol released in 2010-09-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Ragunboneman.
+*On My Mind* earns its place in the Sundown Sessions catalogue through “Ragunboneman”, a selection that offers a direct route into Fabienne DelSol's work.
 
-
+Heard in the context of the full release, “Ragunboneman” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/f/fad-gadget/fad-gadget-by-frank-tovey/index.md
+++ b/src/content/releases/f/fad-gadget/fad-gadget-by-frank-tovey/index.md
@@ -133,10 +133,10 @@ tracklist_edition: "2006-10-17 XE"
 ---
 ## About
 
-Fad Gadget By Frank Tovey is a release by Fad Gadget released in 2006. It has been featured on 1 Sundown Sessions show. Featured tracks include Collapsing New People.
+*Fad Gadget By Frank Tovey* earns its place in the Sundown Sessions catalogue through “Collapsing New People”, a selection that offers a direct route into Fad Gadget's work.
+
+Heard in the context of the full release, “Collapsing New People” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Collapsing New People
-
-

--- a/src/content/releases/f/fairport-convention/babbacombe-lee/index.md
+++ b/src/content/releases/f/fairport-convention/babbacombe-lee/index.md
@@ -52,4 +52,6 @@ tracklist_edition: "1971 CA"
 ---
 ## About
 
-Babbacombe Lee is the sixth studio album by British folk rock band Fairport Convention, released on Island Records in 1971. The album tells the story of John 'Babbacombe' Lee, the 'man they could not hang', in a folk-rock narrative format. It is a distinctive and ambitious work in the band's catalogue, showcasing their ability to marry English folk tradition with contemporary rock instrumentation.
+*Babbacombe Lee* is a distinctive and ambitious work in the band's catalogue, showcasing their ability to marry English folk tradition with contemporary rock instrumentation.
+
+The album tells the story of John 'Babbacombe' Lee, the 'man they could not hang', in a folk-rock narrative format.

--- a/src/content/releases/f/fat-white-family/serfs-up/index.md
+++ b/src/content/releases/f/fat-white-family/serfs-up/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "2019-04-19 XE"
 ---
 ## About
 
-Serfs Up! is a release by Fat White Family released in 2019-04-19. It has been featured on 1 Sundown Sessions show. Featured tracks include Feet.
+*Serfs Up!* earns its place in the Sundown Sessions catalogue through “Feet”, a selection that offers a direct route into Fat White Family's work.
 
-
+Heard in the context of the full release, “Feet” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/f/felt/the-strange-idols-pattern-and-other-short-stories/index.md
+++ b/src/content/releases/f/felt/the-strange-idols-pattern-and-other-short-stories/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1984-10-26 GB"
 ---
 ## About
 
-The Strange Idols Pattern and Other Short Stories is the third studio album by Birmingham indie band Felt, released on Creation Records in 1984. Led by the enigmatic Lawrence, Felt built a devoted following on the UK independent circuit with their Velvets-influenced guitar pop. The album is noted for its melodically rich yet understated approach.
+*The Strange Idols Pattern and Other Short Stories* is noted for its melodically rich yet understated approach.
+
+Led by the enigmatic Lawrence, Felt built a devoted following on the UK independent circuit with their Velvets-influenced guitar pop.

--- a/src/content/releases/f/fews/means/index.md
+++ b/src/content/releases/f/fews/means/index.md
@@ -52,6 +52,6 @@ tracklist_edition: "2016-05-20 XW"
 ---
 ## About
 
-MEANS is a release by FEWS released in 2016-05-20. It has been featured on 1 Sundown Sessions show. Featured tracks include The Zoo.
+*MEANS* earns its place in the Sundown Sessions catalogue through “The Zoo”, a selection that offers a direct route into FEWS's work.
 
-
+Heard in the context of the full release, “The Zoo” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/f/fiona-apple/the-idler-wheel/index.md
+++ b/src/content/releases/f/fiona-apple/the-idler-wheel/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "2012-06-18 XE"
 ---
 ## About
 
-The Idler Wheel... is a release by Fiona Apple released in 2012. It has been featured on 1 Sundown Sessions show. Featured tracks include Werewolf.
+*The Idler Wheel...* earns its place in the Sundown Sessions catalogue through “Werewolf”, a selection that offers a direct route into Fiona Apple's work.
+
+Heard in the context of the full release, “Werewolf” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Werewolf
-
-

--- a/src/content/releases/f/fleetwood-mac/blues-obituary/index.md
+++ b/src/content/releases/f/fleetwood-mac/blues-obituary/index.md
@@ -77,4 +77,4 @@ tracklist_edition: "2000 XE"
 ---
 ## About
 
-Blues Obituary is the second studio album by the original British blues rock version of Fleetwood Mac, released on Immediate Records in 1969. It documents the band led by Peter Green at the height of their creative powers, showcasing the interplay between Green's expressive guitar work and the rhythm section of John McVie and Mick Fleetwood.
+*Blues Obituary* documents the band led by Peter Green at the height of their creative powers, showcasing the interplay between Green's expressive guitar work and the rhythm section of John McVie and Mick Fleetwood.

--- a/src/content/releases/f/fleetwood-mac/then-play-on-2013-remaster-expanded-edition/index.md
+++ b/src/content/releases/f/fleetwood-mac/then-play-on-2013-remaster-expanded-edition/index.md
@@ -67,10 +67,10 @@ tracklist_edition: "2018-11-16 XW 2013 remaster; expanded edition"
 ---
 ## About
 
-Then Play On (2013 Remaster; Expanded Edition) is a release by Fleetwood Mac released in 1969. It has been featured on 1 Sundown Sessions show. Featured tracks include The Green Manalishi (With the Two Prong Crown) - 2013 Remaster.
+*Then Play On (2013 Remaster; Expanded Edition)* earns its place in the Sundown Sessions catalogue through “The Green Manalishi (With the Two Prong Crown) - 2013 Remaster”, a selection that offers a direct route into Fleetwood Mac's work.
+
+Heard in the context of the full release, “The Green Manalishi (With the Two Prong Crown) - 2013 Remaster” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - The Green Manalishi (With the Two Prong Crown) - 2013 Remaster
-
-

--- a/src/content/releases/f/foetus/nail/index.md
+++ b/src/content/releases/f/foetus/nail/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1985 GB"
 ---
 ## About
 
-Nail is a studio album by the project Foetus (Jim Thirlwell), released on his own Self-immolation label in 1985. Thirlwell's Foetus project blends industrial music, funk, orchestral arrangements, and confrontational lyrics into a singular artistic vision. The album is one of his most acclaimed works and a key document of the 1980s industrial scene.
+*Nail* is one of his most acclaimed works and a key document of the 1980s industrial scene.
+
+Thirlwell's Foetus project blends industrial music, funk, orchestral arrangements, and confrontational lyrics into a singular artistic vision.

--- a/src/content/releases/f/frankie-goes-to-hollywood/welcome-to-the-pleasuredome/index.md
+++ b/src/content/releases/f/frankie-goes-to-hollywood/welcome-to-the-pleasuredome/index.md
@@ -57,4 +57,6 @@ tracklist_edition: "1984 XE"
 ---
 ## About
 
-Welcome to the Pleasuredome is the debut studio album by Liverpool dance-pop group Frankie Goes to Hollywood, released on ZTT Records in 1984. It topped the UK Albums Chart on release and was one of the most commercially successful debut albums of the decade. The record included the controversial singles 'Relax' and 'Two Tribes', both of which reached number one in the UK.
+*Welcome to the Pleasuredome* included the controversial singles 'Relax' and 'Two Tribes', both of which reached number one in the UK.
+
+It topped the UK Albums Chart on release and was one of the most commercially successful debut albums of the decade.

--- a/src/content/releases/f/franz-ferdinand/franz-ferdinand/index.md
+++ b/src/content/releases/f/franz-ferdinand/franz-ferdinand/index.md
@@ -80,7 +80,7 @@ tracklist_edition: "2004 XE"
 ---
 ## About
 
-Franz Ferdinand is the debut studio album by Scottish rock band Franz Ferdinand, released on 9 February 2004 through Domino Records. It won the Mercury Prize in 2004.
+*Franz Ferdinand* won the Mercury Prize in 2004.
 
 ## External Links
 

--- a/src/content/releases/f/free/fire-and-water/index.md
+++ b/src/content/releases/f/free/fire-and-water/index.md
@@ -35,4 +35,6 @@ tracklist_edition: "1970 US"
 ---
 ## About
 
-Fire and Water is the third studio album by British hard rock band Free, released on Island Records in 1970. It reached number two on the UK Albums Chart and includes their signature track 'All Right Now', which reached number two on the UK Singles Chart and has since become one of the most enduringly popular rock songs of the era. The album showcases Paul Rodgers' extraordinary voice and Paul Kossoff's blues-rooted guitar playing.
+*Fire and Water* showcases Paul Rodgers' extraordinary voice and Paul Kossoff's blues-rooted guitar playing.
+
+It reached number two on the UK Albums Chart and includes their signature track 'All Right Now', which reached number two on the UK Singles Chart and has since become one of the most enduringly popular rock songs of the era.

--- a/src/content/releases/g/gang-of-four/entertainment/index.md
+++ b/src/content/releases/g/gang-of-four/entertainment/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1979 FR"
 ---
 ## About
 
-Entertainment! is the debut studio album by Leeds post-punk band Gang of Four, released on EMI Records in 1979. Combining jagged, funky guitar with Marxist analysis of consumer culture and interpersonal relationships, the album is considered one of the most politically urgent and musically innovative records of the post-punk era. It has influenced countless subsequent acts from R.E.M. to Rage Against the Machine.
+Combining jagged, funky guitar with Marxist analysis of consumer culture and interpersonal relationships, *Entertainment!* remains one of post-punk's most politically urgent and musically innovative records.
+
+Its influence reaches across generations, from R.E.M. to Rage Against the Machine.

--- a/src/content/releases/g/gary-numan/the-pleasure-principle/index.md
+++ b/src/content/releases/g/gary-numan/the-pleasure-principle/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1979-09-07 CA"
 ---
 ## About
 
-The Pleasure Principle is a release by Gary Numan released in 1979-09-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Airlane.
+*The Pleasure Principle* earns its place in the Sundown Sessions catalogue through “Airlane”, a selection that offers a direct route into Gary Numan's work.
 
-
+Heard in the context of the full release, “Airlane” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/g/gaye-bykers-on-acid/nosedive-karma-ep/index.md
+++ b/src/content/releases/g/gaye-bykers-on-acid/nosedive-karma-ep/index.md
@@ -16,10 +16,10 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-Nosedive Karma EP is a release by Gaye Bykers On Acid released in 1987. It has been featured on 1 Sundown Sessions show. Featured tracks include Nosedive Karma.
+*Nosedive Karma EP* earns its place in the Sundown Sessions catalogue through “Nosedive Karma”, a selection that offers a direct route into Gaye Bykers On Acid's work.
+
+Heard in the context of the full release, “Nosedive Karma” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Nosedive Karma
-
-

--- a/src/content/releases/g/gene/olympian/index.md
+++ b/src/content/releases/g/gene/olympian/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1995 XE"
 ---
 ## About
 
-Olympian is the debut studio album by London indie rock band Gene, released on Costermonger Records in 1995. The album was praised for its sophisticated, emotionally intelligent guitar pop and drew frequent comparisons to The Smiths, with vocalist Martin Rossiter winning particular acclaim. Gene were considered one of the more literate and thoughtful acts of the Britpop generation.
+*Olympian* was praised for its sophisticated, emotionally intelligent guitar pop and drew frequent comparisons to The Smiths, with vocalist Martin Rossiter winning particular acclaim.
+
+Gene were considered one of the more literate and thoughtful acts of the Britpop generation.

--- a/src/content/releases/g/geordie-munro/haste-ye-back/index.md
+++ b/src/content/releases/g/geordie-munro/haste-ye-back/index.md
@@ -27,7 +27,9 @@ tracks:
 ---
 ## About
 
-Haste Ye Back is a release by Geordie Munro released in 2012. It has been featured on 1 Sundown Sessions show. Featured tracks include The Alexander Brothers.
+*Haste Ye Back* earns its place in the Sundown Sessions catalogue through “The Alexander Brothers”, a selection that offers a direct route into Geordie Munro's work.
+
+Heard in the context of the full release, “The Alexander Brothers” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 

--- a/src/content/releases/g/george-thorogood-and-the-destroyers/the-hard-stuff/index.md
+++ b/src/content/releases/g/george-thorogood-and-the-destroyers/the-hard-stuff/index.md
@@ -70,6 +70,6 @@ tracklist_edition: "2006 XW"
 ---
 ## About
 
-The Hard Stuff is a release by George Thorogood & The Destroyers released in 2006-05-22. It has been featured on 2 Sundown Sessions shows. Featured tracks include Love Doctor.
+*The Hard Stuff* earns its place in the Sundown Sessions catalogue through “Love Doctor”, a selection that offers a direct route into George Thorogood & The Destroyers's work.
 
-
+Heard in the context of the full release, “Love Doctor” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/g/giorgio-moroder/from-here-to-eternity/index.md
+++ b/src/content/releases/g/giorgio-moroder/from-here-to-eternity/index.md
@@ -47,6 +47,6 @@ tracklist_edition: "1977 GB"
 ---
 ## About
 
-From Here to Eternity is a release by Giorgio Moroder released in 1977-07-22. It has been featured on 1 Sundown Sessions show. Featured tracks include Utopia - Me Giorgio.
+*From Here to Eternity* earns its place in the Sundown Sessions catalogue through “Utopia - Me Giorgio”, a selection that offers a direct route into Giorgio Moroder's work.
 
-
+Heard in the context of the full release, “Utopia - Me Giorgio” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/g/goldfrapp/supernature/index.md
+++ b/src/content/releases/g/goldfrapp/supernature/index.md
@@ -64,6 +64,6 @@ tracklist_edition: "2005 BR"
 ---
 ## About
 
-Supernature is a release by Goldfrapp released in 2005-08-17. It has been featured on 1 Sundown Sessions show. Featured tracks include Koko.
+*Supernature* earns its place in the Sundown Sessions catalogue through “Koko”, a selection that offers a direct route into Goldfrapp's work.
 
-
+Heard in the context of the full release, “Koko” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/g/goodbye-mr-mackenzie/5/index.md
+++ b/src/content/releases/g/goodbye-mr-mackenzie/5/index.md
@@ -25,10 +25,11 @@ tracks:
 ---
 ## About
 
-5 is a release by Goodbye Mr Mackenzie. It has been featured on 1 Sundown Sessions show. Featured tracks include Hard, Normal Boy.
+*5* has supplied Sundown Sessions with “Hard” and “Normal Boy”, giving more than one way into Goodbye Mr Mackenzie's work.
+
+Together, those choices point beyond isolated favourites towards the character of the wider release.
 
 ## Tracks Featured on Sundown Sessions
 
 - Hard
 - Normal Boy
-

--- a/src/content/releases/g/grandaddy/sumday/index.md
+++ b/src/content/releases/g/grandaddy/sumday/index.md
@@ -70,6 +70,6 @@ tracklist_edition: "2003 US"
 ---
 ## About
 
-Sumday is a release by Grandaddy released in 2003-06-09. It has been featured on 1 Sundown Sessions show. Featured tracks include I'm On Standby.
+*Sumday* earns its place in the Sundown Sessions catalogue through “I'm On Standby”, a selection that offers a direct route into Grandaddy's work.
 
-
+Heard in the context of the full release, “I'm On Standby” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/g/grandmaster-flash-the-furious-five/the-message/index.md
+++ b/src/content/releases/g/grandmaster-flash-the-furious-five/the-message/index.md
@@ -37,4 +37,6 @@ tracklist_edition: "1982 GB"
 ---
 ## About
 
-The Message is the debut studio album by New York hip-hop pioneers Grandmaster Flash & the Furious Five, released on Sugar Hill Records in 1982. The album includes the landmark title track, widely regarded as one of the first hip-hop songs to address social issues such as poverty, crime, and urban decay directly. It is considered one of the most important records in the history of popular music.
+*The Message* includes the landmark title track, widely regarded as one of the first hip-hop songs to address social issues such as poverty, crime, and urban decay directly.
+
+It is considered one of the most important records in the history of popular music.

--- a/src/content/releases/g/grateful-dead/aoxomoxoa/index.md
+++ b/src/content/releases/g/grateful-dead/aoxomoxoa/index.md
@@ -37,4 +37,6 @@ tracklist_edition: "1969 GB"
 ---
 ## About
 
-Aoxomoxoa is the third studio album by San Francisco psychedelic rock band Grateful Dead, released on Warner Bros. Records in 1969. The album represents the band at their most psychedelically experimental in the studio, featuring extended compositions and adventurous sound collages produced with the 16-track recording technology they were among the first to employ. It includes 'St. Stephen' and 'China Cat Sunflower'.
+*Aoxomoxoa* represents the band at their most psychedelically experimental in the studio, featuring extended compositions and adventurous sound collages produced with the 16-track recording technology they were among the first to employ.
+
+Records in 1969. It includes 'St. Stephen' and 'China Cat Sunflower'.

--- a/src/content/releases/h/haircut-one-hundred/pelican-west/index.md
+++ b/src/content/releases/h/haircut-one-hundred/pelican-west/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1982-02 GB"
 ---
 ## About
 
-Pelican West is the debut studio album by Beckenham new wave band Haircut One Hundred, released on Arista Records in 1982. It reached number two on the UK Albums Chart and spawned the hits 'Love Plus One' and 'Favourite Shirts (Boy Meets Girl)'. The album presents a sophisticated, horn-laden blend of funk and pop that made the band one of the leading lights of the early-1980s British new wave scene.
+*Pelican West* presents a sophisticated, horn-laden blend of funk and pop that made the band one of the leading lights of the early-1980s British new wave scene.
+
+It reached number two on the UK Albums Chart and spawned the hits 'Love Plus One' and 'Favourite Shirts (Boy Meets Girl)'.

--- a/src/content/releases/h/happy-mondays/pills-n-thrills-and-bellyaches/index.md
+++ b/src/content/releases/h/happy-mondays/pills-n-thrills-and-bellyaches/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-Pills 'n' Thrills and Bellyaches is the third studio album by Manchester Madchester band Happy Mondays, released on Factory Records in 1990. It reached number four on the UK Albums Chart and is regarded as their masterpiece, combining the band's chaotic funk-rock with state-of-the-art house production from Paul Oakenfold and Steve Osborne. The album includes 'Step On' and 'Kinky Afro'.
+*Pills 'n' Thrills and Bellyaches* reached number four on the UK Albums Chart and is regarded as their masterpiece, combining the band's chaotic funk-rock with state-of-the-art house production from Paul Oakenfold and Steve Osborne.
+
+The album includes 'Step On' and 'Kinky Afro'.

--- a/src/content/releases/h/hawkwind/drive-fast-rock-hard/index.md
+++ b/src/content/releases/h/hawkwind/drive-fast-rock-hard/index.md
@@ -52,10 +52,10 @@ tracklist_edition: "2002-05 GB"
 ---
 ## About
 
-Drive Fast, Rock Hard is a release by Hawkwind released in 2010. It has been featured on 1 Sundown Sessions show. Featured tracks include Silver Machine.
+*Drive Fast, Rock Hard* earns its place in the Sundown Sessions catalogue through “Silver Machine”, a selection that offers a direct route into Hawkwind's work.
+
+Heard in the context of the full release, “Silver Machine” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Silver Machine
-
-

--- a/src/content/releases/h/heaven-17/penthouse-and-pavement/index.md
+++ b/src/content/releases/h/heaven-17/penthouse-and-pavement/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "1981 GB"
 ---
 ## About
 
-Penthouse And Pavement is a release by Heaven 17 released in 1981. It has been featured on 1 Sundown Sessions show. Featured tracks include Let's All Make A Bomb.
+*Penthouse And Pavement* earns its place in the Sundown Sessions catalogue through “Let's All Make A Bomb”, a selection that offers a direct route into Heaven 17's work.
 
-
+Heard in the context of the full release, “Let's All Make A Bomb” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/h/hipsway/hipsway/index.md
+++ b/src/content/releases/h/hipsway/hipsway/index.md
@@ -61,6 +61,6 @@ tracklist_edition: "1986 GB"
 ---
 ## About
 
-Hipsway is a release by Hipsway released in 1986. It has been featured on 2 Sundown Sessions shows. Featured tracks include The Honeythief, Tinder.
+*Hipsway* has supplied Sundown Sessions with “The Honeythief” and “Tinder”, giving more than one way into Hipsway's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/h/hugh-cornwell/totem-and-taboo/index.md
+++ b/src/content/releases/h/hugh-cornwell/totem-and-taboo/index.md
@@ -40,6 +40,6 @@ tracklist_edition: "2012-09-10 GB"
 ---
 ## About
 
-Totem & Taboo is a release by Hugh Cornwell released in 2012-09-10. It has been featured on 1 Sundown Sessions show. Featured tracks include Totem and Taboo.
+*Totem & Taboo* earns its place in the Sundown Sessions catalogue through “Totem and Taboo”, a selection that offers a direct route into Hugh Cornwell's work.
 
-
+Heard in the context of the full release, “Totem and Taboo” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/h/humble-pie/performance-rockin-the-fillmore/index.md
+++ b/src/content/releases/h/humble-pie/performance-rockin-the-fillmore/index.md
@@ -41,4 +41,4 @@ tracklist_edition: "1971 GB"
 ---
 ## About
 
-Performance: Rockin' the Fillmore is a live double album by British rock band Humble Pie, released on A&M Records in 1971. It is widely regarded as the definitive document of the band's live power, capturing Steve Marriott's extraordinary vocal performances and the band's sprawling, blues-drenched hard rock at its most visceral.
+*Performance - Rockin' the Fillmore* is widely regarded as the definitive document of the band's live power, capturing Steve Marriott's extraordinary vocal performances and the band's sprawling, blues-drenched hard rock at its most visceral.

--- a/src/content/releases/h/hussey-regan/curios/index.md
+++ b/src/content/releases/h/hussey-regan/curios/index.md
@@ -59,6 +59,6 @@ tracklist_edition: "2011-10-10 GB"
 ---
 ## About
 
-Curios is a release by Hussey-Regan released in 2011-10-10. It has been featured on 1 Sundown Sessions show. Featured tracks include Naked and Savage.
+*Curios* earns its place in the Sundown Sessions catalogue through “Naked and Savage”, a selection that offers a direct route into Hussey-Regan's work.
 
-
+Heard in the context of the full release, “Naked and Savage” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/i/i-got-you-on-tape/spinning-for-the-cause/index.md
+++ b/src/content/releases/i/i-got-you-on-tape/spinning-for-the-cause/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "2009 BE"
 ---
 ## About
 
-Spinning for the Cause is a release by I Got You On Tape released in 2009-10-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Spinning For The Cause.
+*Spinning for the Cause* earns its place in the Sundown Sessions catalogue through “Spinning For The Cause”, a selection that offers a direct route into I Got You On Tape's work.
 
-
+Heard in the context of the full release, “Spinning For The Cause” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/i/in-letter-form/fracture-repair-repeat/index.md
+++ b/src/content/releases/i/in-letter-form/fracture-repair-repeat/index.md
@@ -55,6 +55,6 @@ tracklist_edition: "2016-05-20 US"
 ---
 ## About
 
-Fracture. Repair. Repeat. is a release by In Letter Form released in 2016-05-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Terror (Is A State Of Mind).
+*Fracture. Repair. Repeat.* earns its place in the Sundown Sessions catalogue through “Terror (Is A State Of Mind)”, a selection that offers a direct route into In Letter Form's work.
 
-
+Heard in the context of the full release, “Terror (Is A State Of Mind)” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/i/inspiral-carpets/life/index.md
+++ b/src/content/releases/i/inspiral-carpets/life/index.md
@@ -62,4 +62,6 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-Life is the debut studio album by Oldham indie rock band Inspiral Carpets, released on Mute Records in 1990. It reached number two on the UK Albums Chart and is one of the defining albums of the Madchester era, featuring Clint Boon's distinctive Vox Continental organ sound and Tom Hingley's deadpan vocals. The album includes the anthemic singles 'This Is How It Feels' and 'She Comes in the Fall'.
+*Life* reached number two on the UK Albums Chart and is one of the defining albums of the Madchester era, featuring Clint Boon's distinctive Vox Continental organ sound and Tom Hingley's deadpan vocals.
+
+The album includes the anthemic singles 'This Is How It Feels' and 'She Comes in the Fall'.

--- a/src/content/releases/i/inspiral-carpets/revenge-of-the-goldfish/index.md
+++ b/src/content/releases/i/inspiral-carpets/revenge-of-the-goldfish/index.md
@@ -69,6 +69,6 @@ tracklist_edition: "1992 JP"
 ---
 ## About
 
-Revenge Of The Goldfish is a release by Inspiral Carpets released in 1992-10-05. It has been featured on 1 Sundown Sessions show. Featured tracks include Bitches Brew.
+*Revenge Of The Goldfish* earns its place in the Sundown Sessions catalogue through “Bitches Brew”, a selection that offers a direct route into Inspiral Carpets's work.
 
-
+Heard in the context of the full release, “Bitches Brew” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/i/interpol/antics/index.md
+++ b/src/content/releases/i/interpol/antics/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "2004 ZA"
 ---
 ## About
 
-Antics is a release by Interpol released in 2004-09-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Slow Hands.
+*Antics* earns its place in the Sundown Sessions catalogue through “Slow Hands”, a selection that offers a direct route into Interpol's work.
 
-
+Heard in the context of the full release, “Slow Hands” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/i/iron-maiden/the-number-of-the-beast/index.md
+++ b/src/content/releases/i/iron-maiden/the-number-of-the-beast/index.md
@@ -38,4 +38,6 @@ tracklist_edition: "1982 NL"
 ---
 ## About
 
-The Number of the Beast is the third studio album by East London heavy metal band Iron Maiden, released on EMI Records in 1982. It debuted at number one on the UK Albums Chart, making it the band's first chart-topper, and is widely regarded as one of the greatest heavy metal albums ever recorded. The album was the first to feature vocalist Bruce Dickinson and includes the classic tracks 'Run to the Hills' and the epic title track.
+*The Number of the Beast* debuted at number one on the UK Albums Chart, making it the band's first chart-topper, and is widely regarded as one of the greatest heavy metal albums ever recorded.
+
+The album was the first to feature vocalist Bruce Dickinson and includes the classic tracks 'Run to the Hills' and the epic title track.

--- a/src/content/releases/i/isobel-campbell/ballad-of-the-broken-seas/index.md
+++ b/src/content/releases/i/isobel-campbell/ballad-of-the-broken-seas/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "2006-01-30 GB"
 ---
 ## About
 
-Ballad of the Broken Seas is a release by Isobel Campbell released in 2006-01-30. It has been featured on 1 Sundown Sessions show. Featured tracks include The False Husband.
+*Ballad of the Broken Seas* earns its place in the Sundown Sessions catalogue through “The False Husband”, a selection that offers a direct route into Isobel Campbell's work.
 
-
+Heard in the context of the full release, “The False Husband” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/i/ist-ist/architecture/index.md
+++ b/src/content/releases/i/ist-ist/architecture/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "2020-05-01 GB"
 ---
 ## About
 
-Architecture is the debut studio album by Manchester post-punk band IST IST, self-released in 2020. The album showcases the band's brooding, atmospheric sound, influenced by Joy Division and Interpol. It received widespread critical acclaim in the UK independent music community and established IST IST as one of the most compelling post-punk acts to emerge in recent years.
+*Architecture* showcases the band's brooding, atmospheric sound, influenced by Joy Division and Interpol.
+
+It received widespread critical acclaim in the UK independent music community and established IST IST as one of the most compelling post-punk acts to emerge in recent years.

--- a/src/content/releases/i/ist-ist/lost-my-shadow/index.md
+++ b/src/content/releases/i/ist-ist/lost-my-shadow/index.md
@@ -24,6 +24,6 @@ tracklist_edition: "2024-03-08 XW"
 ---
 ## About
 
-Lost My Shadow is a release by IST IST released in 2024-03-08. It has been featured on 1 Sundown Sessions show. Featured tracks include Lost My Shadow.
+*Lost My Shadow* earns its place in the Sundown Sessions catalogue through “Lost My Shadow”, a selection that offers a direct route into IST IST's work.
 
-
+Heard in the context of the full release, “Lost My Shadow” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/i/ist-ist/the-art-of-lying/index.md
+++ b/src/content/releases/i/ist-ist/the-art-of-lying/index.md
@@ -43,4 +43,4 @@ tracklist_edition: "2021-11-26 XW"
 ---
 ## About
 
-The Art of Lying is the second studio album by Manchester post-punk band IST IST, released on Grita Records in 2021. The album builds on the brooding atmospheric sound of their debut Architecture, expanding their sonic palette while retaining the intense, introspective quality that made their first record such a critical success.
+*The Art of Lying* builds on the brooding atmospheric sound of their debut Architecture, expanding their sonic palette while retaining the intense, introspective quality that made their first record such a critical success.

--- a/src/content/releases/j/jacco-gardner/cabinet-of-curiosities/index.md
+++ b/src/content/releases/j/jacco-gardner/cabinet-of-curiosities/index.md
@@ -122,6 +122,6 @@ tracklist_edition: "2013-02-11 NL"
 ---
 ## About
 
-Cabinet of Curiosities is a release by Jacco Gardner released in 2013-02-11. It has been featured on 3 Sundown Sessions shows. Featured tracks include Clear The Air, The Ballad of Little Jane, The One Eyed King.
+*Cabinet of Curiosities* has supplied Sundown Sessions with “Clear The Air”, “The Ballad of Little Jane” and “The One Eyed King”, giving more than one way into Jacco Gardner's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/j/jack-white/as-i-am/index.md
+++ b/src/content/releases/j/jack-white/as-i-am/index.md
@@ -16,10 +16,10 @@ tracklist_edition: "2022-06-08 AF"
 ---
 ## About
 
-As I Am is a release by Jack White released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include Another Way to Die.
+*As I Am* earns its place in the Sundown Sessions catalogue through “Another Way to Die”, a selection that offers a direct route into Jack White's work.
+
+Heard in the context of the full release, “Another Way to Die” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Another Way to Die
-
-

--- a/src/content/releases/j/jackie-lomax/come-and-get-it-the-best-of-apple-records/index.md
+++ b/src/content/releases/j/jackie-lomax/come-and-get-it-the-best-of-apple-records/index.md
@@ -49,10 +49,10 @@ tracklist_edition: "2004 US"
 ---
 ## About
 
-Come And Get It - The Best Of Apple Records is a release by Jackie Lomax released in 2010. It has been featured on 1 Sundown Sessions show. Featured tracks include Sour Milk Sea.
+*Come And Get It - The Best Of Apple Records* earns its place in the Sundown Sessions catalogue through “Sour Milk Sea”, a selection that offers a direct route into Jackie Lomax's work.
+
+Heard in the context of the full release, “Sour Milk Sea” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Sour Milk Sea
-
-

--- a/src/content/releases/j/james/gold-mother/index.md
+++ b/src/content/releases/j/james/gold-mother/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-Gold Mother is the fourth studio album by Manchester indie rock band James, released on Fontana Records in 1990. It reached number two on the UK Albums Chart and spawned two beloved singles: 'Come Home' and a re-released version of 'Sit Down', which became one of the anthems of the early-1990s indie scene. The album cemented James as one of the most enduring and beloved British bands of their generation.
+*Gold Mother* reached number two on the UK Albums Chart and spawned two beloved singles: 'Come Home' and a re-released version of 'Sit Down', which became one of the anthems of the early-1990s indie scene.
+
+The album cemented James as one of the most enduring and beloved British bands of their generation.

--- a/src/content/releases/j/japan/oil-on-canvas/index.md
+++ b/src/content/releases/j/japan/oil-on-canvas/index.md
@@ -59,4 +59,6 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-Oil on Canvas is a live album by Japanese-influenced British art pop group Japan, released on Virgin Records in 1983. It reached number five on the UK Albums Chart and was recorded during the band's farewell Visions of China tour in 1982. The album captures the sonic refinement the band had developed across their final studio trilogy.
+*Oil on Canvas* captures the sonic refinement the band had developed across their final studio trilogy.
+
+It reached number five on the UK Albums Chart and was recorded during the band's farewell Visions of China tour in 1982.

--- a/src/content/releases/j/jarvis-cocker/jarvis/index.md
+++ b/src/content/releases/j/jarvis-cocker/jarvis/index.md
@@ -52,10 +52,10 @@ tracklist_edition: "2006-11 AU"
 ---
 ## About
 
-Jarvis is a release by Jarvis Cocker released in 2006. It has been featured on 1 Sundown Sessions show. Featured tracks include Fat Children.
+*Jarvis* earns its place in the Sundown Sessions catalogue through “Fat Children”, a selection that offers a direct route into Jarvis Cocker's work.
+
+Heard in the context of the full release, “Fat Children” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Fat Children
-
-

--- a/src/content/releases/j/jefferson-airplane/surrealistic-pillow/index.md
+++ b/src/content/releases/j/jefferson-airplane/surrealistic-pillow/index.md
@@ -35,4 +35,4 @@ tracklist_edition: "1967 GB"
 ---
 ## About
 
-Surrealistic Pillow is the second studio album by San Francisco psychedelic rock band Jefferson Airplane, released on RCA Victor in 1967. It is considered one of the defining records of the 1960s Summer of Love and the San Francisco psychedelic scene, featuring the hits 'Somebody to Love' and 'White Rabbit', both featuring the extraordinary voice of Grace Slick.
+*Surrealistic Pillow* is considered one of the defining records of the 1960s Summer of Love and the San Francisco psychedelic scene, featuring the hits 'Somebody to Love' and 'White Rabbit', both featuring the extraordinary voice of Grace Slick.

--- a/src/content/releases/j/jethro-tull/aqualung/index.md
+++ b/src/content/releases/j/jethro-tull/aqualung/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1971 GB"
 ---
 ## About
 
-Aqualung is the fourth studio album by British rock band Jethro Tull, released on Chrysalis Records in 1971. It reached number four on the UK Albums Chart and includes the iconic title track alongside 'Locomotive Breath'. The album is loosely thematic, exploring religion, homelessness, and social hypocrisy through Ian Anderson's lyrics and the band's distinctive blend of folk, hard rock, and jazz.
+*Aqualung* is loosely thematic, exploring religion, homelessness, and social hypocrisy through Ian Anderson's lyrics and the band's distinctive blend of folk, hard rock, and jazz.
+
+It reached number four on the UK Albums Chart and includes the iconic title track alongside 'Locomotive Breath'.

--- a/src/content/releases/j/jethro-tull/this-was/index.md
+++ b/src/content/releases/j/jethro-tull/this-was/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1968 GB"
 ---
 ## About
 
-This Was is the debut studio album by British rock band Jethro Tull, released on Island Records in 1968. It reached number 10 on the UK Albums Chart and introduced the band's distinctive blues-influenced sound. In its original form, the album features the short-lived double lead guitar line-up of Mick Abrahams and the emerging talents of Ian Anderson, whose flute playing would become the band's trademark.
+*This Was* reached number 10 on the UK Albums Chart and introduced the band's distinctive blues-influenced sound.
+
+In its original form, the album features the short-lived double lead guitar line-up of Mick Abrahams and the emerging talents of Ian Anderson, whose flute playing would become the band's trademark.

--- a/src/content/releases/j/jim-morrison/an-american-prayer/index.md
+++ b/src/content/releases/j/jim-morrison/an-american-prayer/index.md
@@ -58,4 +58,6 @@ tracklist_edition: "1978 DE"
 ---
 ## About
 
-An American Prayer is a studio album released posthumously in 1978, pairing spoken-word recordings made by The Doors vocalist Jim Morrison in 1969 and 1970 with new musical accompaniment recorded by the remaining members of The Doors. It is a document of Morrison's considerable gifts as a poet and performer, and includes the track 'A Feast of Friends'.
+*An American Prayer* is a document of Morrison's considerable gifts as a poet and performer, and includes the track 'A Feast of Friends'.
+
+Spoken-word recordings made by Morrison in 1969 and 1970 are paired with later musical accompaniment from the remaining members of The Doors.

--- a/src/content/releases/j/jimi-hendrix/are-you-experienced/index.md
+++ b/src/content/releases/j/jimi-hendrix/are-you-experienced/index.md
@@ -67,6 +67,6 @@ tracklist_edition: "2010 US"
 ---
 ## About
 
-Are You Experienced is a release by Jimi Hendrix released in 2010-07-10. It has been featured on 1 Sundown Sessions show. Featured tracks include Hey Joe.
+*Are You Experienced* earns its place in the Sundown Sessions catalogue through “Hey Joe”, a selection that offers a direct route into Jimi Hendrix's work.
 
-
+Heard in the context of the full release, “Hey Joe” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/j/jimi-hendrix/axis-bold-as-love/index.md
+++ b/src/content/releases/j/jimi-hendrix/axis-bold-as-love/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "1967 FR mono + stereo"
 ---
 ## About
 
-Axis: Bold As Love is a release by Jimi Hendrix released in 1967-12-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Little Wing.
+*Axis: Bold As Love* earns its place in the Sundown Sessions catalogue through “Little Wing”, a selection that offers a direct route into Jimi Hendrix's work.
 
-
+Heard in the context of the full release, “Little Wing” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/j/joe-satriani/flying-in-a-blue-dream/index.md
+++ b/src/content/releases/j/joe-satriani/flying-in-a-blue-dream/index.md
@@ -78,6 +78,6 @@ tracklist_edition: "1989 GB"
 ---
 ## About
 
-Flying In A Blue Dream is a release by Joe Satriani released in 1989-10-30. It has been featured on 1 Sundown Sessions show. Featured tracks include Day at the Beach (New Rays from an Ancient Sun).
+*Flying In A Blue Dream* earns its place in the Sundown Sessions catalogue through “Day at the Beach (New Rays from an Ancient Sun)”, a selection that offers a direct route into Joe Satriani's work.
 
-
+Heard in the context of the full release, “Day at the Beach (New Rays from an Ancient Sun)” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/j/john-grant/queen-of-denmark/index.md
+++ b/src/content/releases/j/john-grant/queen-of-denmark/index.md
@@ -87,6 +87,6 @@ tracklist_edition: "2010 GB"
 ---
 ## About
 
-Queen of Denmark is a release by John Grant released in 2010-04-06. It has been featured on 2 Sundown Sessions shows. Featured tracks include Marz, Where Dreams Go To Die.
+*Queen of Denmark* has supplied Sundown Sessions with “Marz” and “Where Dreams Go To Die”, giving more than one way into John Grant's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/j/john-lennon/mind-games/index.md
+++ b/src/content/releases/j/john-lennon/mind-games/index.md
@@ -30,6 +30,6 @@ tracklist_edition: "1973 DE Keep a/c on labels"
 ---
 ## About
 
-Mind Games is a release by John Lennon released in 1973-10-29. It has been featured on 1 Sundown Sessions show. Featured tracks include Out The Blue.
+*Mind Games* earns its place in the Sundown Sessions catalogue through “Out The Blue”, a selection that offers a direct route into John Lennon's work.
 
-
+Heard in the context of the full release, “Out The Blue” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/j/john-lennon/plastic-ono-band/index.md
+++ b/src/content/releases/j/john-lennon/plastic-ono-band/index.md
@@ -46,10 +46,10 @@ tracklist_edition: "2010-10-01 XW"
 ---
 ## About
 
-Plastic Ono Band is a release by John Lennon released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Love.
+*Plastic Ono Band* earns its place in the Sundown Sessions catalogue through “Love”, a selection that offers a direct route into John Lennon's work.
+
+Heard in the context of the full release, “Love” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Love
-
-

--- a/src/content/releases/j/john-lennon/sometime-in-new-york-city/index.md
+++ b/src/content/releases/j/john-lennon/sometime-in-new-york-city/index.md
@@ -32,10 +32,10 @@ tracklist_edition: "2005 AR"
 ---
 ## About
 
-Sometime In New York City is a release by John Lennon released in 1972. It has been featured on 1 Sundown Sessions show. Featured tracks include New York City.
+*Sometime In New York City* earns its place in the Sundown Sessions catalogue through “New York City”, a selection that offers a direct route into John Lennon's work.
+
+Heard in the context of the full release, “New York City” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - New York City
-
-

--- a/src/content/releases/j/johnny-cash/american-iv-the-man-comes-around/index.md
+++ b/src/content/releases/j/johnny-cash/american-iv-the-man-comes-around/index.md
@@ -58,4 +58,6 @@ tracklist_edition: "2002 US"
 ---
 ## About
 
-American IV - The Man Comes Around is the fourth volume in Johnny Cash's acclaimed American Recordings series, produced by Rick Rubin and released in 2002. It is best known for its devastatingly raw cover of Nine Inch Nails' 'Hurt', accompanied by a music video widely regarded as one of the greatest ever made. The album was released just months before Cash's death in September 2003.
+*American IV - The Man Comes Around* is best known for its devastatingly raw cover of Nine Inch Nails' 'Hurt', accompanied by a music video widely regarded as one of the greatest ever made.
+
+The album was released just months before Cash's death in September 2003.

--- a/src/content/releases/j/joy-division/unknown-pleasures/index.md
+++ b/src/content/releases/j/joy-division/unknown-pleasures/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1979-06-15 GB textured sleeve"
 ---
 ## About
 
-Unknown Pleasures is the debut studio album by Manchester post-punk band Joy Division, released on Factory Records in 1979. Produced by Martin Hannett, its sparse, echoey sound became the defining sonic template of post-punk. The album's influence on subsequent music is immeasurable, and the iconic Peter Saville sleeve design has become one of the most recognisable images in popular culture.
+Produced by Martin Hannett, its sparse, echoey sound became the defining sonic template of post-punk.
+
+The album's influence on subsequent music is immeasurable, and the iconic Peter Saville sleeve design has become one of the most recognisable images in popular culture.

--- a/src/content/releases/j/judas-priest/british-steel/index.md
+++ b/src/content/releases/j/judas-priest/british-steel/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1980 DE"
 ---
 ## About
 
-British Steel is the sixth studio album by Birmingham heavy metal band Judas Priest, released on CBS Records in 1980. It reached number four on the UK Albums Chart and is regarded as one of the defining albums of the New Wave of British Heavy Metal (NWOBHM), featuring the anthemic singles 'Living After Midnight' and 'Breaking the Law'. The album's stripped-down, no-frills approach became a template for metal bands worldwide.
+*British Steel* reached number four on the UK Albums Chart and is regarded as one of the defining albums of the New Wave of British Heavy Metal (NWOBHM), featuring the anthemic singles 'Living After Midnight' and 'Breaking the Law'.
+
+The album's stripped-down, no-frills approach became a template for metal bands worldwide.

--- a/src/content/releases/j/juicy-lucy/juicy-lucy/index.md
+++ b/src/content/releases/j/juicy-lucy/juicy-lucy/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1995 US"
 ---
 ## About
 
-Juicy Lucy is a release by Juicy Lucy released in 1995. It has been featured on 1 Sundown Sessions show. Featured tracks include Mississippi Woman.
+*Juicy Lucy* earns its place in the Sundown Sessions catalogue through “Mississippi Woman”, a selection that offers a direct route into Juicy Lucy's work.
 
-
+Heard in the context of the full release, “Mississippi Woman” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/j/juicy-lucy/who-do-you-love/index.md
+++ b/src/content/releases/j/juicy-lucy/who-do-you-love/index.md
@@ -40,10 +40,10 @@ tracklist_edition: "1992 DE"
 ---
 ## About
 
-Who Do You Love is a release by Juicy Lucy released in 2002. It has been featured on 1 Sundown Sessions show. Featured tracks include Who Do You Love?.
+*Who Do You Love* earns its place in the Sundown Sessions catalogue through “Who Do You Love?”, a selection that offers a direct route into Juicy Lucy's work.
+
+Heard in the context of the full release, “Who Do You Love?” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Who Do You Love?
-
-

--- a/src/content/releases/k/karel-fialka/human-animal/index.md
+++ b/src/content/releases/k/karel-fialka/human-animal/index.md
@@ -61,6 +61,6 @@ tracklist_edition: "1988 US"
 ---
 ## About
 
-Human Animal is a release by Karel Fialka released in 1988. It has been featured on 1 Sundown Sessions show. Featured tracks include Hey Matthew.
+*Human Animal* earns its place in the Sundown Sessions catalogue through “Hey Matthew”, a selection that offers a direct route into Karel Fialka's work.
 
-
+Heard in the context of the full release, “Hey Matthew” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/k/killing-joke/killing-joke/index.md
+++ b/src/content/releases/k/killing-joke/killing-joke/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1980 US"
 ---
 ## About
 
-Killing Joke is the self-titled debut studio album by London post-punk band Killing Joke, released on EG Records in 1980. It reached number 39 on the UK Albums Chart and established the band's distinctive sonic signature: relentless rhythmic drive, abrasive guitars, and Jaz Coleman's howling, apocalyptic vocals. The album was enormously influential on subsequent industrial rock and metal acts.
+*Killing Joke* reached number 39 on the UK Albums Chart and established the band's distinctive sonic signature: relentless rhythmic drive, abrasive guitars, and Jaz Coleman's howling, apocalyptic vocals.
+
+The album was enormously influential on subsequent industrial rock and metal acts.

--- a/src/content/releases/k/killing-joke/night-time/index.md
+++ b/src/content/releases/k/killing-joke/night-time/index.md
@@ -48,6 +48,6 @@ tracklist_edition: "1985 XE"
 ---
 ## About
 
-Night Time is a release by Killing Joke released in 1985-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Love Like Blood.
+*Night Time* earns its place in the Sundown Sessions catalogue through “Love Like Blood”, a selection that offers a direct route into Killing Joke's work.
 
-
+Heard in the context of the full release, “Love Like Blood” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/k/killing-joke/singles-collection-1979-2012/index.md
+++ b/src/content/releases/k/killing-joke/singles-collection-1979-2012/index.md
@@ -147,11 +147,11 @@ tracklist_edition: "2013 XE"
 ---
 ## About
 
-Singles Collection 1979 - 2012 is a release by Killing Joke released in 2013. It has been featured on 2 Sundown Sessions shows. Featured tracks include Eighties, Kings And Queens.
+*Singles Collection 1979 - 2012* has supplied Sundown Sessions with “Eighties” and “Kings And Queens”, giving more than one way into Killing Joke's work.
+
+Together, those choices point beyond isolated favourites towards the character of the wider release.
 
 ## Tracks Featured on Sundown Sessions
 
 - Eighties
 - Kings And Queens
-
-

--- a/src/content/releases/k/killing-kind/killing-kind/index.md
+++ b/src/content/releases/k/killing-kind/killing-kind/index.md
@@ -43,6 +43,6 @@ tracklist_edition: "2023-01-27 XW"
 ---
 ## About
 
-Killing Kind is a release by Killing Kind released in 2023-01-27. It has been featured on 1 Sundown Sessions show. Featured tracks include This Beautiful World.
+*Killing Kind* earns its place in the Sundown Sessions catalogue through “This Beautiful World”, a selection that offers a direct route into Killing Kind's work.
 
-
+Heard in the context of the full release, “This Beautiful World” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/k/king-crimson/in-the-court-of-the-crimson-king/index.md
+++ b/src/content/releases/k/king-crimson/in-the-court-of-the-crimson-king/index.md
@@ -29,4 +29,6 @@ tracklist_edition: "1969 NL"
 ---
 ## About
 
-In the Court of the Crimson King is the debut studio album by London progressive rock group King Crimson, released on Island Records in 1969. It reached number five on the UK Albums Chart and is universally regarded as the founding document of progressive rock, combining extended instrumental passages, unconventional time signatures, and literary lyrical ambition. The album's influence on subsequent music is immeasurable.
+*In the Court of the Crimson King* reached number five on the UK Albums Chart and is universally regarded as the founding document of progressive rock, combining extended instrumental passages, unconventional time signatures, and literary lyrical ambition.
+
+The album's influence on subsequent music is immeasurable.

--- a/src/content/releases/k/kirsten-adamson/landing-place/index.md
+++ b/src/content/releases/k/kirsten-adamson/landing-place/index.md
@@ -38,6 +38,6 @@ tracklist_edition: "2023-02-03 GB"
 ---
 ## About
 
-Landing Place is a release by Kirsten Adamson released in 2023-02-03. It has been featured on 1 Sundown Sessions show. Featured tracks include My Father's Songs.
+*Landing Place* earns its place in the Sundown Sessions catalogue through “My Father's Songs”, a selection that offers a direct route into Kirsten Adamson's work.
 
-
+Heard in the context of the full release, “My Father's Songs” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/k/kirsten-adamson/take-me-as-i-am/index.md
+++ b/src/content/releases/k/kirsten-adamson/take-me-as-i-am/index.md
@@ -16,9 +16,10 @@ tracks:
 ---
 ## About
 
-Take Me As I Am is a release by Kirsten Adamson released in 2023. It has been featured on 1 Sundown Sessions show. Featured tracks include Take Me As I Am.
+*Take Me As I Am* earns its place in the Sundown Sessions catalogue through “Take Me As I Am”, a selection that offers a direct route into Kirsten Adamson's work.
+
+Heard in the context of the full release, “Take Me As I Am” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Take Me As I Am
-

--- a/src/content/releases/k/kristin-hersh/hips-and-makers/index.md
+++ b/src/content/releases/k/kristin-hersh/hips-and-makers/index.md
@@ -68,6 +68,6 @@ tracklist_edition: "1994 DE"
 ---
 ## About
 
-Hips and Makers is a release by Kristin Hersh released in 1994-01-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Your Ghost.
+*Hips and Makers* earns its place in the Sundown Sessions catalogue through “Your Ghost”, a selection that offers a direct route into Kristin Hersh's work.
 
-
+Heard in the context of the full release, “Your Ghost” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/k/kubb/mother/index.md
+++ b/src/content/releases/k/kubb/mother/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "2005-11-14 GB"
 ---
 ## About
 
-Mother is a release by Kubb released in 2005-11-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Wicked Soul.
+*Mother* earns its place in the Sundown Sessions catalogue through “Wicked Soul”, a selection that offers a direct route into Kubb's work.
 
-
+Heard in the context of the full release, “Wicked Soul” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/k/kula-shaker/kollected-the-best-of-kula-shaker/index.md
+++ b/src/content/releases/k/kula-shaker/kollected-the-best-of-kula-shaker/index.md
@@ -70,4 +70,6 @@ tracklist_edition: "2002-12-16 XW"
 ---
 ## About
 
-Kollected: The Best of Kula Shaker is a compilation album by British psychedelic rock band Kula Shaker, released in 2002. It draws together their most celebrated singles and album tracks, including 'Hush' and 'Tattva'. The band rose to prominence in the mid-1990s Britpop era, blending classic rock with Eastern mysticism.
+*Kollected - The Best of Kula Shaker* draws together their most celebrated singles and album tracks, including 'Hush' and 'Tattva'.
+
+The band rose to prominence in the mid-1990s Britpop era, blending classic rock with Eastern mysticism.

--- a/src/content/releases/l/led-zeppelin/houses-of-the-holy/index.md
+++ b/src/content/releases/l/led-zeppelin/houses-of-the-holy/index.md
@@ -38,4 +38,6 @@ tracklist_edition: "1973 CA"
 ---
 ## About
 
-Houses of the Holy is the fifth studio album by British rock band Led Zeppelin, released on Atlantic Records in 1973. It topped the UK Albums Chart and further expanded the band's sonic palette beyond blues rock to incorporate reggae, funk, and even touches of Eastern music. The album includes 'The Song Remains the Same' and 'Over the Hills and Far Away'.
+*Houses of the Holy* includes 'The Song Remains the Same' and 'Over the Hills and Far Away'.
+
+It topped the UK Albums Chart and further expanded the band's sonic palette beyond blues rock to incorporate reggae, funk, and even touches of Eastern music.

--- a/src/content/releases/l/led-zeppelin/led-zeppelin-ii/index.md
+++ b/src/content/releases/l/led-zeppelin/led-zeppelin-ii/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1969 US RL Monarch"
 ---
 ## About
 
-Led Zeppelin II is the second studio album by British rock band Led Zeppelin, released on Atlantic Records in 1969. It topped the UK Albums Chart and includes some of the band's most celebrated and influential tracks, including 'Whole Lotta Love' and 'Ramble On'. The album is considered one of the defining works of hard rock and heavy metal.
+*Led Zeppelin II* is considered one of the defining works of hard rock and heavy metal.
+
+It topped the UK Albums Chart and includes some of the band's most celebrated and influential tracks, including 'Whole Lotta Love' and 'Ramble On'.

--- a/src/content/releases/l/led-zeppelin/led-zeppelin-iii-remaster/index.md
+++ b/src/content/releases/l/led-zeppelin/led-zeppelin-iii-remaster/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "2005-05-25 JP 2005 Japanese remaster"
 ---
 ## About
 
-Led Zeppelin III (Remaster) is a release by Led Zeppelin released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Since I've Been Loving You - Remaster.
+*Led Zeppelin III (Remaster)* earns its place in the Sundown Sessions catalogue through “Since I've Been Loving You - Remaster”, a selection that offers a direct route into Led Zeppelin's work.
+
+Heard in the context of the full release, “Since I've Been Loving You - Remaster” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Since I've Been Loving You - Remaster
-
-

--- a/src/content/releases/l/led-zeppelin/led-zeppelin/index.md
+++ b/src/content/releases/l/led-zeppelin/led-zeppelin/index.md
@@ -45,6 +45,6 @@ tracklist_edition: "1969-03-31 GB"
 ---
 ## About
 
-Led Zeppelin is a release by Led Zeppelin released in 2001. It has been featured on 1 Sundown Sessions show. Featured tracks include I Can't Quit You Baby.
+*Led Zeppelin* earns its place in the Sundown Sessions catalogue through “I Can't Quit You Baby”, a selection that offers a direct route into Led Zeppelin's work.
 
-
+Heard in the context of the full release, “I Can't Quit You Baby” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/l/leftfield/leftism/index.md
+++ b/src/content/releases/l/leftfield/leftism/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1995 US"
 ---
 ## About
 
-Leftism is the debut studio album by London electronic music duo Leftfield, released on Hard Hands Records in 1995. It reached number three on the UK Albums Chart and is regarded as one of the most important electronic albums of the decade, blending progressive house, dub, and breakbeat. The album features the UK top-twenty single 'Original' and the politically charged anthem 'Open Up', featuring John Lydon.
+*Leftism* reached number three on the UK Albums Chart and is regarded as one of the most important electronic albums of the decade, blending progressive house, dub, and breakbeat.
+
+The album features the UK top-twenty single 'Original' and the politically charged anthem 'Open Up', featuring John Lydon.

--- a/src/content/releases/l/lenny-kravitz/are-you-gonna-go-my-way/index.md
+++ b/src/content/releases/l/lenny-kravitz/are-you-gonna-go-my-way/index.md
@@ -36,6 +36,6 @@ tracklist_edition: "1993 XE CD1"
 ---
 ## About
 
-Are You Gonna Go My Way is a release by Lenny Kravitz released in 1993. It has been featured on 1 Sundown Sessions show. Featured tracks include Are You Gonna Go My Way.
+*Are You Gonna Go My Way* earns its place in the Sundown Sessions catalogue through “Are You Gonna Go My Way”, a selection that offers a direct route into Lenny Kravitz's work.
 
-
+Heard in the context of the full release, “Are You Gonna Go My Way” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/l/live/throwing-copper/index.md
+++ b/src/content/releases/l/live/throwing-copper/index.md
@@ -85,10 +85,10 @@ tracklist_edition: "1994 XE Limited Edition"
 ---
 ## About
 
-Throwing Copper is a release by Live released in 1994. It has been featured on 1 Sundown Sessions show. Featured tracks include Selling The Drama.
+*Throwing Copper* earns its place in the Sundown Sessions catalogue through “Selling The Drama”, a selection that offers a direct route into Live's work.
+
+Heard in the context of the full release, “Selling The Drama” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Selling The Drama
-
-

--- a/src/content/releases/l/lloyd-cole-and-the-commotions/mainstream/index.md
+++ b/src/content/releases/l/lloyd-cole-and-the-commotions/mainstream/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-Mainstream is a release by Lloyd Cole and the Commotions released in 1987-10-26. It has been featured on 1 Sundown Sessions show. Featured tracks include My Bag.
+*Mainstream* earns its place in the Sundown Sessions catalogue through “My Bag”, a selection that offers a direct route into Lloyd Cole and the Commotions's work.
 
-
+Heard in the context of the full release, “My Bag” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/l/lloyd-cole-the-commotions/rattlesnakes/index.md
+++ b/src/content/releases/l/lloyd-cole-the-commotions/rattlesnakes/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1984 US"
 ---
 ## About
 
-Rattlesnakes is the debut studio album by Lloyd Cole & the Commotions, released on Polydor Records in 1984. It reached number 13 on the UK Albums Chart and announced Cole as one of the most gifted lyricists of his generation. Influenced by Velvet Underground, the Byrds, and the literary tradition of Kafka and Simone de Beauvoir, the album remains one of the finest British indie debuts of the 1980s.
+Influenced by Velvet Underground, the Byrds, and the literary tradition of Kafka and Simone de Beauvoir, *Rattlesnakes* remains one of the finest British indie debuts of the 1980s.
+
+It reached number 13 on the UK Albums Chart and announced Cole as one of the most gifted lyricists of his generation.

--- a/src/content/releases/l/love-and-rockets/express/index.md
+++ b/src/content/releases/l/love-and-rockets/express/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1986 US"
 ---
 ## About
 
-Express is a release by Love and Rockets released in 1986-09-15. It has been featured on 1 Sundown Sessions show. Featured tracks include Kundalini Express.
+*Express* earns its place in the Sundown Sessions catalogue through “Kundalini Express”, a selection that offers a direct route into Love and Rockets's work.
 
-
+Heard in the context of the full release, “Kundalini Express” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/l/love/da-capo/index.md
+++ b/src/content/releases/l/love/da-capo/index.md
@@ -34,4 +34,6 @@ tracklist_edition: "1967 US"
 ---
 ## About
 
-Da Capo is the second studio album by Los Angeles psychedelic rock band Love, released on Elektra Records in 1967. Led by Arthur Lee, the album blends folk, garage rock, R&B, and psychedelia into something genuinely eclectic and unique. The album is notable for the 18-minute Side Two track 'Revelation', which showcases the band's improvisational ambitions.
+*Da Capo* is notable for the 18-minute Side Two track 'Revelation', which showcases the band's improvisational ambitions.
+
+Led by Arthur Lee, the album blends folk, garage rock, R&B, and psychedelia into something genuinely eclectic and unique.

--- a/src/content/releases/l/love/forever-changes/index.md
+++ b/src/content/releases/l/love/forever-changes/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1967 US mono"
 ---
 ## About
 
-Forever Changes is a release by Love released in 1967-11-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Alone Again Or.
+*Forever Changes* earns its place in the Sundown Sessions catalogue through “Alone Again Or”, a selection that offers a direct route into Love's work.
 
-
+Heard in the context of the full release, “Alone Again Or” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/l/love/love/index.md
+++ b/src/content/releases/l/love/love/index.md
@@ -39,6 +39,6 @@ tracklist_edition: "2017-09-06 JP Type B"
 ---
 ## About
 
-Love is a release by Love released in 2017-09-06. It has been featured on 1 Sundown Sessions show. Featured tracks include My Flash On You.
+*Love* earns its place in the Sundown Sessions catalogue through “My Flash On You”, a selection that offers a direct route into Love's work.
 
-
+Heard in the context of the full release, “My Flash On You” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/l/lush/split/index.md
+++ b/src/content/releases/l/lush/split/index.md
@@ -74,4 +74,6 @@ tracklist_edition: "1994 BE limited edition"
 ---
 ## About
 
-Split is the second studio album by London shoegazing band Lush, released on 4AD in 1994. It reached number 19 on the UK Albums Chart and is regarded as their most consistent and accessible record, with Miki Berenyi and Emma Anderson's songwriting at its most focused. The album appeared at the intersection of shoegaze and Britpop and helped establish Lush as one of the most enduring acts on the 4AD roster.
+*Split* reached number 19 on the UK Albums Chart and is regarded as their most consistent and accessible record, with Miki Berenyi and Emma Anderson's songwriting at its most focused.
+
+The album appeared at the intersection of shoegaze and Britpop and helped establish Lush as one of the most enduring acts on the 4AD roster.

--- a/src/content/releases/m/madness/complete-madness/index.md
+++ b/src/content/releases/m/madness/complete-madness/index.md
@@ -62,4 +62,6 @@ tracklist_edition: "1982 GB"
 ---
 ## About
 
-Complete Madness is the first compilation album by Camden ska revival band Madness, released on Stiff Records in 1982. It reached number one on the UK Albums Chart and gathered together the band's most beloved singles, including 'One Step Beyond', 'My Girl', 'Baggy Trousers', and 'House of Fun'. It remains one of the most successful British compilations ever released.
+*Complete Madness* remains one of the most successful British compilations ever released.
+
+It reached number one on the UK Albums Chart and gathered together the band's most beloved singles, including 'One Step Beyond', 'My Girl', 'Baggy Trousers', and 'House of Fun'.

--- a/src/content/releases/m/magazine/real-life/index.md
+++ b/src/content/releases/m/magazine/real-life/index.md
@@ -40,4 +40,6 @@ tracklist_edition: "1978 DE"
 ---
 ## About
 
-Real Life is the debut studio album by Manchester post-punk band Magazine, released on Virgin Records in 1978. Formed by Howard Devoto after his departure from the Buzzcocks, Magazine established a distinctive sound that blended punk's energy with keyboards, jazz influences, and literary lyrics. 'The Light Pours Out of Me' is one of the album's most celebrated tracks.
+Formed by Howard Devoto after his departure from the Buzzcocks, Magazine established a distinctive sound that blended punk's energy with keyboards, jazz influences, and literary lyrics.
+
+'The Light Pours Out of Me' is one of the album's most celebrated tracks.

--- a/src/content/releases/m/magazine/secondhand-daylight/index.md
+++ b/src/content/releases/m/magazine/secondhand-daylight/index.md
@@ -40,4 +40,6 @@ tracklist_edition: "1979 GB"
 ---
 ## About
 
-Secondhand Daylight is the second studio album by Manchester post-punk band Magazine, released on Virgin Records in 1979. The album refines the angular art-rock of their debut Real Life, with Barry Adamson's bass lines and Dave Formula's keyboards creating a more cinematic and atmospheric sound. It is regarded as one of the most sophisticated records of the post-punk era.
+*Secondhand Daylight* is regarded as one of the most sophisticated records of the post-punk era.
+
+The album refines the angular art-rock of their debut Real Life, with Barry Adamson's bass lines and Dave Formula's keyboards creating a more cinematic and atmospheric sound.

--- a/src/content/releases/m/mansun/attack-of-the-grey-lantern/index.md
+++ b/src/content/releases/m/mansun/attack-of-the-grey-lantern/index.md
@@ -47,4 +47,4 @@ tracklist_edition: "1997 AU"
 ---
 ## About
 
-Attack of the Grey Lantern is the debut studio album by Chester art pop band Mansun, released on Parlophone in 1997. It debuted at number one on the UK Albums Chart and became one of the most critically celebrated debut albums of the Britpop era, showcasing the band's ambitious blend of glam rock, art pop, and progressive influences under singer Paul Draper's idiosyncratic vision.
+*Attack of the Grey Lantern* debuted at number one on the UK Albums Chart and became one of the most critically celebrated debut albums of the Britpop era, showcasing the band's ambitious blend of glam rock, art pop, and progressive influences under singer Paul Draper's idiosyncratic vision.

--- a/src/content/releases/m/marc-bolan/the-t-rex-wax-co-singles-as-and-bs-1972-77/index.md
+++ b/src/content/releases/m/marc-bolan/the-t-rex-wax-co-singles-as-and-bs-1972-77/index.md
@@ -73,10 +73,10 @@ tracklist_edition: "XE"
 ---
 ## About
 
-The T.Rex Wax Co. Singles A's & B's 1972-77 is a release by Marc Bolan released in 2002. It has been featured on 1 Sundown Sessions show. Featured tracks include Children Of The Revolution.
+*The T.Rex Wax Co. Singles A's & B's 1972-77* earns its place in the Sundown Sessions catalogue through “Children Of The Revolution”, a selection that offers a direct route into Marc Bolan's work.
+
+Heard in the context of the full release, “Children Of The Revolution” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Children Of The Revolution
-
-

--- a/src/content/releases/m/maria-mckee/you-gotta-sin-to-get-saved/index.md
+++ b/src/content/releases/m/maria-mckee/you-gotta-sin-to-get-saved/index.md
@@ -52,6 +52,6 @@ tracklist_edition: "1993 GB"
 ---
 ## About
 
-You Gotta Sin To Get Saved is a release by Maria McKee released in 1993-06-22. It has been featured on 1 Sundown Sessions show. Featured tracks include I Can't Make It Alone.
+*You Gotta Sin To Get Saved* earns its place in the Sundown Sessions catalogue through “I Can't Make It Alone”, a selection that offers a direct route into Maria McKee's work.
 
-
+Heard in the context of the full release, “I Can't Make It Alone” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/m/massive-attack/blue-lines/index.md
+++ b/src/content/releases/m/massive-attack/blue-lines/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1991 GB"
 ---
 ## About
 
-Blue Lines is the debut studio album by Bristol collective Massive Attack, released in 1991. It reached number 13 on the UK Albums Chart and is widely regarded as the founding document of trip-hop, blending hip-hop, soul, and ambient music into something genuinely new. The album features guest vocalists Shara Nelson, Horace Andy, and Tricky, and includes 'Unfinished Sympathy', one of the most celebrated British tracks of the decade.
+*Blue Lines* reached number 13 on the UK Albums Chart and is widely regarded as the founding document of trip-hop, blending hip-hop, soul, and ambient music into something genuinely new.
+
+The album features guest vocalists Shara Nelson, Horace Andy, and Tricky, and includes 'Unfinished Sympathy', one of the most celebrated British tracks of the decade.

--- a/src/content/releases/m/masters-of-reality/pine-cross-dover/index.md
+++ b/src/content/releases/m/masters-of-reality/pine-cross-dover/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "2009-08-24 XE"
 ---
 ## About
 
-Pine/Cross Dover is a release by Masters Of Reality released in 2009-08-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Dreamtime Stomp.
+*Pine/Cross Dover* earns its place in the Sundown Sessions catalogue through “Dreamtime Stomp”, a selection that offers a direct route into Masters Of Reality's work.
 
-
+Heard in the context of the full release, “Dreamtime Stomp” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/m/masters-of-reality/sunrise-on-the-sufferbus/index.md
+++ b/src/content/releases/m/masters-of-reality/sunrise-on-the-sufferbus/index.md
@@ -61,4 +61,6 @@ tracklist_edition: "1992 US"
 ---
 ## About
 
-*Sunrise on the Sufferbus* is the second studio album by Masters of Reality, released by Chrysalis in 1992. With Ginger Baker playing drums and Chris Goss producing, it folds blues, psychedelia and heavy rock into an unusually loose, exploratory record. “100 Years (Of Tears to the Wind)” is Show #2's way into that collaboration.
+With Ginger Baker playing drums and Chris Goss producing, *Sunrise on the Sufferbus* folds blues, psychedelia and heavy rock into an unusually loose, exploratory record.
+
+“100 Years (Of Tears to the Wind)” is Show #2's way into that collaboration.

--- a/src/content/releases/m/may-blitz/may-blitz/index.md
+++ b/src/content/releases/m/may-blitz/may-blitz/index.md
@@ -45,6 +45,6 @@ tracklist_edition: "1970 GB"
 ---
 ## About
 
-May Blitz is a release by May Blitz released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include I Don't Know?.
+*May Blitz* earns its place in the Sundown Sessions catalogue through “I Don't Know?”, a selection that offers a direct route into May Blitz's work.
 
-
+Heard in the context of the full release, “I Don't Know?” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/m/mean-gene-kelton/most-requested/index.md
+++ b/src/content/releases/m/mean-gene-kelton/most-requested/index.md
@@ -61,6 +61,6 @@ tracklist_edition: ""
 ---
 ## About
 
-Most Requested is a release by Mean Gene Kelton released in 1999. It has been featured on 1 Sundown Sessions show. Featured tracks include My Baby Don't Wear No Panties.
+*Most Requested* earns its place in the Sundown Sessions catalogue through “My Baby Don't Wear No Panties”, a selection that offers a direct route into Mean Gene Kelton's work.
 
-
+Heard in the context of the full release, “My Baby Don't Wear No Panties” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/m/melys/chinese-whispers/index.md
+++ b/src/content/releases/m/melys/chinese-whispers/index.md
@@ -31,6 +31,6 @@ tracklist_edition: "2001 GB"
 ---
 ## About
 
-Chinese Whispers is a release by Melys released in 2001. It has been featured on 1 Sundown Sessions show. Featured tracks include Chinese Whispers.
+*Chinese Whispers* earns its place in the Sundown Sessions catalogue through “Chinese Whispers”, a selection that offers a direct route into Melys's work.
 
-
+Heard in the context of the full release, “Chinese Whispers” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/m/menswear/nuisance/index.md
+++ b/src/content/releases/m/menswear/nuisance/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1995 US"
 ---
 ## About
 
-Nuisance is the debut studio album by London indie pop band Menswear, released on Laurel Records in 1995. It reached number 11 on the UK Albums Chart and captured the band at the height of their Britpop-era celebrity. Though subject to critical ambivalence at the time, the album is now regarded as a solid document of the mid-1990s UK indie scene.
+Though subject to critical ambivalence at the time, *Nuisance* is now regarded as a solid document of the mid-1990s UK indie scene.
+
+It reached number 11 on the UK Albums Chart and captured the band at the height of their Britpop-era celebrity.

--- a/src/content/releases/m/metallica/load/index.md
+++ b/src/content/releases/m/metallica/load/index.md
@@ -68,6 +68,6 @@ tracklist_edition: "1996 XE PMDC France pressing, BIEM/MCPS on disc"
 ---
 ## About
 
-Load is a release by Metallica released in 1996-05-04. It has been featured on 2 Sundown Sessions shows. Featured tracks include King Nothing.
+*Load* earns its place in the Sundown Sessions catalogue through “King Nothing”, a selection that offers a direct route into Metallica's work.
 
-
+Heard in the context of the full release, “King Nothing” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/m/moby-grape/moby-grape/index.md
+++ b/src/content/releases/m/moby-grape/moby-grape/index.md
@@ -52,4 +52,6 @@ tracklist_edition: "1967-06 US stereo"
 ---
 ## About
 
-Moby Grape is the self-titled debut studio album by San Francisco psychedelic rock band Moby Grape, released on Columbia Records in 1967. The album is remarkable for its consistent quality, with five strong songwriters contributing across a blend of folk, country, blues, and psychedelia. Despite its commercial failure at the time, it is now regarded as one of the finest debut albums of the psychedelic era.
+Despite its commercial failure at the time, *Moby Grape* is now regarded as one of the finest debut albums of the psychedelic era.
+
+The album is remarkable for its consistent quality, with five strong songwriters contributing across a blend of folk, country, blues, and psychedelia.

--- a/src/content/releases/m/motorhead/ace-of-spades/index.md
+++ b/src/content/releases/m/motorhead/ace-of-spades/index.md
@@ -21,4 +21,6 @@ tracklist_edition: "1980-10 GB"
 ---
 ## About
 
-Ace of Spades is the fourth studio album by British rock band Motörhead, released on Bronze Records in 1980. It reached number four on the UK Albums Chart and includes the iconic title track, one of the most recognisable riffs in rock music. The album cemented Motörhead's status as one of the heaviest and most uncompromising acts in British rock history.
+*Ace of Spades* cemented Motörhead's status as one of the heaviest and most uncompromising acts in British rock history.
+
+It reached number four on the UK Albums Chart and includes the iconic title track, one of the most recognisable riffs in rock music.

--- a/src/content/releases/m/mountain/climbing/index.md
+++ b/src/content/releases/m/mountain/climbing/index.md
@@ -40,4 +40,6 @@ tracklist_edition: "1970 US Monarch pressing"
 ---
 ## About
 
-Climbing! is the debut studio album by American hard rock band Mountain, released on Windfall Records in 1970. The album features the band's best-known track, 'Mississippi Queen', and established Mountain as one of the heaviest American rock acts of the era. Guitarist Leslie West's massive, overdriven tone was a defining influence on subsequent heavy rock music.
+Guitarist Leslie West's massive, overdriven tone was a defining influence on subsequent heavy rock music.
+
+The album features the band's best-known track, 'Mississippi Queen', and established Mountain as one of the heaviest American rock acts of the era.

--- a/src/content/releases/m/muse/absolution/index.md
+++ b/src/content/releases/m/muse/absolution/index.md
@@ -62,4 +62,6 @@ tracklist_edition: "2003 DE"
 ---
 ## About
 
-Absolution is the third studio album by Teignmouth rock trio Muse, released in 2003. It entered the UK Albums Chart at number one and went on to sell over five million copies worldwide. The album showcases the band at their most symphonic, blending progressive rock with heavy metal and orchestral arrangements on tracks such as 'Hysteria' and 'Sing for Absolution'.
+*Absolution* showcases the band at their most symphonic, blending progressive rock with heavy metal and orchestral arrangements on tracks such as 'Hysteria' and 'Sing for Absolution'.
+
+It entered the UK Albums Chart at number one and went on to sell over five million copies worldwide.

--- a/src/content/releases/m/my-bloody-valentine/loveless/index.md
+++ b/src/content/releases/m/my-bloody-valentine/loveless/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1991 CA"
 ---
 ## About
 
-Loveless is the second studio album by Irish-British shoegazing band My Bloody Valentine, released on Creation Records in 1991. It reached number 24 on the UK Albums Chart and is widely regarded as the definitive shoegaze album and one of the greatest records ever made. Kevin Shields' revolutionary use of tremolo and pitch-shifting created a new vocabulary for electric guitar and changed the direction of alternative rock permanently.
+*Loveless* reached number 24 on the UK Albums Chart and is widely regarded as the definitive shoegaze album and one of the greatest records ever made.
+
+Kevin Shields' revolutionary use of tremolo and pitch-shifting created a new vocabulary for electric guitar and changed the direction of alternative rock permanently.

--- a/src/content/releases/n/nadine-shah/filthy-underneath/index.md
+++ b/src/content/releases/n/nadine-shah/filthy-underneath/index.md
@@ -55,6 +55,6 @@ tracklist_edition: "2024-02-23 GB"
 ---
 ## About
 
-Filthy Underneath is a release by Nadine Shah released in 2024-02-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Greatest Dancer.
+*Filthy Underneath* earns its place in the Sundown Sessions catalogue through “Greatest Dancer”, a selection that offers a direct route into Nadine Shah's work.
 
-
+Heard in the context of the full release, “Greatest Dancer” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/n/nancy-sinatra/nancy-in-london/index.md
+++ b/src/content/releases/n/nancy-sinatra/nancy-in-london/index.md
@@ -56,6 +56,6 @@ tracklist_edition: "1966 US stereo"
 ---
 ## About
 
-Nancy In London is a release by Nancy Sinatra released in 1966. It has been featured on 1 Sundown Sessions show. Featured tracks include Friday's Child.
+*Nancy In London* earns its place in the Sundown Sessions catalogue through “Friday's Child”, a selection that offers a direct route into Nancy Sinatra's work.
 
-
+Heard in the context of the full release, “Friday's Child” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/n/nazareth/razamanaz/index.md
+++ b/src/content/releases/n/nazareth/razamanaz/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1973 US"
 ---
 ## About
 
-Razamanaz is the third studio album by Dunfermline hard rock band Nazareth, released on Mooncrest Records in 1973. It reached number 11 on the UK Albums Chart and marked the commercial breakthrough of the band with the UK hit singles 'Broken Down Angel' and 'Bad Bad Boy'. Produced by Roger Glover of Deep Purple, it remains one of their most celebrated records.
+*Razamanaz* reached number 11 on the UK Albums Chart and marked the commercial breakthrough of the band with the UK hit singles 'Broken Down Angel' and 'Bad Bad Boy'.
+
+Produced by Roger Glover of Deep Purple, it remains one of their most celebrated records.

--- a/src/content/releases/n/nazareth/the-anthology/index.md
+++ b/src/content/releases/n/nazareth/the-anthology/index.md
@@ -175,6 +175,6 @@ tracklist_edition: "2009 GB"
 ---
 ## About
 
-The Anthology is a release by Nazareth released in 2009-01-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Bad, Bad Boy.
+*The Anthology* has supplied Sundown Sessions with “Bad” and “Bad Boy”, giving more than one way into Nazareth's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/n/nazz/nazz/index.md
+++ b/src/content/releases/n/nazz/nazz/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1968 US"
 ---
 ## About
 
-Nazz is a release by Nazz released in 1968. It has been featured on 1 Sundown Sessions show. Featured tracks include Open My Eyes.
+*Nazz* earns its place in the Sundown Sessions catalogue through “Open My Eyes”, a selection that offers a direct route into Nazz's work.
 
-
+Heard in the context of the full release, “Open My Eyes” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/n/neil-young/living-with-war/index.md
+++ b/src/content/releases/n/neil-young/living-with-war/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "2006 AU"
 ---
 ## About
 
-Living with War is a release by Neil Young released in 2006-05-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Heart Of Gold.
+*Living with War* earns its place in the Sundown Sessions catalogue through “Heart Of Gold”, a selection that offers a direct route into Neil Young's work.
 
-
+Heard in the context of the full release, “Heart Of Gold” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/n/new-order/technique/index.md
+++ b/src/content/releases/n/new-order/technique/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1989 US SRC Pressing"
 ---
 ## About
 
-Technique is the fifth studio album by Manchester electronic rock band New Order, released on Factory Records in 1989. It debuted at number one on the UK Albums Chart, making it the band's first chart-topper. The album was partly recorded in Ibiza and blends the band's post-punk roots with the influence of acid house, resulting in one of their most dancefloor-oriented and commercially successful records.
+*Technique* was partly recorded in Ibiza and blends the band's post-punk roots with the influence of acid house, resulting in one of their most dancefloor-oriented and commercially successful records.
+
+It debuted at number one on the UK Albums Chart, making it the band's first chart-topper.

--- a/src/content/releases/n/nick-cave-and-the-bad-seeds/from-her-to-eternity/index.md
+++ b/src/content/releases/n/nick-cave-and-the-bad-seeds/from-her-to-eternity/index.md
@@ -20,9 +20,10 @@ tracks:
 ---
 ## About
 
-From Her to Eternity is a release by Nick Cave & The Bad Seeds released in 2009. It has been featured on 1 Sundown Sessions show. Featured tracks include From Her to Eternity.
+*From Her to Eternity* earns its place in the Sundown Sessions catalogue through “From Her to Eternity”, a selection that offers a direct route into Nick Cave & The Bad Seeds's work.
+
+Heard in the context of the full release, “From Her to Eternity” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - From Her to Eternity
-

--- a/src/content/releases/n/nick-cave-the-bad-seeds/abattoir-blues-the-lyre-of-orpheus/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/abattoir-blues-the-lyre-of-orpheus/index.md
@@ -39,4 +39,4 @@ tracklist_edition: "2004 RU"
 ---
 ## About
 
-Abattoir Blues / The Lyre of Orpheus is the thirteenth studio album by Australian rock group Nick Cave & the Bad Seeds, released as a double album on Mute Records in 2004. It reached number two on the UK Albums Chart and is regarded as a resurgent work, with Abattoir Blues featuring an unexpectedly ferocious, gospel-infused rock sound and The Lyre of Orpheus providing a more reflective counterpoint.
+*Abattoir Blues / The Lyre of Orpheus* reached number two on the UK Albums Chart and is regarded as a resurgent work, with Abattoir Blues featuring an unexpectedly ferocious, gospel-infused rock sound and The Lyre of Orpheus providing a more reflective counterpoint.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/dig-lazarus-dig/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/dig-lazarus-dig/index.md
@@ -21,4 +21,6 @@ tracklist_edition: "2008-02-18 GB"
 ---
 ## About
 
-Dig, Lazarus, Dig!!! is the fourteenth studio album by Nick Cave & the Bad Seeds, released on Mute Records in 2008. It reached number four on the UK Albums Chart and represented a return to a more energetic, rock-driven sound. The album draws on the mythology of Lazarus as a lens through which to examine modern alienation and celebrity culture.
+*Dig, Lazarus, Dig!!!* represented a return to a more energetic, rock-driven sound and reached number four on the UK Albums Chart.
+
+The record draws on the mythology of Lazarus as a lens through which to examine modern alienation and celebrity culture.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/ghosteen/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/ghosteen/index.md
@@ -59,4 +59,6 @@ tracklist_edition: "2019-10-03 XW"
 ---
 ## About
 
-Ghosteen is the seventeenth studio album by Nick Cave & the Bad Seeds, released in 2019. It reached number two on the UK Albums Chart and is a meditation on grief, loss, and the possibility of transcendence, continuing the reflective journey begun on Skeleton Tree. The album features Cave's most ambient and oceanic sound to date, co-created with Warren Ellis.
+*Ghosteen* features Cave's most ambient and oceanic sound to date, co-created with Warren Ellis.
+
+It reached number two on the UK Albums Chart and is a meditation on grief, loss, and the possibility of transcendence, continuing the reflective journey begun on Skeleton Tree.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/henrys-dream/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/henrys-dream/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1992 US"
 ---
 ## About
 
-Henry's Dream is the eighth studio album by Nick Cave & the Bad Seeds, released on Mute Records in 1992. Produced by David Briggs, the album has a rawer, more direct sound compared to its predecessor The Good Son. Cave's songwriting continues to draw on Southern Gothic imagery and Old Testament themes, and the album includes the ferocious 'Papa Won't Leave You, Henry'.
+Cave's songwriting continues to draw on Southern Gothic imagery and Old Testament themes, and the album includes the ferocious 'Papa Won't Leave You, Henry'.
+
+Produced by David Briggs, the album has a rawer, more direct sound compared to its predecessor The Good Son.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/let-love-in/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/let-love-in/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1994 AU"
 ---
 ## About
 
-Let Love In is the ninth studio album by Nick Cave & the Bad Seeds, released on Mute Records in 1994. The album includes the scorched, guitar-driven 'Do You Love Me?' and the tender 'Red Right Hand', which became one of the group's signature pieces. It represents the band at their most viscerally powerful and is widely regarded as a landmark of their classic period.
+*Let Love In* includes the scorched, guitar-driven 'Do You Love Me?' and the tender 'Red Right Hand', which became one of the group's signature pieces.
+
+It represents the band at their most viscerally powerful and is widely regarded as a landmark of their classic period.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/murder-ballads/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/murder-ballads/index.md
@@ -45,4 +45,6 @@ tracklist_edition: "1996 GB"
 ---
 ## About
 
-Murder Ballads is the ninth studio album by Nick Cave & the Bad Seeds, released on Mute Records in 1996. It reached number eight on the UK Albums Chart and is a theatrical collection of murder narratives, featuring guest appearances from PJ Harvey, Kylie Minogue, and Shane MacGowan. The duet with Minogue, 'Where the Wild Roses Grow', became a UK top-ten single and one of Cave's most iconic songs.
+The duet with Minogue, 'Where the Wild Roses Grow', became a UK top-ten single and one of Cave's most iconic songs.
+
+It reached number eight on the UK Albums Chart and is a theatrical collection of murder narratives, featuring guest appearances from PJ Harvey, Kylie Minogue, and Shane MacGowan.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/no-more-shall-we-part/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/no-more-shall-we-part/index.md
@@ -191,4 +191,6 @@ tracklist_edition: "2001 None"
 ---
 ## About
 
-No More Shall We Part is the twelfth studio album by Nick Cave & the Bad Seeds, released on Mute Records in 2001. It reached number 16 on the UK Albums Chart and continued the spare, piano-centred approach of The Boatman's Call, but with a somewhat warmer and more expansive palette. The album is notable for its sustained meditation on love, loss, and faith.
+*No More Shall We Part* is notable for its sustained meditation on love, loss, and faith.
+
+It reached number 16 on the UK Albums Chart and continued the spare, piano-centred approach of The Boatman's Call, but with a somewhat warmer and more expansive palette.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/nocturama/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/nocturama/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "2003 None"
 ---
 ## About
 
-Nocturama is the thirteenth studio album by Nick Cave & the Bad Seeds, released on Mute Records in 2003. Regarded as a transitional work in the band's catalogue, the album includes the extended track 'Babe, I'm on Fire', which runs to nearly 15 minutes on the studio version. Despite being overshadowed by the Abattoir Blues double album that followed, it contains several of Cave's most affecting songs.
+Regarded as a transitional work in the band's catalogue, *Nocturama* includes the extended track 'Babe, I'm on Fire', which runs to nearly 15 minutes on the studio version.
+
+Despite being overshadowed by the Abattoir Blues double album that followed, it contains several of Cave's most affecting songs.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/push-the-sky-away/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/push-the-sky-away/index.md
@@ -110,4 +110,4 @@ tracklist_edition: "2013 XE special deluxe edition"
 ---
 ## About
 
-Push the Sky Away is the fifteenth studio album by Australian rock band Nick Cave & the Bad Seeds, released on Bad Seed Ltd in 2013. It reached number two on the UK Albums Chart and was praised for its sparse, meditative soundscapes, representing a departure from the more confrontational work of previous albums.
+*Push the Sky Away* reached number two on the UK Albums Chart and was praised for its sparse, meditative soundscapes, representing a departure from the more confrontational work of previous albums.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/skeleton-tree/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/skeleton-tree/index.md
@@ -39,4 +39,6 @@ tracklist_edition: "2016-09-09 XE"
 ---
 ## About
 
-Skeleton Tree is the sixteenth studio album by Nick Cave & the Bad Seeds, released on Bad Seed Ltd in 2016. It debuted at number one on the UK Albums Chart and was partly recorded before and partly after the tragic death of Cave's teenage son Arthur. The album is suffused with grief and disorientation, and is considered one of the most powerful and emotionally raw records of Cave's career.
+*Skeleton Tree* is suffused with grief and disorientation, and is considered one of the most powerful and emotionally raw records of Cave's career.
+
+It debuted at number one on the UK Albums Chart and was partly recorded before and partly after the tragic death of Cave's teenage son Arthur.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/the-boatmans-call/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/the-boatmans-call/index.md
@@ -50,4 +50,4 @@ tracklist_edition: "1997 CZ"
 ---
 ## About
 
-The Boatman's Call is the eleventh studio album by Nick Cave & the Bad Seeds, released on Mute Records in 1997. Stripped to its barest bones — largely just piano and voice — it is perhaps the most intimate and confessional record Cave has made, dealing openly with the breakdown of his relationship with PJ Harvey and his renewed engagement with Christian faith.
+Stripped to its barest bones — largely just piano and voice — it is perhaps the most intimate and confessional record Cave has made, dealing openly with the breakdown of his relationship with PJ Harvey and his renewed engagement with Christian faith.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/the-good-son/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/the-good-son/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1990 GB"
 ---
 ## About
 
-The Good Son is the seventh studio album by Nick Cave & the Bad Seeds, released on Mute Records in 1990. The album represents a significant maturation in Cave's songwriting, trading the confrontational energy of his earlier work for a more measured, orchestrated sound. It draws on American gospel and classical music, and is often cited as the beginning of Cave's great mature period.
+*The Good Son* represents a significant maturation in Cave's songwriting, trading the confrontational energy of his earlier work for a more measured, orchestrated sound.
+
+It draws on American gospel and classical music, and is often cited as the beginning of Cave's great mature period.

--- a/src/content/releases/n/nick-cave-the-bad-seeds/wild-god/index.md
+++ b/src/content/releases/n/nick-cave-the-bad-seeds/wild-god/index.md
@@ -18,4 +18,6 @@ tracklist_edition: "2024-03-06 XW"
 ---
 ## About
 
-Wild God is the eighteenth studio album by Nick Cave & the Bad Seeds, released on Bad Seed Ltd in 2024. It debuted at number one on the UK Albums Chart and was received as a joyful, even euphoric record — a striking contrast to the grief-stricken Skeleton Tree and Ghosteen. The album marks something of a spiritual resurgence, finding beauty and hope in the face of loss.
+*Wild God* marks something of a spiritual resurgence, finding beauty and hope in the face of loss.
+
+It debuted at number one on the UK Albums Chart and was received as a joyful, even euphoric record — a striking contrast to the grief-stricken Skeleton Tree and Ghosteen.

--- a/src/content/releases/n/nick-lowe/party-of-one/index.md
+++ b/src/content/releases/n/nick-lowe/party-of-one/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-Party Of One is a release by Nick Lowe released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include You Got The Look I Like.
+*Party Of One* earns its place in the Sundown Sessions catalogue through “You Got The Look I Like”, a selection that offers a direct route into Nick Lowe's work.
 
-
+Heard in the context of the full release, “You Got The Look I Like” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/n/nick-lowe/quiet-please-the-new-best-of-nick-lowe/index.md
+++ b/src/content/releases/n/nick-lowe/quiet-please-the-new-best-of-nick-lowe/index.md
@@ -209,10 +209,10 @@ tracklist_edition: "2009-03-09 XE"
 ---
 ## About
 
-Quiet Please: The New Best of Nick Lowe is a release by Nick Lowe released in 2009. It has been featured on 1 Sundown Sessions show. Featured tracks include Half a Boy and Half a Man.
+*Quiet Please: The New Best of Nick Lowe* earns its place in the Sundown Sessions catalogue through “Half a Boy and Half a Man”, a selection that offers a direct route into Nick Lowe's work.
+
+Heard in the context of the full release, “Half a Boy and Half a Man” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Half a Boy and Half a Man
-
-

--- a/src/content/releases/n/nirvana/all-of-us/index.md
+++ b/src/content/releases/n/nirvana/all-of-us/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1968 GB"
 ---
 ## About
 
-All Of Us is a release by Nirvana released in 1968. It has been featured on 1 Sundown Sessions show. Featured tracks include Rainbow Chaser.
+*All Of Us* earns its place in the Sundown Sessions catalogue through “Rainbow Chaser”, a selection that offers a direct route into Nirvana's work.
 
-
+Heard in the context of the full release, “Rainbow Chaser” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/o/oasis/whats-the-story-morning-glory/index.md
+++ b/src/content/releases/o/oasis/whats-the-story-morning-glory/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1995 MX"
 ---
 ## About
 
-(What's the Story) Morning Glory? is the second studio album by Manchester rock band Oasis, released on Creation Records in 1995. It topped the UK Albums Chart and became the second best-selling album in UK chart history. Featuring the anthems 'Wonderwall', 'Don't Look Back in Anger', and 'Champagne Supernova', it defined the Britpop era and remains one of the most commercially successful British albums ever made.
+Featuring the anthems 'Wonderwall', 'Don't Look Back in Anger', and 'Champagne Supernova', *(What's the Story) Morning Glory?* defined the Britpop era and remains one of the most commercially successful British albums ever made.
+
+It topped the UK Albums Chart and became the second best-selling album in UK chart history.

--- a/src/content/releases/o/orange-juice/you-cant-hide-your-love-forever/index.md
+++ b/src/content/releases/o/orange-juice/you-cant-hide-your-love-forever/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "1982-02 GB"
 ---
 ## About
 
-You Can't Hide Your Love Forever is the debut studio album by Glasgow jangly pop band Orange Juice, released on Polydor Records in 1982. It reached number 21 on the UK Albums Chart and is a landmark of the Scottish post-punk scene, blending angular guitars with an upbeat, optimistic sensibility that would later be called indie pop. The band was led by Edwyn Collins, who went on to a successful solo career.
+*You Can't Hide Your Love Forever* reached number 21 on the UK Albums Chart and is a landmark of the Scottish post-punk scene, blending angular guitars with an upbeat, optimistic sensibility that would later be called indie pop.
+
+The band was led by Edwyn Collins, who went on to a successful solo career.

--- a/src/content/releases/o/orbital/orbital-brown-album/index.md
+++ b/src/content/releases/o/orbital/orbital-brown-album/index.md
@@ -77,4 +77,6 @@ tracklist_edition: "2025-05-23 GB"
 ---
 ## About
 
-Orbital (the Brown Album) is the second studio album by Sevenoaks electronic music duo Orbital, released on Internal Records in 1993. It builds on the techno and rave influences of their debut into something more ambitious and melodically rich. The album is a landmark of British electronic music and features some of the duo's most celebrated compositions.
+*Orbital (Brown Album)* is a landmark of British electronic music and features some of the duo's most celebrated compositions.
+
+It builds on the techno and rave influences of their debut into something more ambitious and melodically rich.

--- a/src/content/releases/o/orchestral-manoeuvres-in-the-dark/orchestral-manoeuvres-in-the-dark/index.md
+++ b/src/content/releases/o/orchestral-manoeuvres-in-the-dark/orchestral-manoeuvres-in-the-dark/index.md
@@ -50,6 +50,6 @@ tracklist_edition: "1980 CA"
 ---
 ## About
 
-Orchestral Manoeuvres In The Dark is a release by Orchestral Manoeuvres In The Dark released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Messages.
+*Orchestral Manoeuvres In The Dark* earns its place in the Sundown Sessions catalogue through “Messages”, a selection that offers a direct route into Orchestral Manoeuvres In The Dark's work.
 
-
+Heard in the context of the full release, “Messages” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/patti-smith/gung-ho/index.md
+++ b/src/content/releases/p/patti-smith/gung-ho/index.md
@@ -62,6 +62,6 @@ tracklist_edition: "2000-03-20 DE"
 ---
 ## About
 
-Gung Ho is a release by Patti Smith released in 2000-03-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Glitter In Their Eyes.
+*Gung Ho* earns its place in the Sundown Sessions catalogue through “Glitter In Their Eyes”, a selection that offers a direct route into Patti Smith's work.
 
-
+Heard in the context of the full release, “Glitter In Their Eyes” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/paul-mccartney/ram/index.md
+++ b/src/content/releases/p/paul-mccartney/ram/index.md
@@ -93,10 +93,10 @@ tracklist_edition: "2012-05 None"
 ---
 ## About
 
-Ram is a release by Paul McCartney released in 1971. It has been featured on 1 Sundown Sessions show. Featured tracks include Smile Away.
+*Ram* earns its place in the Sundown Sessions catalogue through “Smile Away”, a selection that offers a direct route into Paul McCartney's work.
+
+Heard in the context of the full release, “Smile Away” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Smile Away
-
-

--- a/src/content/releases/p/penetration/moving-targets/index.md
+++ b/src/content/releases/p/penetration/moving-targets/index.md
@@ -46,4 +46,4 @@ tracklist_edition: "1978 US"
 ---
 ## About
 
-Moving Targets is the debut studio album by County Durham punk band Penetration, released on Virgin Records in 1978. Fronted by Pauline Murray, the album is one of the finest debut records of the UK punk era, combining raw punk energy with melodic intelligence and Murray's powerful, distinctive voice.
+Fronted by Pauline Murray, *Moving Targets* is one of the finest debut records of the UK punk era, combining raw punk energy with melodic intelligence and Murray's powerful, distinctive voice.

--- a/src/content/releases/p/pere-ubu/the-modern-dance/index.md
+++ b/src/content/releases/p/pere-ubu/the-modern-dance/index.md
@@ -43,4 +43,4 @@ tracklist_edition: "1978 GB"
 ---
 ## About
 
-The Modern Dance is the debut studio album by Cleveland avant-punk band Pere Ubu, released on Blank Records in 1978. The album is a landmark of art punk and post-punk music, combining angular guitar, David Thomas's unsettling vocals, and dissonant, avant-garde arrangements into something genuinely unlike anything that had preceded it.
+*The Modern Dance* is a landmark of art punk and post-punk music, combining angular guitar, David Thomas's unsettling vocals, and dissonant, avant-garde arrangements into something genuinely unlike anything that had preceded it.

--- a/src/content/releases/p/pete-shelley/homosapien/index.md
+++ b/src/content/releases/p/pete-shelley/homosapien/index.md
@@ -19,4 +19,6 @@ tracklist_edition: "1981 GB"
 ---
 ## About
 
-Homosapien is the debut solo studio album by Buzzcocks singer Pete Shelley, released on Genetic Records in 1981. It is a landmark synth-pop record, blending Shelley's melodic songwriting with pulsing electronic arrangements. The title track was banned by the BBC for its explicit lyrical content but became an underground classic and a key influence on the development of electronic pop.
+*Homosapien* is a landmark synth-pop record, blending Shelley's melodic songwriting with pulsing electronic arrangements.
+
+The title track was banned by the BBC for its explicit lyrical content but became an underground classic and a key influence on the development of electronic pop.

--- a/src/content/releases/p/pete-shelley/xla-1/index.md
+++ b/src/content/releases/p/pete-shelley/xla-1/index.md
@@ -44,10 +44,10 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-XLÂ·1 is a release by Pete Shelley released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Telephone Operator.
+*XLÂ·1* earns its place in the Sundown Sessions catalogue through “Telephone Operator”, a selection that offers a direct route into Pete Shelley's work.
+
+Heard in the context of the full release, “Telephone Operator” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Telephone Operator
-
-

--- a/src/content/releases/p/peter-murphy/remixes-from-lion/index.md
+++ b/src/content/releases/p/peter-murphy/remixes-from-lion/index.md
@@ -53,6 +53,6 @@ tracklist_edition: "2015-06 None"
 ---
 ## About
 
-Remixes from Lion is a release by Peter Murphy released in 2015-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Hang Up - Youth Remix.
+*Remixes from Lion* earns its place in the Sundown Sessions catalogue through “Hang Up - Youth Remix”, a selection that offers a direct route into Peter Murphy's work.
 
-
+Heard in the context of the full release, “Hang Up - Youth Remix” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/phil-lynott/the-philip-lynott-album/index.md
+++ b/src/content/releases/p/phil-lynott/the-philip-lynott-album/index.md
@@ -46,10 +46,10 @@ tracklist_edition: ""
 ---
 ## About
 
-The Philip Lynott Album is a release by Phil Lynott released in 1982. It has been featured on 1 Sundown Sessions show. Featured tracks include Yellow Pearl.
+*The Philip Lynott Album* earns its place in the Sundown Sessions catalogue through “Yellow Pearl”, a selection that offers a direct route into Phil Lynott's work.
+
+Heard in the context of the full release, “Yellow Pearl” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Yellow Pearl
-
-

--- a/src/content/releases/p/pigs-pigs-pigs-pigs-pigs-pigs-pigs/hot-stuff/index.md
+++ b/src/content/releases/p/pigs-pigs-pigs-pigs-pigs-pigs-pigs/hot-stuff/index.md
@@ -27,6 +27,6 @@ tracklist_edition: "2021-10-20 XW"
 ---
 ## About
 
-Hot Stuff is a release by Pigs Pigs Pigs Pigs Pigs Pigs Pigs released in 2021-10-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Hot Stuff.
+*Hot Stuff* earns its place in the Sundown Sessions catalogue through “Hot Stuff”, a selection that offers a direct route into Pigs Pigs Pigs Pigs Pigs Pigs Pigs's work.
 
-
+Heard in the context of the full release, “Hot Stuff” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/pink-floyd/the-early-years-1967-72-cre-ation/index.md
+++ b/src/content/releases/p/pink-floyd/the-early-years-1967-72-cre-ation/index.md
@@ -121,10 +121,10 @@ tracklist_edition: "2016-11-11 GB"
 ---
 ## About
 
-The Early Years 1967-72 Cre/ation is a release by Pink Floyd released in 2016. It has been featured on 1 Sundown Sessions show. Featured tracks include See Emily Play.
+*The Early Years 1967-72 Cre/ation* earns its place in the Sundown Sessions catalogue through “See Emily Play”, a selection that offers a direct route into Pink Floyd's work.
+
+Heard in the context of the full release, “See Emily Play” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - See Emily Play
-
-

--- a/src/content/releases/p/pink-floyd/the-piper-at-the-gates-of-dawn/index.md
+++ b/src/content/releases/p/pink-floyd/the-piper-at-the-gates-of-dawn/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1967 GB"
 ---
 ## About
 
-The Piper At The Gates Of Dawn is a release by Pink Floyd released in 1967-07-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Astronomy Domine.
+*The Piper At The Gates Of Dawn* earns its place in the Sundown Sessions catalogue through “Astronomy Domine”, a selection that offers a direct route into Pink Floyd's work.
 
-
+Heard in the context of the full release, “Astronomy Domine” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/pixies/surfer-rosa/index.md
+++ b/src/content/releases/p/pixies/surfer-rosa/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "1988 XE"
 ---
 ## About
 
-Surfer Rosa is a release by Pixies released in 1988-03-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Where Is My Mind?.
+*Surfer Rosa* earns its place in the Sundown Sessions catalogue through “Where Is My Mind?”, a selection that offers a direct route into Pixies's work.
 
-
+Heard in the context of the full release, “Where Is My Mind?” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/pj-harvey/dry/index.md
+++ b/src/content/releases/p/pj-harvey/dry/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1992 CA"
 ---
 ## About
 
-Dry is the debut studio album by Bridport singer-songwriter PJ Harvey, released on Too Pure Records in 1992. The album announced Harvey as one of the most viscerally powerful new voices in British alternative music, combining abrasive, blues-influenced guitar rock with unflinchingly raw lyrics. It established her as a significant artistic force and has been cited as an influence by countless subsequent musicians.
+*Dry* established her as a significant artistic force and has been cited as an influence by countless subsequent musicians.
+
+The album announced Harvey as one of the most viscerally powerful new voices in British alternative music, combining abrasive, blues-influenced guitar rock with unflinchingly raw lyrics.

--- a/src/content/releases/p/plastic-bertrand/plastic-bertrand/index.md
+++ b/src/content/releases/p/plastic-bertrand/plastic-bertrand/index.md
@@ -81,6 +81,6 @@ tracklist_edition: "1998 BE"
 ---
 ## About
 
-Plastic Bertrand is a release by Plastic Bertrand released in 1998. It has been featured on 1 Sundown Sessions show. Featured tracks include Ca Plane Pour Moi.
+*Plastic Bertrand* earns its place in the Sundown Sessions catalogue through “Ca Plane Pour Moi”, a selection that offers a direct route into Plastic Bertrand's work.
 
-
+Heard in the context of the full release, “Ca Plane Pour Moi” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/portishead/dummy/index.md
+++ b/src/content/releases/p/portishead/dummy/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1994 AU"
 ---
 ## About
 
-Dummy is the debut studio album by Bristol trip-hop act Portishead, released on Go! Discs in 1994. It reached number two on the UK Albums Chart, won the Mercury Prize in 1995, and went on to sell over two million copies in the UK. The album's fusion of cinematic samples, haunting synthesisers, and Beth Gibbons' extraordinary vocals helped define the trip-hop movement.
+*Dummy*'s fusion of cinematic samples, haunting synthesisers, and Beth Gibbons' extraordinary vocals helped define the trip-hop movement.
+
+It reached number two on the UK Albums Chart, won the Mercury Prize in 1995, and went on to sell over two million copies in the UK.

--- a/src/content/releases/p/prefab-sprout/swoon/index.md
+++ b/src/content/releases/p/prefab-sprout/swoon/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1984 GB"
 ---
 ## About
 
-Swoon is the debut studio album by Durham pop band Prefab Sprout, released on Kitchenware Records in 1984. It reached number 22 on the UK Albums Chart and announced Paddy McAloon as one of the most gifted and eccentric British songwriters of his generation. The album is unusually complex for a debut, with intricate chord changes and poetic, elusive lyrics.
+*Swoon* is unusually complex for a debut, with intricate chord changes and poetic, elusive lyrics.
+
+It reached number 22 on the UK Albums Chart and announced Paddy McAloon as one of the most gifted and eccentric British songwriters of his generation.

--- a/src/content/releases/p/primal-scream/screamadelica/index.md
+++ b/src/content/releases/p/primal-scream/screamadelica/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1991 AU"
 ---
 ## About
 
-Screamadelica is the third studio album by Glasgow rock band Primal Scream, released on Creation Records in 1991. It reached number eight on the UK Albums Chart and won the inaugural Mercury Prize in 1992. The album fuses rock, house, dance, soul, and gospel into a celebratory whole that captured the spirit of the late-1980s rave scene. 'Loaded' and 'Come Together' remain two of the most beloved British dance records of the era.
+'Loaded' and 'Come Together' remain two of the most beloved British dance records of the era.
+
+It reached number eight on the UK Albums Chart and won the inaugural Mercury Prize in 1992. The album fuses rock, house, dance, soul, and gospel into a celebratory whole that captured the spirit of the late-1980s rave scene.

--- a/src/content/releases/p/prince/nothing-compares-2-u/index.md
+++ b/src/content/releases/p/prince/nothing-compares-2-u/index.md
@@ -26,6 +26,6 @@ tracklist_edition: "2018-04-19 None"
 ---
 ## About
 
-Nothing Compares 2 U is a release by Prince released in 2018-04-19. It has been featured on 1 Sundown Sessions show. Featured tracks include Nothing Compares 2 U.
+*Nothing Compares 2 U* earns its place in the Sundown Sessions catalogue through “Nothing Compares 2 U”, a selection that offers a direct route into Prince's work.
 
-
+Heard in the context of the full release, “Nothing Compares 2 U” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/p/propaganda/a-secret-wish/index.md
+++ b/src/content/releases/p/propaganda/a-secret-wish/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1985 US"
 ---
 ## About
 
-A Secret Wish is the debut studio album by German synth-pop group Propaganda, released on ZTT Records in 1985. It reached number 16 on the UK Albums Chart and is celebrated for its lavish, orchestrated production, overseen by Trevor Horn. The album includes the singles 'Dr Mabuse' and 'Duel', both of which became cult favourites in the UK.
+*A Secret Wish* includes the singles 'Dr Mabuse' and 'Duel', both of which became cult favourites in the UK.
+
+It reached number 16 on the UK Albums Chart and is celebrated for its lavish, orchestrated production, overseen by Trevor Horn.

--- a/src/content/releases/q/queen/a-night-at-the-opera/index.md
+++ b/src/content/releases/q/queen/a-night-at-the-opera/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1975 IT"
 ---
 ## About
 
-A Night at the Opera is the fourth studio album by London rock band Queen, released on EMI Records in 1975. It topped the UK Albums Chart and includes 'Bohemian Rhapsody', one of the most celebrated and inventive singles in the history of popular music. The album is a tour de force of studio craft and theatrical excess, showcasing the band's extraordinary range and ambition.
+*A Night at the Opera* is a tour de force of studio craft and theatrical excess, showcasing the band's extraordinary range and ambition.
+
+It topped the UK Albums Chart and includes 'Bohemian Rhapsody', one of the most celebrated and inventive singles in the history of popular music.

--- a/src/content/releases/q/queens-of-the-stone-age/like-clockwork/index.md
+++ b/src/content/releases/q/queens-of-the-stone-age/like-clockwork/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "2013 RU"
 ---
 ## About
 
-...Like Clockwork is a release by Queens of the Stone Age released in 2013. It has been featured on 1 Sundown Sessions show. Featured tracks include I Sat By The Ocean.
+*...Like Clockwork* earns its place in the Sundown Sessions catalogue through “I Sat By The Ocean”, a selection that offers a direct route into Queens of the Stone Age's work.
+
+Heard in the context of the full release, “I Sat By The Ocean” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - I Sat By The Ocean
-
-

--- a/src/content/releases/q/queens-of-the-stone-age/villains/index.md
+++ b/src/content/releases/q/queens-of-the-stone-age/villains/index.md
@@ -60,7 +60,7 @@ tracklist_edition: "2017-08-25 US"
 ---
 ## About
 
-Villains is the seventh studio album by Queens of the Stone Age, released on 25 August 2017 through Matador Records. Produced by Mark Ronson, it was the band's first album in four years following ...Like Clockwork (2013).
+Produced by Mark Ronson, *Villains* was the band's first album in four years following ...Like Clockwork (2013).
 
 ## External Links
 

--- a/src/content/releases/q/quicksilver-messenger-service/happy-trails/index.md
+++ b/src/content/releases/q/quicksilver-messenger-service/happy-trails/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1969 GB mono"
 ---
 ## About
 
-Happy Trails is the second studio album by San Francisco psychedelic rock band Quicksilver Messenger Service, released on Capitol Records in 1969. The album is dominated by an extended live version of Bo Diddley's 'Who Do You Love', spread across most of the first side, that showcases the band's extended improvisational approach. It is regarded as one of the finest live recordings of the psychedelic era.
+*Happy Trails* is regarded as one of the finest live recordings of the psychedelic era.
+
+The album is dominated by an extended live version of Bo Diddley's 'Who Do You Love', spread across most of the first side, that showcases the band's extended improvisational approach.

--- a/src/content/releases/r/r-e-m/green/index.md
+++ b/src/content/releases/r/r-e-m/green/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1988 XE price code France WE 851"
 ---
 ## About
 
-Green is a release by R.E.M. released in 1988-11-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Pop Song 89.
+*Green* earns its place in the Sundown Sessions catalogue through “Pop Song 89”, a selection that offers a direct route into R.E.M.'s work.
 
-
+Heard in the context of the full release, “Pop Song 89” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/r-e-m/lifes-rich-pageant/index.md
+++ b/src/content/releases/r/r-e-m/lifes-rich-pageant/index.md
@@ -78,6 +78,6 @@ tracklist_edition: "1986 GB"
 ---
 ## About
 
-Lifes Rich Pageant is a release by R.E.M. released in 1986-07-28. It has been featured on 1 Sundown Sessions show. Featured tracks include Fall On Me.
+*Lifes Rich Pageant* earns its place in the Sundown Sessions catalogue through “Fall On Me”, a selection that offers a direct route into R.E.M.'s work.
 
-
+Heard in the context of the full release, “Fall On Me” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/r-e-m/new-adventures-in-hi-fi/index.md
+++ b/src/content/releases/r/r-e-m/new-adventures-in-hi-fi/index.md
@@ -55,10 +55,10 @@ tracklist_edition: "1996 BR"
 ---
 ## About
 
-New Adventures In Hi-Fi is a release by R.E.M. released in 1996. It has been featured on 1 Sundown Sessions show. Featured tracks include E-Bow The Letter.
+*New Adventures In Hi-Fi* earns its place in the Sundown Sessions catalogue through “E-Bow The Letter”, a selection that offers a direct route into R.E.M.'s work.
+
+Heard in the context of the full release, “E-Bow The Letter” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - E-Bow The Letter
-
-

--- a/src/content/releases/r/radio-stars/songs-for-swinging-lovers/index.md
+++ b/src/content/releases/r/radio-stars/songs-for-swinging-lovers/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "1977 NL"
 ---
 ## About
 
-Songs for Swinging Lovers is a release by Radio Stars released in 1977. It has been featured on 1 Sundown Sessions show. Featured tracks include Nervous Wreck.
+*Songs for Swinging Lovers* earns its place in the Sundown Sessions catalogue through “Nervous Wreck”, a selection that offers a direct route into Radio Stars's work.
 
-
+Heard in the context of the full release, “Nervous Wreck” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/radiohead/ok-computer/index.md
+++ b/src/content/releases/r/radiohead/ok-computer/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1997 None"
 ---
 ## About
 
-OK Computer is the third studio album by Radiohead, released on Parlophone in 1997. It topped the UK Albums Chart and was universally acclaimed as one of the defining albums of the decade, winning the Mercury Prize. The album's themes of alienation, technology, and social isolation were matched by Radiohead's most ambitious and varied music to date.
+*OK Computer* topped the UK Albums Chart and was universally acclaimed as one of the defining albums of the decade, winning the Mercury Prize.
+
+The album's themes of alienation, technology, and social isolation were matched by Radiohead's most ambitious and varied music to date.

--- a/src/content/releases/r/radiohead/pablo-honey/index.md
+++ b/src/content/releases/r/radiohead/pablo-honey/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1993 XE printed in Italy, made in Italy"
 ---
 ## About
 
-Pablo Honey is the debut studio album by Radiohead, released on Parlophone in 1993. It reached number 25 on the UK Albums Chart and is best known for the breakthrough single 'Creep', which became an international hit and established the band as a major force in 1990s alternative rock. While the band have spoken ambivalently about the album since, it remains a significant document of their early sound.
+*Pablo Honey* reached number 25 on the UK Albums Chart and is best known for the breakthrough single 'Creep', which became an international hit and established the band as a major force in 1990s alternative rock.
+
+While the band have spoken ambivalently about the album since, it remains a significant document of their early sound.

--- a/src/content/releases/r/radiohead/the-bends/index.md
+++ b/src/content/releases/r/radiohead/the-bends/index.md
@@ -51,4 +51,6 @@ tracklist_edition: "1995 GB made in Holland, printed in the UK"
 ---
 ## About
 
-The Bends is the second studio album by Oxford alternative rock band Radiohead, released on Parlophone in 1995. It reached number four on the UK Albums Chart and is widely regarded as the album on which the band found their distinctive voice, combining alternative rock guitar work with Thom Yorke's emotionally intense lyrics. It includes the singles 'Fake Plastic Trees', 'Just', and 'High and Dry'.
+*The Bends* reached number four on the UK Albums Chart and is widely regarded as the album on which the band found their distinctive voice, combining alternative rock guitar work with Thom Yorke's emotionally intense lyrics.
+
+It includes the singles 'Fake Plastic Trees', 'Just', and 'High and Dry'.

--- a/src/content/releases/r/rainbow/down-to-earth/index.md
+++ b/src/content/releases/r/rainbow/down-to-earth/index.md
@@ -46,6 +46,6 @@ tracklist_edition: "1979 GB"
 ---
 ## About
 
-Down To Earth is a release by Rainbow released in 1979. It has been featured on 1 Sundown Sessions show. Featured tracks include All Night Long.
+*Down To Earth* earns its place in the Sundown Sessions catalogue through “All Night Long”, a selection that offers a direct route into Rainbow's work.
 
-
+Heard in the context of the full release, “All Night Long” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/rainbow/rising/index.md
+++ b/src/content/releases/r/rainbow/rising/index.md
@@ -32,4 +32,6 @@ tracklist_edition: "1976 GB"
 ---
 ## About
 
-Rising is the second studio album by Ritchie Blackmore's Rainbow, released on Polydor Records in 1976. It reached number 11 on the UK Albums Chart and is widely regarded as the definitive Rainbow album, featuring the classic line-up of Blackmore, Ronnie James Dio, Cozy Powell, Tony Carey, and Jimmy Bain. The album includes 'Stargazer' and 'A Light in the Black', two of hard rock's most epic compositions.
+*Rising* reached number 11 on the UK Albums Chart and is widely regarded as the definitive Rainbow album, featuring the classic line-up of Blackmore, Ronnie James Dio, Cozy Powell, Tony Carey, and Jimmy Bain.
+
+The album includes 'Stargazer' and 'A Light in the Black', two of hard rock's most epic compositions.

--- a/src/content/releases/r/ramones/end-of-the-century/index.md
+++ b/src/content/releases/r/ramones/end-of-the-century/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "1980 DE"
 ---
 ## About
 
-End of the Century is a release by Ramones released in 1980-02-04. It has been featured on 1 Sundown Sessions show. Featured tracks include Rock 'n' Roll Radio.
+*End of the Century* earns its place in the Sundown Sessions catalogue through “Rock 'n' Roll Radio”, a selection that offers a direct route into Ramones's work.
 
-
+Heard in the context of the full release, “Rock 'n' Roll Radio” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/red-lorry-yellow-lorry/talk-about-the-weather/index.md
+++ b/src/content/releases/r/red-lorry-yellow-lorry/talk-about-the-weather/index.md
@@ -47,6 +47,6 @@ tracklist_edition: "1985 GB"
 ---
 ## About
 
-Talk About The Weather is a release by Red Lorry Yellow Lorry released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include Talk About The Weather.
+*Talk About The Weather* earns its place in the Sundown Sessions catalogue through “Talk About The Weather”, a selection that offers a direct route into Red Lorry Yellow Lorry's work.
 
-
+Heard in the context of the full release, “Talk About The Weather” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/ride/nowhere/index.md
+++ b/src/content/releases/r/ride/nowhere/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-Nowhere is the debut studio album by Oxford shoegaze band Ride, released on Creation Records in 1990. It reached number 11 on the UK Albums Chart and is regarded as one of the defining albums of the shoegaze movement, alongside My Bloody Valentine's Loveless. The album submerges Mark Gardener and Andy Bell's melodic songs beneath walls of shimmering, effects-drenched guitar noise.
+*Nowhere* reached number 11 on the UK Albums Chart and is regarded as one of the defining albums of the shoegaze movement, alongside My Bloody Valentine's Loveless.
+
+The album submerges Mark Gardener and Andy Bell's melodic songs beneath walls of shimmering, effects-drenched guitar noise.

--- a/src/content/releases/r/ringo-starr/ringo/index.md
+++ b/src/content/releases/r/ringo-starr/ringo/index.md
@@ -53,6 +53,6 @@ tracklist_edition: "1973 FR"
 ---
 ## About
 
-Ringo is a release by Ringo Starr released in 1973-11-23. It has been featured on 1 Sundown Sessions show. Featured tracks include It Don't Come Easy.
+*Ringo* earns its place in the Sundown Sessions catalogue through “It Don't Come Easy”, a selection that offers a direct route into Ringo Starr's work.
 
-
+Heard in the context of the full release, “It Don't Come Easy” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/roachford/roachford/index.md
+++ b/src/content/releases/r/roachford/roachford/index.md
@@ -53,6 +53,6 @@ tracklist_edition: "1988 AU"
 ---
 ## About
 
-Roachford is a release by Roachford released in 1988-07-11. It has been featured on 1 Sundown Sessions show. Featured tracks include Cuddly Toy.
+*Roachford* earns its place in the Sundown Sessions catalogue through “Cuddly Toy”, a selection that offers a direct route into Roachford's work.
 
-
+Heard in the context of the full release, “Cuddly Toy” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/robert-forster/calling-from-a-country-phone/index.md
+++ b/src/content/releases/r/robert-forster/calling-from-a-country-phone/index.md
@@ -43,4 +43,4 @@ tracklist_edition: "1993 GB"
 ---
 ## About
 
-Calling from a Country Phone is the second solo studio album by Go-Betweens co-founder Robert Forster, released on Beggars Banquet in 1993. It showcases Forster's gifts as a songwriter and storyteller, with a warm, acoustic-influenced sound that reflects his return to Australia after years living abroad.
+*Calling from a Country Phone* showcases Forster's gifts as a songwriter and storyteller, with a warm, acoustic-influenced sound that reflects his return to Australia after years living abroad.

--- a/src/content/releases/r/robert-hazard-and-the-heroes/out-of-the-blue/index.md
+++ b/src/content/releases/r/robert-hazard-and-the-heroes/out-of-the-blue/index.md
@@ -64,6 +64,6 @@ tracklist_edition: ""
 ---
 ## About
 
-Out Of The Blue is a release by Robert Hazard & The Heroes released in 2018. It has been featured on 1 Sundown Sessions show. Featured tracks include Escalator Of Life.
+*Out Of The Blue* earns its place in the Sundown Sessions catalogue through “Escalator Of Life”, a selection that offers a direct route into Robert Hazard & The Heroes's work.
 
-
+Heard in the context of the full release, “Escalator Of Life” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/robert-palmer/secrets/index.md
+++ b/src/content/releases/r/robert-palmer/secrets/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1979-06-28 US"
 ---
 ## About
 
-Secrets is a release by Robert Palmer released in 1979-06-28. It has been featured on 1 Sundown Sessions show. Featured tracks include Bad Case Of Loving You (Doctor, Doctor).
+*Secrets* has supplied Sundown Sessions with “Bad Case Of Loving You (Doctor” and “Doctor)”, giving more than one way into Robert Palmer's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/r/roddy-frame/the-north-star/index.md
+++ b/src/content/releases/r/roddy-frame/the-north-star/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "1998-09-21 GB"
 ---
 ## About
 
-The North Star is a release by Roddy Frame released in 1998-09-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Reason For Living.
+*The North Star* earns its place in the Sundown Sessions catalogue through “Reason For Living”, a selection that offers a direct route into Roddy Frame's work.
 
-
+Heard in the context of the full release, “Reason For Living” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/roxy-music/country-life/index.md
+++ b/src/content/releases/r/roxy-music/country-life/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1974 GB"
 ---
 ## About
 
-Country Life is the fourth studio album by British art rock band Roxy Music, released on Island Records in 1974. It reached number three on the UK Albums Chart and includes some of the band's most celebrated material, including 'All I Want Is You' and 'The Thrill of It All'. The album showcases the band at their most debonair, blending sophisticated pop with Bryan Ferry's arch romanticism.
+*Country Life* showcases the band at their most debonair, blending sophisticated pop with Bryan Ferry's arch romanticism.
+
+It reached number three on the UK Albums Chart and includes some of the band's most celebrated material, including 'All I Want Is You' and 'The Thrill of It All'.

--- a/src/content/releases/r/roxy-music/manifesto/index.md
+++ b/src/content/releases/r/roxy-music/manifesto/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1979 US"
 ---
 ## About
 
-Manifesto is the sixth studio album by British art rock band Roxy Music, released on Polydor Records in 1979. It reached number seven on the UK Albums Chart and marked the band's commercial return after a three-year hiatus. The album features the hit single 'Dance Away' and heralded a more streamlined, polished sound that would define the group's final phase.
+*Manifesto* reached number seven on the UK Albums Chart and marked the band's commercial return after a three-year hiatus.
+
+The album features the hit single 'Dance Away' and heralded a more streamlined, polished sound that would define the group's final phase.

--- a/src/content/releases/r/roxy-music/roxy-music/index.md
+++ b/src/content/releases/r/roxy-music/roxy-music/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1972 US"
 ---
 ## About
 
-Roxy Music is a release by Roxy Music released in 1972-06-16. It has been featured on 1 Sundown Sessions show. Featured tracks include Virginia Plain.
+*Roxy Music* earns its place in the Sundown Sessions catalogue through “Virginia Plain”, a selection that offers a direct route into Roxy Music's work.
 
-
+Heard in the context of the full release, “Virginia Plain” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/royal-blood/back-to-the-water-below/index.md
+++ b/src/content/releases/r/royal-blood/back-to-the-water-below/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "2023-09-01 GB"
 ---
 ## About
 
-Back To The Water Below is a release by Royal Blood released in 2023-09-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Supermodel Avalanches.
+*Back To The Water Below* earns its place in the Sundown Sessions catalogue through “Supermodel Avalanches”, a selection that offers a direct route into Royal Blood's work.
 
-
+Heard in the context of the full release, “Supermodel Avalanches” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/r/royal-blood/royal-blood/index.md
+++ b/src/content/releases/r/royal-blood/royal-blood/index.md
@@ -48,4 +48,6 @@ tracklist_edition: "2014 GB"
 ---
 ## About
 
-Royal Blood is the self-titled debut studio album by Brighton rock duo Royal Blood, released on Warner Bros. Records in 2014. It reached number one on the UK Albums Chart on its release week, making Royal Blood the first debut rock act to achieve this in over a decade. The album's raw, bass-driven sound drew comparisons to Queens of the Stone Age and Jack White.
+*Royal Blood*'s raw, bass-driven sound drew comparisons to Queens of the Stone Age and Jack White.
+
+Records in 2014. It reached number one on the UK Albums Chart on its release week, making Royal Blood the first debut rock act to achieve this in over a decade.

--- a/src/content/releases/r/rush/moving-pictures/index.md
+++ b/src/content/releases/r/rush/moving-pictures/index.md
@@ -35,4 +35,6 @@ tracklist_edition: "1981 DE atomic CD face"
 ---
 ## About
 
-Moving Pictures is the eighth studio album by Canadian progressive rock band Rush, released on Mercury Records in 1981. It reached number three on the UK Albums Chart and is widely regarded as the band's masterpiece, perfectly balancing their progressive rock ambitions with a more accessible, streamlined sound. The album includes 'Tom Sawyer', 'Limelight', and 'YYZ', and remains one of the most beloved rock albums of the era.
+*Moving Pictures* includes 'Tom Sawyer', 'Limelight', and 'YYZ', and remains one of the most beloved rock albums of the era.
+
+It reached number three on the UK Albums Chart and is widely regarded as the band's masterpiece, perfectly balancing their progressive rock ambitions with a more accessible, streamlined sound.

--- a/src/content/releases/r/rush/permanent-waves/index.md
+++ b/src/content/releases/r/rush/permanent-waves/index.md
@@ -42,6 +42,6 @@ tracklist_edition: "1980 XE"
 ---
 ## About
 
-Permanent Waves is a release by Rush released in 1980-01-01. It has been featured on 1 Sundown Sessions show. Featured tracks include The Spirit Of Radio.
+*Permanent Waves* earns its place in the Sundown Sessions catalogue through “The Spirit Of Radio”, a selection that offers a direct route into Rush's work.
 
-
+Heard in the context of the full release, “The Spirit Of Radio” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/saint-etienne/so-tough/index.md
+++ b/src/content/releases/s/saint-etienne/so-tough/index.md
@@ -62,4 +62,6 @@ tracklist_edition: "1993 CA"
 ---
 ## About
 
-So Tough is the second studio album by London dance-pop act Saint Etienne, released on Heavenly Recordings in 1993. It reached number 26 on the UK Albums Chart and is a highly accomplished and affectionate exploration of British pop culture, nostalgia, and suburban life. Sarah Cracknell's vocals and the duo of Bob Stanley and Pete Wiggs create a warm, layered sound that remains uniquely their own.
+Sarah Cracknell's vocals and the duo of Bob Stanley and Pete Wiggs create a warm, layered sound that remains uniquely their own.
+
+It reached number 26 on the UK Albums Chart and is a highly accomplished and affectionate exploration of British pop culture, nostalgia, and suburban life.

--- a/src/content/releases/s/sananda-maitreya/introducing-the-hardline-according-to-sananda-maitreya/index.md
+++ b/src/content/releases/s/sananda-maitreya/introducing-the-hardline-according-to-sananda-maitreya/index.md
@@ -46,10 +46,10 @@ tracklist_edition: "XW"
 ---
 ## About
 
-Introducing The Hardline According To Sananda Maitreya is a release by Sananda Maitreya released in 1987. It has been featured on 1 Sundown Sessions show. Featured tracks include Who's Loving You.
+*Introducing The Hardline According To Sananda Maitreya* earns its place in the Sundown Sessions catalogue through “Who's Loving You”, a selection that offers a direct route into Sananda Maitreya's work.
+
+Heard in the context of the full release, “Who's Loving You” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Who's Loving You
-
-

--- a/src/content/releases/s/santana/ultimate-santana/index.md
+++ b/src/content/releases/s/santana/ultimate-santana/index.md
@@ -80,6 +80,6 @@ tracklist_edition: "2007 AU"
 ---
 ## About
 
-Ultimate Santana is a release by Santana released in 2007-10-16. It has been featured on 1 Sundown Sessions show. Featured tracks include Europa.
+*Ultimate Santana* earns its place in the Sundown Sessions catalogue through “Europa”, a selection that offers a direct route into Santana's work.
 
-
+Heard in the context of the full release, “Europa” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/saxon/strong-arm-of-the-law/index.md
+++ b/src/content/releases/s/saxon/strong-arm-of-the-law/index.md
@@ -20,4 +20,6 @@ tracklist_edition: "1980 None"
 ---
 ## About
 
-Strong Arm of the Law is the third studio album by Barnsley heavy metal band Saxon, released on Carrere Records in 1980. It reached number 11 on the UK Albums Chart and is one of the landmark albums of the New Wave of British Heavy Metal movement. The album showcases the band at their most powerful, with the title track and '20,000 Ft' among their most celebrated compositions.
+*Strong Arm of the Law* showcases the band at their most powerful, with the title track and '20,000 Ft' among their most celebrated compositions.
+
+It reached number 11 on the UK Albums Chart and is one of the landmark albums of the New Wave of British Heavy Metal movement.

--- a/src/content/releases/s/scorpions/crazy-world/index.md
+++ b/src/content/releases/s/scorpions/crazy-world/index.md
@@ -31,6 +31,6 @@ tracklist_edition: "1990 GB"
 ---
 ## About
 
-Crazy World is a release by Scorpions released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include Wind Of Change.
+*Crazy World* earns its place in the Sundown Sessions catalogue through “Wind Of Change”, a selection that offers a direct route into Scorpions's work.
 
-
+Heard in the context of the full release, “Wind Of Change” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/sex-gang-children/song-and-legend/index.md
+++ b/src/content/releases/s/sex-gang-children/song-and-legend/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-Song and Legend is a release by Sex Gang Children released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Sebastiane.
+*Song and Legend* earns its place in the Sundown Sessions catalogue through “Sebastiane”, a selection that offers a direct route into Sex Gang Children's work.
 
-
+Heard in the context of the full release, “Sebastiane” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/shed-seven/a-maximum-high/index.md
+++ b/src/content/releases/s/shed-seven/a-maximum-high/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1996-03-29 GB"
 ---
 ## About
 
-A Maximum High is the second studio album by York indie rock band Shed Seven, released on Polydor Records in 1996. It reached number eight on the UK Albums Chart and consolidated the commercial breakthrough of their debut Change Giver. The album reflects the band's anthemic, hook-laden Britpop sound and represents their most commercially successful period.
+*A Maximum High* reached number eight on the UK Albums Chart and consolidated the commercial breakthrough of their debut Change Giver.
+
+The album reflects the band's anthemic, hook-laden Britpop sound and represents their most commercially successful period.

--- a/src/content/releases/s/simple-minds/empires-and-dance/index.md
+++ b/src/content/releases/s/simple-minds/empires-and-dance/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1980-09-01 GB"
 ---
 ## About
 
-Empires And Dance is a release by Simple Minds released in 1980-09-01. It has been featured on 1 Sundown Sessions show. Featured tracks include I Travel.
+*Empires And Dance* earns its place in the Sundown Sessions catalogue through “I Travel”, a selection that offers a direct route into Simple Minds's work.
 
-
+Heard in the context of the full release, “I Travel” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/simple-minds/life-in-a-day/index.md
+++ b/src/content/releases/s/simple-minds/life-in-a-day/index.md
@@ -19,4 +19,6 @@ tracklist_edition: "1979-03-25 GB “Special View” fade-out pressing"
 ---
 ## About
 
-Life In A Day is the debut studio album by Glasgow post-punk band Simple Minds, released on Zoom Records in 1979. The album captures the band in their earliest phase, with an angular, new wave sound quite distinct from the anthemic stadium rock they would later become known for. It is an important document of the late-1970s Scottish post-punk scene.
+*Life In A Day* captures the band in their earliest phase, with an angular, new wave sound quite distinct from the anthemic stadium rock they would later become known for.
+
+It is an important document of the late-1970s Scottish post-punk scene.

--- a/src/content/releases/s/simple-minds/new-gold-dream-81-82-83-84/index.md
+++ b/src/content/releases/s/simple-minds/new-gold-dream-81-82-83-84/index.md
@@ -24,6 +24,6 @@ tracklist_edition: "1983-03-01 IT"
 ---
 ## About
 
-New Gold Dream (81/82/83/84) is a release by Simple Minds released in 1983-03-01. It has been featured on 1 Sundown Sessions show. Featured tracks include New Gold Dream (81/82/83/84).
+*New Gold Dream (81/82/83/84)* earns its place in the Sundown Sessions catalogue through “New Gold Dream (81/82/83/84)”, a selection that offers a direct route into Simple Minds's work.
 
-
+Heard in the context of the full release, “New Gold Dream (81/82/83/84)” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/simple-minds/reel-to-real-cacophony/index.md
+++ b/src/content/releases/s/simple-minds/reel-to-real-cacophony/index.md
@@ -49,10 +49,10 @@ tracklist_edition: "2003-01-06 GB"
 ---
 ## About
 
-Reel To Real Cacophony is a release by Simple Minds released in 1979. It has been featured on 1 Sundown Sessions show. Featured tracks include Changeling.
+*Reel To Real Cacophony* earns its place in the Sundown Sessions catalogue through “Changeling”, a selection that offers a direct route into Simple Minds's work.
+
+Heard in the context of the full release, “Changeling” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Changeling
-
-

--- a/src/content/releases/s/simple-minds/sons-and-fascinationsister-feelings-call/index.md
+++ b/src/content/releases/s/simple-minds/sons-and-fascinationsister-feelings-call/index.md
@@ -74,4 +74,6 @@ tracklist_edition: "1981-08 GB"
 ---
 ## About
 
-Sons and Fascination/Sister Feelings Call is the fourth and fifth studio albums by Simple Minds, released together as a double album package on Virgin Records in 1981. The record marked a decisive shift towards a more textural, synthesiser-led sound influenced by Krautrock and post-punk experimentalism. It reached number 11 on the UK Albums Chart and is considered a creative high point of the band's early career.
+*Sons And Fascination/Sister Feelings Call* marked a decisive shift towards a more textural, synthesiser-led sound influenced by Krautrock and post-punk experimentalism.
+
+It reached number 11 on the UK Albums Chart and is considered a creative high point of the band's early career.

--- a/src/content/releases/s/siobhan-wilson/there-are-no-saints/index.md
+++ b/src/content/releases/s/siobhan-wilson/there-are-no-saints/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "2017-07-14 XW"
 ---
 ## About
 
-There Are No Saints is a release by Siobhan Wilson released in 2017-07-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Make You Mine.
+*There Are No Saints* earns its place in the Sundown Sessions catalogue through “Make You Mine”, a selection that offers a direct route into Siobhan Wilson's work.
 
-
+Heard in the context of the full release, “Make You Mine” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/siouxsie-and-the-banshees/kaleidoscope/index.md
+++ b/src/content/releases/s/siouxsie-and-the-banshees/kaleidoscope/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1980 US"
 ---
 ## About
 
-Kaleidoscope is the third studio album by Bromley post-punk band Siouxsie and the Banshees, released on Polydor Records in 1980. It reached number five on the UK Albums Chart and marked the arrival of guitarist John McGeoch, whose fluid, multi-textured playing transformed the band's sound. The album is considered one of their finest, featuring the singles 'Happy House' and 'Christine'.
+*Kaleidoscope* reached number five on the UK Albums Chart and marked the arrival of guitarist John McGeoch, whose fluid, multi-textured playing transformed the band's sound.
+
+The album is considered one of their finest, featuring the singles 'Happy House' and 'Christine'.

--- a/src/content/releases/s/siouxsie-and-the-banshees/the-scream/index.md
+++ b/src/content/releases/s/siouxsie-and-the-banshees/the-scream/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1978 JP"
 ---
 ## About
 
-The Scream is the debut studio album by Bromley post-punk band Siouxsie and the Banshees, released on Polydor Records in 1978. It reached number 12 on the UK Albums Chart and is a foundational post-punk record, characterised by John McKay's abrasive guitar lines and Siouxsie Sioux's imperious, confrontational vocal style. The album influenced the subsequent development of gothic rock, post-punk, and new wave.
+*The Scream* influenced the subsequent development of gothic rock, post-punk, and new wave.
+
+It reached number 12 on the UK Albums Chart and is a foundational post-punk record, characterised by John McKay's abrasive guitar lines and Siouxsie Sioux's imperious, confrontational vocal style.

--- a/src/content/releases/s/siouxsie/mantaray/index.md
+++ b/src/content/releases/s/siouxsie/mantaray/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "2007-09-03 XE"
 ---
 ## About
 
-Mantaray is a release by Siouxsie released in 2007-09-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Into a Swan.
+*Mantaray* earns its place in the Sundown Sessions catalogue through “Into a Swan”, a selection that offers a direct route into Siouxsie's work.
 
-
+Heard in the context of the full release, “Into a Swan” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/sisters-of-mercy/first-and-last-and-always-collection/index.md
+++ b/src/content/releases/s/sisters-of-mercy/first-and-last-and-always-collection/index.md
@@ -67,10 +67,10 @@ tracklist_edition: "2015-07-24 XW remastered digital media version / Eldritch mi
 ---
 ## About
 
-First and Last and Always Collection is a release by Sisters of Mercy released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include Marian.
+*First and Last and Always Collection* earns its place in the Sundown Sessions catalogue through “Marian”, a selection that offers a direct route into Sisters of Mercy's work.
+
+Heard in the context of the full release, “Marian” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Marian
-
-

--- a/src/content/releases/s/sisters-of-mercy/some-girls-wander-by-mistake/index.md
+++ b/src/content/releases/s/sisters-of-mercy/some-girls-wander-by-mistake/index.md
@@ -81,6 +81,6 @@ tracklist_edition: "1992 US"
 ---
 ## About
 
-Some Girls Wander by Mistake is a release by Sisters of Mercy released in 1992-04-27. It has been featured on 1 Sundown Sessions show. Featured tracks include Alice.
+*Some Girls Wander by Mistake* earns its place in the Sundown Sessions catalogue through “Alice”, a selection that offers a direct route into Sisters of Mercy's work.
 
-
+Heard in the context of the full release, “Alice” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/skids/days-in-europa/index.md
+++ b/src/content/releases/s/skids/days-in-europa/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1979-10-12 GB"
 ---
 ## About
 
-Days In Europa is a release by Skids released in 1979-10-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Charade.
+*Days In Europa* earns its place in the Sundown Sessions catalogue through “Charade”, a selection that offers a direct route into Skids's work.
 
-
+Heard in the context of the full release, “Charade” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/skids/scared-to-dance/index.md
+++ b/src/content/releases/s/skids/scared-to-dance/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1979 CA"
 ---
 ## About
 
-Scared to Dance is the debut studio album by Dunfermline punk band Skids, released on Virgin Records in 1979. It reached number 19 on the UK Albums Chart and showcased the band's energetic blend of punk urgency and melodic guitar work, driven by Stuart Adamson's distinctive playing and Richard Jobson's declamatory vocals. Adamson would go on to found Big Country.
+*Scared To Dance* reached number 19 on the UK Albums Chart and showcased the band's energetic blend of punk urgency and melodic guitar work, driven by Stuart Adamson's distinctive playing and Richard Jobson's declamatory vocals.
+
+Adamson would go on to found Big Country.

--- a/src/content/releases/s/sleeper/smart/index.md
+++ b/src/content/releases/s/sleeper/smart/index.md
@@ -49,4 +49,6 @@ tracklist_edition: "1995 US"
 ---
 ## About
 
-Smart is the debut studio album by London indie rock band Sleeper, released on Indolent Records in 1995. The album established Louise Wener as one of the most distinctive voices of the Britpop era, combining sharp, sardonic lyrics with melodic indie pop. The band were a regular presence on the Britpop circuit alongside contemporaries such as Elastica and Echobelly.
+*Smart* established Louise Wener as one of the most distinctive voices of the Britpop era, combining sharp, sardonic lyrics with melodic indie pop.
+
+The band were a regular presence on the Britpop circuit alongside contemporaries such as Elastica and Echobelly.

--- a/src/content/releases/s/snowy-white/bird-of-paradise-an-anthology/index.md
+++ b/src/content/releases/s/snowy-white/bird-of-paradise-an-anthology/index.md
@@ -141,10 +141,10 @@ tracklist_edition: "2004 GB"
 ---
 ## About
 
-Bird of Paradise - An Anthology is a release by Snowy White released in 2003. It has been featured on 1 Sundown Sessions show. Featured tracks include Bird of Paradise.
+*Bird of Paradise - An Anthology* earns its place in the Sundown Sessions catalogue through “Bird of Paradise”, a selection that offers a direct route into Snowy White's work.
+
+Heard in the context of the full release, “Bird of Paradise” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Bird of Paradise
-
-

--- a/src/content/releases/s/soft-cell/non-stop-ecstatic-dancing/index.md
+++ b/src/content/releases/s/soft-cell/non-stop-ecstatic-dancing/index.md
@@ -42,6 +42,6 @@ tracklist_edition: "1982 GB"
 ---
 ## About
 
-Non Stop Ecstatic Dancing is a release by Soft Cell released in 1982-06-21. It has been featured on 1 Sundown Sessions show. Featured tracks include Tainted Love / Where Did Our Love Go?.
+*Non Stop Ecstatic Dancing* earns its place in the Sundown Sessions catalogue through “Tainted Love / Where Did Our Love Go?”, a selection that offers a direct route into Soft Cell's work.
 
-
+Heard in the context of the full release, “Tainted Love / Where Did Our Love Go?” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/soft-cell/non-stop-erotic-cabaret/index.md
+++ b/src/content/releases/s/soft-cell/non-stop-erotic-cabaret/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1981 GB"
 ---
 ## About
 
-Non-Stop Erotic Cabaret is the debut studio album by Leeds synth-pop duo Soft Cell, released in 1981. It reached number five on the UK Albums Chart and included the number-one hit 'Tainted Love' as well as the beloved 'Say Hello, Wave Goodbye'. The album's sleazy, electronic torch-song aesthetic made it one of the most distinctive records of the early 1980s.
+*Non-Stop Erotic Cabaret*'s sleazy, electronic torch-song aesthetic made it one of the most distinctive records of the early 1980s.
+
+It reached number five on the UK Albums Chart and included the number-one hit 'Tainted Love' as well as the beloved 'Say Hello, Wave Goodbye'.

--- a/src/content/releases/s/soft-machine/third/index.md
+++ b/src/content/releases/s/soft-machine/third/index.md
@@ -29,4 +29,6 @@ tracklist_edition: "1970-06-06 GB"
 ---
 ## About
 
-Third is the third studio album by British jazz rock band Soft Machine, released on CBS Records in 1970. The double album is a watershed moment in the development of fusion and progressive jazz-rock in Britain, featuring extended, largely instrumental compositions that draw on avant-garde jazz, rock, and classical music. It is widely regarded as one of the most important and adventurous British albums of the era.
+*Third* is widely regarded as one of the most important and adventurous British albums of the era.
+
+The double album is a watershed moment in the development of fusion and progressive jazz-rock in Britain, featuring extended, largely instrumental compositions that draw on avant-garde jazz, rock, and classical music.

--- a/src/content/releases/s/something-happens/stuck-together-with-gods-glue/index.md
+++ b/src/content/releases/s/something-happens/stuck-together-with-gods-glue/index.md
@@ -52,10 +52,10 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-Stuck Together With God's Glue is a release by Something Happens released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include Hello, Hello, Hello, Hello, Hello (Petrol).
+*Stuck Together With God's Glue* has supplied Sundown Sessions with “Hello”, “Hello”, “Hello”, “Hello” and “Hello (Petrol)”, giving more than one way into Something Happens's work.
+
+Together, those choices point beyond isolated favourites towards the character of the wider release.
 
 ## Tracks Featured on Sundown Sessions
 
 - Hello, Hello, Hello, Hello, Hello (Petrol)
-
-

--- a/src/content/releases/s/space/the-best-of/index.md
+++ b/src/content/releases/s/space/the-best-of/index.md
@@ -64,6 +64,6 @@ tracklist_edition: "2009-11-09 GB"
 ---
 ## About
 
-The Best Of is a release by Space released in 2009-11-09. It has been featured on 1 Sundown Sessions show. Featured tracks include Magic Fly.
+*The Best Of* earns its place in the Sundown Sessions catalogue through “Magic Fly”, a selection that offers a direct route into Space's work.
 
-
+Heard in the context of the full release, “Magic Fly” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/sparks/kimono-my-house/index.md
+++ b/src/content/releases/s/sparks/kimono-my-house/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1974 DE"
 ---
 ## About
 
-Kimono My House is a release by Sparks released in 1974-05. It has been featured on 1 Sundown Sessions show. Featured tracks include Amateur Hour.
+*Kimono My House* earns its place in the Sundown Sessions catalogue through “Amateur Hour”, a selection that offers a direct route into Sparks's work.
 
-
+Heard in the context of the full release, “Amateur Hour” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/sparks/no-1-in-heaven/index.md
+++ b/src/content/releases/s/sparks/no-1-in-heaven/index.md
@@ -31,4 +31,6 @@ tracklist_edition: "1979-03-02 GB"
 ---
 ## About
 
-No. 1 in Heaven is the ninth studio album by American pop duo Sparks, released on Virgin Records in 1979. Produced by Giorgio Moroder, it was a landmark record in the development of synth-pop and electronic dance music, combining Moroder's pulsing Eurodisco production with Ron Mael's deadpan vocal style. The album had a profound influence on the subsequent development of electronic pop in Britain.
+1 In Heaven* was a landmark record in the development of synth-pop and electronic dance music, combining Moroder's pulsing Eurodisco production with Ron Mael's deadpan vocal style.
+
+Produced by Giorgio Moroder, *No. The album had a profound influence on the subsequent development of electronic pop in Britain.

--- a/src/content/releases/s/spirit/spirit/index.md
+++ b/src/content/releases/s/spirit/spirit/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1968 US"
 ---
 ## About
 
-Spirit is the self-titled debut studio album by Los Angeles psychedelic rock band Spirit, released on Ode Records in 1968. The album introduces the band's unique blend of psychedelic rock, jazz, and folk influences, with Randy California's lyrical guitar work at its centre. Spirit were one of the most musically sophisticated and underappreciated acts of the late-1960s psychedelic movement.
+*Spirit* introduces the band's unique blend of psychedelic rock, jazz, and folk influences, with Randy California's lyrical guitar work at its centre.
+
+Spirit were one of the most musically sophisticated and underappreciated acts of the late-1960s psychedelic movement.

--- a/src/content/releases/s/spiritualized/ladies-and-gentlemen-we-are-floating-in-space/index.md
+++ b/src/content/releases/s/spiritualized/ladies-and-gentlemen-we-are-floating-in-space/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1997 XE clear tray"
 ---
 ## About
 
-Ladies and Gentlemen We Are Floating in Space is the third studio album by Rugby space rock band Spiritualized, released on Dedicated Records in 1997. It reached number four on the UK Albums Chart and is widely regarded as their masterpiece: a dense, orchestral, and emotionally overwhelming record that blends gospel, blues, and ambient music. The cover, designed to look like a pharmaceutical blister pack, is one of the most celebrated pieces of record packaging of the decade.
+*Ladies and Gentlemen We Are Floating in Space* reached number four on the UK Albums Chart and is widely regarded as their masterpiece: a dense, orchestral, and emotionally overwhelming record that blends gospel, blues, and ambient music.
+
+The cover, designed to look like a pharmaceutical blister pack, is one of the most celebrated pieces of record packaging of the decade.

--- a/src/content/releases/s/spoon/tv-set/index.md
+++ b/src/content/releases/s/spoon/tv-set/index.md
@@ -23,6 +23,6 @@ tracklist_edition: "2015-05-19 CA"
 ---
 ## About
 
-TV Set is a release by Spoon released in 2015-05-19. It has been featured on 1 Sundown Sessions show. Featured tracks include TV Set.
+*TV Set* earns its place in the Sundown Sessions catalogue through “TV Set”, a selection that offers a direct route into Spoon's work.
 
-
+Heard in the context of the full release, “TV Set” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/squeeze/east-side-story/index.md
+++ b/src/content/releases/s/squeeze/east-side-story/index.md
@@ -56,4 +56,6 @@ tracklist_edition: "1981 US"
 ---
 ## About
 
-East Side Story is the fourth studio album by London new wave band Squeeze, released on A&M Records in 1981. It reached number 19 on the UK Albums Chart and is widely regarded as one of their finest achievements, co-produced by Elvis Costello. The album draws on soul, pub rock, and skiffle to create a rich, eclectic sound underpinned by the songwriting partnership of Glenn Tilbrook and Chris Difford.
+*East Side Story* reached number 19 on the UK Albums Chart and is widely regarded as one of their finest achievements, co-produced by Elvis Costello.
+
+The album draws on soul, pub rock, and skiffle to create a rich, eclectic sound underpinned by the songwriting partnership of Glenn Tilbrook and Chris Difford.

--- a/src/content/releases/s/squeeze/some-fantastic-place/index.md
+++ b/src/content/releases/s/squeeze/some-fantastic-place/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1993-09 GB"
 ---
 ## About
 
-Some Fantastic Place is a release by Squeeze released in 1993-09-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Third Rail.
+*Some Fantastic Place* earns its place in the Sundown Sessions catalogue through “Third Rail”, a selection that offers a direct route into Squeeze's work.
 
-
+Heard in the context of the full release, “Third Rail” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/s/stereolab/transient-random-noise-bursts-with-announcements/index.md
+++ b/src/content/releases/s/stereolab/transient-random-noise-bursts-with-announcements/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1993-08 US"
 ---
 ## About
 
-Transient Random-Noise Bursts with Announcements is the second studio album by London-based Franco-British art pop band Stereolab, released on Duophonic Records in 1993. The album blends motorik rhythms, vintage keyboard sounds, and politically charged lyrics in a unique combination that drew on Krautrock, French pop, and post-punk. It is regarded as one of the most original and influential British albums of the early 1990s.
+*Transient Random-Noise Bursts with Announcements* is regarded as one of the most original and influential British albums of the early 1990s.
+
+The album blends motorik rhythms, vintage keyboard sounds, and politically charged lyrics in a unique combination that drew on Krautrock, French pop, and post-punk.

--- a/src/content/releases/s/stevie-ray-vaughan/texas-flood-legacy-edition/index.md
+++ b/src/content/releases/s/stevie-ray-vaughan/texas-flood-legacy-edition/index.md
@@ -93,10 +93,10 @@ tracklist_edition: "2013-01-28 XE legacy edition"
 ---
 ## About
 
-Texas Flood (Legacy Edition) is a release by Stevie Ray Vaughan released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Tell Me.
+*Texas Flood (Legacy Edition)* earns its place in the Sundown Sessions catalogue through “Tell Me”, a selection that offers a direct route into Stevie Ray Vaughan's work.
+
+Heard in the context of the full release, “Tell Me” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Tell Me
-
-

--- a/src/content/releases/s/subway-sect/we-oppose-all-rock-roll/index.md
+++ b/src/content/releases/s/subway-sect/we-oppose-all-rock-roll/index.md
@@ -73,4 +73,6 @@ tracklist_edition: "1996 GB"
 ---
 ## About
 
-We Oppose All Rock & Roll is a retrospective compilation documenting the early recordings of Vic Godard's Subway Sect, one of the most underrated acts of the original UK punk scene. The band's angular, minimal approach was enormously influential on the subsequent post-punk and indie movements.
+The band's angular, minimal approach was enormously influential on the subsequent post-punk and indie movements.
+
+We Oppose All Rock & Roll is a retrospective compilation documenting the early recordings of Vic Godard's Subway Sect, one of the most underrated acts of the original UK punk scene.

--- a/src/content/releases/s/suede/dog-man-star-30th-anniversary-edition/index.md
+++ b/src/content/releases/s/suede/dog-man-star-30th-anniversary-edition/index.md
@@ -125,4 +125,4 @@ tracklist_edition: "2024-10-18 XE 30th Anniversary Edition"
 ---
 ## About
 
-Dog Man Star (30th Anniversary Edition) is the expanded reissue of Suede's acclaimed 1994 second album, released in 2024 to celebrate its 30th anniversary. The original album, one of the defining records of the Britpop era, is presented here alongside previously unreleased material and alternative versions, offering a comprehensive account of the band's most ambitious recording project.
+The original album, one of the defining records of the Britpop era, is presented here alongside previously unreleased material and alternative versions, offering a comprehensive account of the band's most ambitious recording project.

--- a/src/content/releases/s/suede/dog-man-star/index.md
+++ b/src/content/releases/s/suede/dog-man-star/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1994-10-10 GB"
 ---
 ## About
 
-Dog Man Star is the second studio album by London glam rock band Suede, released on Nude Records in 1994. It reached number three on the UK Albums Chart and is widely regarded as their masterpiece: a sprawling, orchestral record in which Brett Anderson's literary romanticism meets Bernard Butler's extravagant guitar work. The album was recorded amid considerable personal and creative tension within the band.
+*Dog Man Star* reached number three on the UK Albums Chart and is widely regarded as their masterpiece: a sprawling, orchestral record in which Brett Anderson's literary romanticism meets Bernard Butler's extravagant guitar work.
+
+The album was recorded amid considerable personal and creative tension within the band.

--- a/src/content/releases/s/super-furry-animals/rings-around-the-world/index.md
+++ b/src/content/releases/s/super-furry-animals/rings-around-the-world/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "2001-07-23 GB"
 ---
 ## About
 
-Rings Around the World is the fifth studio album by Welsh psychedelic rock band Super Furry Animals, released on Epic Records in 2001. It debuted at number one on the UK Albums Chart, becoming the band's first chart-topper, and went on to win the Welsh Music Prize. The album represents a high-water mark of their career, blending pop hooks with ambitious studio experimentation.
+*Rings Around the World* represents a high-water mark of their career, blending pop hooks with ambitious studio experimentation.
+
+It debuted at number one on the UK Albums Chart, becoming the band's first chart-topper, and went on to win the Welsh Music Prize.

--- a/src/content/releases/s/supergrass/i-should-coco/index.md
+++ b/src/content/releases/s/supergrass/i-should-coco/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "1995 AU"
 ---
 ## About
 
-I Should Coco is the debut studio album by Oxford indie rock band Supergrass, released on Parlophone in 1995. It debuted at number one on the UK Albums Chart and was a critical and commercial sensation, combining the energy of punk with an irresistible melodic sensibility. The album spawned the hit singles 'Alright' and 'Lenny', and helped define the exuberant, youthful spirit of mid-1990s Britpop.
+*I Should Coco* spawned the hit singles 'Alright' and 'Lenny', and helped define the exuberant, youthful spirit of mid-1990s Britpop.
+
+It debuted at number one on the UK Albums Chart and was a critical and commercial sensation, combining the energy of punk with an irresistible melodic sensibility.

--- a/src/content/releases/t/t-rex/tanx/index.md
+++ b/src/content/releases/t/t-rex/tanx/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "1973 US"
 ---
 ## About
 
-Tanx is a release by T. Rex released in 1973-01-28. It has been featured on 1 Sundown Sessions show. Featured tracks include 20th Century Boy.
+*Tanx* earns its place in the Sundown Sessions catalogue through “20th Century Boy”, a selection that offers a direct route into T. Rex's work.
 
-
+Heard in the context of the full release, “20th Century Boy” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/talk-talk/the-colour-of-spring/index.md
+++ b/src/content/releases/t/talk-talk/the-colour-of-spring/index.md
@@ -48,6 +48,6 @@ tracklist_edition: "1986 GB"
 ---
 ## About
 
-The Colour of Spring is a release by Talk Talk released in 1986-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Life's What You Make It.
+*The Colour of Spring* earns its place in the Sundown Sessions catalogue through “Life's What You Make It”, a selection that offers a direct route into Talk Talk's work.
 
-
+Heard in the context of the full release, “Life's What You Make It” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/talk-talk/the-partys-over/index.md
+++ b/src/content/releases/t/talk-talk/the-partys-over/index.md
@@ -40,10 +40,10 @@ tracklist_edition: "1982 US"
 ---
 ## About
 
-The Party's Over is a release by Talk Talk released in 1982. It has been featured on 1 Sundown Sessions show. Featured tracks include Talk Talk.
+*The Party's Over* earns its place in the Sundown Sessions catalogue through “Talk Talk”, a selection that offers a direct route into Talk Talk's work.
+
+Heard in the context of the full release, “Talk Talk” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Talk Talk
-
-

--- a/src/content/releases/t/talking-heads/burning-down-the-house/index.md
+++ b/src/content/releases/t/talking-heads/burning-down-the-house/index.md
@@ -33,6 +33,6 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-Burning Down the House is a release by Talking Heads released in 1983. It has been featured on 1 Sundown Sessions show. Featured tracks include Burning Down the House.
+*Burning Down the House* earns its place in the Sundown Sessions catalogue through “Burning Down the House”, a selection that offers a direct route into Talking Heads's work.
 
-
+Heard in the context of the full release, “Burning Down the House” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/talking-heads/fear-of-music/index.md
+++ b/src/content/releases/t/talking-heads/fear-of-music/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1979 JP"
 ---
 ## About
 
-Fear of Music is the third studio album by New York art rock band Talking Heads, released on Sire Records in 1979. Co-produced with Brian Eno, the album expands the band's sound into funk, Afrobeat, and ambient music, creating a more paranoid and angular record than their previous work. It is regarded as one of the most innovative albums of the post-punk era.
+*Fear of Music* is regarded as one of the most innovative albums of the post-punk era.
+
+Co-produced with Brian Eno, the album expands the band's sound into funk, Afrobeat, and ambient music, creating a more paranoid and angular record than their previous work.

--- a/src/content/releases/t/taste/on-the-boards/index.md
+++ b/src/content/releases/t/taste/on-the-boards/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1970 GB"
 ---
 ## About
 
-On the Boards is the second and final studio album by Belfast blues rock band Taste, released on Polydor Records in 1970. It reached number 18 on the UK Albums Chart and is widely regarded as their most ambitious work, with guitarist Rory Gallagher displaying some of his most adventurous playing. The album incorporates jazz and folk elements alongside the band's characteristic blues rock.
+*On the Boards* reached number 18 on the UK Albums Chart and is widely regarded as their most ambitious work, with guitarist Rory Gallagher displaying some of his most adventurous playing.
+
+The album incorporates jazz and folk elements alongside the band's characteristic blues rock.

--- a/src/content/releases/t/tears-for-fears/the-tipping-point/index.md
+++ b/src/content/releases/t/tears-for-fears/the-tipping-point/index.md
@@ -21,6 +21,6 @@ tracklist_edition: "2021-10-07 XW"
 ---
 ## About
 
-The Tipping Point is a release by Tears For Fears released in 2021-10-07. It has been featured on 1 Sundown Sessions show. Featured tracks include My Demons.
+*The Tipping Point* earns its place in the Sundown Sessions catalogue through “My Demons”, a selection that offers a direct route into Tears For Fears's work.
 
-
+Heard in the context of the full release, “My Demons” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/teenage-fanclub/bandwagonesque/index.md
+++ b/src/content/releases/t/teenage-fanclub/bandwagonesque/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1991 US"
 ---
 ## About
 
-Bandwagonesque is the third studio album by Scottish indie rock band Teenage Fanclub, released on Creation Records in 1991. It reached number 22 on the UK Albums Chart and was voted album of the year by Spin magazine, ahead of Nevermind and Achtung Baby. The album distils influences from the Byrds and Big Star into a series of gloriously melodic, hook-laden guitar-pop songs.
+*Bandwagonesque* distils influences from the Byrds and Big Star into a series of gloriously melodic, hook-laden guitar-pop songs.
+
+It reached number 22 on the UK Albums Chart and was voted album of the year by Spin magazine, ahead of Nevermind and Achtung Baby.

--- a/src/content/releases/t/teenage-fanclub/four-thousand-seven-hundred-and-seventy-seconds-a-shortcut-to-teenage-fanclub/index.md
+++ b/src/content/releases/t/teenage-fanclub/four-thousand-seven-hundred-and-seventy-seconds-a-shortcut-to-teenage-fanclub/index.md
@@ -76,10 +76,10 @@ tracklist_edition: "2003 ES"
 ---
 ## About
 
-Four Thousand, Seven Hundred and Seventy seconds; A Shortcut to Teenage Fanclub is a release by Teenage Fanclub released in 2003. It has been featured on 1 Sundown Sessions show. Featured tracks include Ain't That Enough.
+*Four Thousand, Seven Hundred and Seventy seconds; A Shortcut to Teenage Fanclub* earns its place in the Sundown Sessions catalogue through “Ain't That Enough”, a selection that offers a direct route into Teenage Fanclub's work.
+
+Heard in the context of the full release, “Ain't That Enough” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Ain't That Enough
-
-

--- a/src/content/releases/t/ten-years-after/a-space-in-time/index.md
+++ b/src/content/releases/t/ten-years-after/a-space-in-time/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1971-08 GB"
 ---
 ## About
 
-A Space in Time is the sixth studio album by Nottingham blues rock band Ten Years After, released on Chrysalis Records in 1971. It reached number 36 on the UK Albums Chart and includes 'I'd Love to Change the World', their best-known track and a significant international hit. The album demonstrates the band's ability to blend acoustic and electric textures within a broadly blues rock framework.
+*A Space in Time* demonstrates the band's ability to blend acoustic and electric textures within a broadly blues rock framework.
+
+It reached number 36 on the UK Albums Chart and includes 'I'd Love to Change the World', their best-known track and a significant international hit.

--- a/src/content/releases/t/terrorvision/how-to-make-friends-and-influence-people/index.md
+++ b/src/content/releases/t/terrorvision/how-to-make-friends-and-influence-people/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "1994 GB missing Total Vegas Recordings cat#"
 ---
 ## About
 
-How to Make Friends and Influence People is the second studio album by Bradford rock band Terrorvision, released in 1994. It reached number 18 on the UK Albums Chart and spawned the hits 'Oblivion' and 'Pretend Best Friend'. The album showcases the band's energetic blend of pop hooks and grunge-influenced rock that made them one of the more commercially successful British rock bands of the mid-1990s.
+*How to Make Friends and Influence People* showcases the band's energetic blend of pop hooks and grunge-influenced rock that made them one of the more commercially successful British rock bands of the mid-1990s.
+
+It reached number 18 on the UK Albums Chart and spawned the hits 'Oblivion' and 'Pretend Best Friend'.

--- a/src/content/releases/t/the-13th-floor-elevators/easter-everywhere/index.md
+++ b/src/content/releases/t/the-13th-floor-elevators/easter-everywhere/index.md
@@ -43,4 +43,4 @@ tracklist_edition: "1967 US mono"
 ---
 ## About
 
-Easter Everywhere is the second studio album by Austin psychedelic rock band The 13th Floor Elevators, released on International Artists in 1967. Led by Roky Erickson, the album is a remarkable document of the psychedelic movement's most experimental outer reaches, combining electric jug, distorted guitar, and ecstatic vocal performances.
+Led by Roky Erickson, *Easter Everywhere* is a remarkable document of the psychedelic movement's most experimental outer reaches, combining electric jug, distorted guitar, and ecstatic vocal performances.

--- a/src/content/releases/t/the-adventures/the-sea-of-love/index.md
+++ b/src/content/releases/t/the-adventures/the-sea-of-love/index.md
@@ -49,6 +49,6 @@ tracklist_edition: "1988 US"
 ---
 ## About
 
-The Sea Of Love is a release by The Adventures released in 1988. It has been featured on 1 Sundown Sessions show. Featured tracks include Broken Land.
+*The Sea Of Love* earns its place in the Sundown Sessions catalogue through “Broken Land”, a selection that offers a direct route into The Adventures's work.
 
-
+Heard in the context of the full release, “Broken Land” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-airborne-toxic-event/digital-ep/index.md
+++ b/src/content/releases/t/the-airborne-toxic-event/digital-ep/index.md
@@ -21,10 +21,10 @@ tracklist_edition: "2008-09-22 GB"
 ---
 ## About
 
-Digital EP is a release by The Airborne Toxic Event. It has been featured on 1 Sundown Sessions show. Featured tracks include This Is Nowhere.
+*Digital EP* earns its place in the Sundown Sessions catalogue through “This Is Nowhere”, a selection that offers a direct route into The Airborne Toxic Event's work.
+
+Heard in the context of the full release, “This Is Nowhere” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - This Is Nowhere
-
-

--- a/src/content/releases/t/the-alarm/declaration/index.md
+++ b/src/content/releases/t/the-alarm/declaration/index.md
@@ -56,6 +56,6 @@ tracklist_edition: "1984 GB"
 ---
 ## About
 
-Declaration is a release by The Alarm released in 1984-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Sixty Eight Guns.
+*Declaration* earns its place in the Sundown Sessions catalogue through “Sixty Eight Guns”, a selection that offers a direct route into The Alarm's work.
 
-
+Heard in the context of the full release, “Sixty Eight Guns” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-associates/the-very-best-of-the-associates/index.md
+++ b/src/content/releases/t/the-associates/the-very-best-of-the-associates/index.md
@@ -117,10 +117,10 @@ tracklist_edition: "2016-04-08 GB"
 ---
 ## About
 
-The Very Best of The Associates is a release by The Associates released in 2016. It has been featured on 1 Sundown Sessions show. Featured tracks include White Car in Germany.
+*The Very Best of The Associates* earns its place in the Sundown Sessions catalogue through “White Car in Germany”, a selection that offers a direct route into The Associates's work.
+
+Heard in the context of the full release, “White Car in Germany” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - White Car in Germany
-
-

--- a/src/content/releases/t/the-beatles/abbey-road/index.md
+++ b/src/content/releases/t/the-beatles/abbey-road/index.md
@@ -65,4 +65,6 @@ tracklist_edition: "1969 ES"
 ---
 ## About
 
-Abbey Road is the eleventh studio album by Liverpool rock band The Beatles, released on Apple Records in 1969. It topped the UK Albums Chart and has never left the top tier of British albums since. The album was the last to be recorded by the four Beatles together and includes such enduring compositions as 'Come Together', 'Something', and the extended 'Golden Slumbers / Carry That Weight / The End' medley.
+*Abbey Road* was the last to be recorded by the four Beatles together and includes such enduring compositions as 'Come Together', 'Something', and the extended 'Golden Slumbers / Carry That Weight / The End' medley.
+
+It topped the UK Albums Chart and has never left the top tier of British albums since.

--- a/src/content/releases/t/the-beatles/the-beatles-1967-1970-remastered/index.md
+++ b/src/content/releases/t/the-beatles/the-beatles-1967-1970-remastered/index.md
@@ -133,10 +133,10 @@ tracklist_edition: "2015-12-24 XW Remastered"
 ---
 ## About
 
-The Beatles 1967 - 1970 (Remastered) is a release by The Beatles released in 1973. It has been featured on 1 Sundown Sessions show. Featured tracks include Revolution - Remastered 2009.
+*The Beatles 1967 - 1970 (Remastered)* earns its place in the Sundown Sessions catalogue through “Revolution - Remastered 2009”, a selection that offers a direct route into The Beatles's work.
+
+Heard in the context of the full release, “Revolution - Remastered 2009” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Revolution - Remastered 2009
-
-

--- a/src/content/releases/t/the-beatles/the-beatles/index.md
+++ b/src/content/releases/t/the-beatles/the-beatles/index.md
@@ -78,6 +78,6 @@ tracklist_edition: ""
 ---
 ## About
 
-The Beatles is a release by The Beatles released in 1968. It has been featured on 2 Sundown Sessions shows. Featured tracks include Everybody's Got Something To Hide Except Me And My Monkey, Glass Onion, Good Night.
+*The Beatles* has supplied Sundown Sessions with “Everybody's Got Something To Hide Except Me And My Monkey”, “Glass Onion” and “Good Night”, giving more than one way into The Beatles's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/t/the-birthday-party/prayers-on-fire/index.md
+++ b/src/content/releases/t/the-birthday-party/prayers-on-fire/index.md
@@ -46,4 +46,4 @@ tracklist_edition: "1981 NZ"
 ---
 ## About
 
-Prayers on Fire is the second studio album by Melbourne avant-garde punk band The Birthday Party, released on Missing Link Records in 1981. The album is a visceral, chaotic document of one of the most extreme bands to emerge from the post-punk era, featuring Nick Cave's increasingly confrontational lyrics and the band's deliberately abrasive, experimental sound.
+*Prayers on Fire* is a visceral, chaotic document of one of the most extreme bands to emerge from the post-punk era, featuring Nick Cave's increasingly confrontational lyrics and the band's deliberately abrasive, experimental sound.

--- a/src/content/releases/t/the-blue-nile/hats/index.md
+++ b/src/content/releases/t/the-blue-nile/hats/index.md
@@ -35,4 +35,6 @@ tracklist_edition: "1989 GB"
 ---
 ## About
 
-Hats is the second studio album by Glasgow art pop trio The Blue Nile, released on Linn Records in 1989. It reached number 12 on the UK Albums Chart and is their most celebrated work: a sparse, atmospheric record of extraordinary emotional depth, centred on Paul Buchanan's aching vocals and the band's meticulous attention to sonic detail. The album has achieved a devoted cult following worldwide.
+*Hats* has achieved a devoted cult following worldwide.
+
+It reached number 12 on the UK Albums Chart and is their most celebrated work: a sparse, atmospheric record of extraordinary emotional depth, centred on Paul Buchanan's aching vocals and the band's meticulous attention to sonic detail.

--- a/src/content/releases/t/the-bravery/the-bravery/index.md
+++ b/src/content/releases/t/the-bravery/the-bravery/index.md
@@ -51,4 +51,6 @@ tracklist_edition: "2005 AR"
 ---
 ## About
 
-The Bravery is the self-titled debut album by New York new wave revival band The Bravery, released on Island Records in 2005. It reached number four on the UK Albums Chart and spawned the single 'An Honest Mistake', which peaked at number seven in the UK. The album helped define the 2000s new wave revival alongside contemporaries such as The Killers and Interpol.
+*The Bravery* helped define the 2000s new wave revival alongside contemporaries such as The Killers and Interpol.
+
+It reached number four on the UK Albums Chart and spawned the single 'An Honest Mistake', which peaked at number seven in the UK.

--- a/src/content/releases/t/the-byrds/younger-than-yesterday/index.md
+++ b/src/content/releases/t/the-byrds/younger-than-yesterday/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1967-02-06 US mono"
 ---
 ## About
 
-Younger Than Yesterday is the fourth studio album by Los Angeles folk rock band The Byrds, released on Columbia Records in 1967. It is regarded as one of their most inventive and satisfying records, featuring contributions from all four band members and encompassing folk rock, country, psychedelia, and even proto-world music influences. The album includes 'So You Want to Be a Rock 'n' Roll Star' and 'My Back Pages'.
+*Younger Than Yesterday* is regarded as one of their most inventive and satisfying records, featuring contributions from all four band members and encompassing folk rock, country, psychedelia, and even proto-world music influences.
+
+The album includes 'So You Want to Be a Rock 'n' Roll Star' and 'My Back Pages'.

--- a/src/content/releases/t/the-cars/the-cars/index.md
+++ b/src/content/releases/t/the-cars/the-cars/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "1978 GB"
 ---
 ## About
 
-The Cars is a release by The Cars released in 1978-06-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Just What I Needed.
+*The Cars* earns its place in the Sundown Sessions catalogue through “Just What I Needed”, a selection that offers a direct route into The Cars's work.
 
-
+Heard in the context of the full release, “Just What I Needed” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-chameleons/script-of-the-bridge/index.md
+++ b/src/content/releases/t/the-chameleons/script-of-the-bridge/index.md
@@ -49,4 +49,6 @@ tracklist_edition: "1983 NL"
 ---
 ## About
 
-Script of the Bridge is the debut studio album by Middleton post-punk band The Chameleons, released on Epic Records in 1983. It is regarded as one of the defining albums of the UK post-punk era, combining shimmering, delay-drenched guitars with emotionally intense songwriting from vocalist Mark Burgess. The album has grown in stature considerably since its original release.
+*Script of the Bridge* is regarded as one of the defining albums of the UK post-punk era, combining shimmering, delay-drenched guitars with emotionally intense songwriting from vocalist Mark Burgess.
+
+The album has grown in stature considerably since its original release.

--- a/src/content/releases/t/the-charlatans/some-friendly/index.md
+++ b/src/content/releases/t/the-charlatans/some-friendly/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1990 FR"
 ---
 ## About
 
-Some Friendly is the debut studio album by Northwich indie rock band The Charlatans, released on Situation Two Records in 1990. It debuted at number one on the UK Albums Chart on its release week, driven by the organ-led groove of 'The Only One I Know'. The album is a key document of the Madchester era, blending psychedelic pop with baggy rhythms and a warm, danceable energy.
+*Some Friendly* is a key document of the Madchester era, blending psychedelic pop with baggy rhythms and a warm, danceable energy.
+
+It debuted at number one on the UK Albums Chart on its release week, driven by the organ-led groove of 'The Only One I Know'.

--- a/src/content/releases/t/the-civil-wars/the-civil-wars/index.md
+++ b/src/content/releases/t/the-civil-wars/the-civil-wars/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "2013 AR"
 ---
 ## About
 
-The Civil Wars is a release by The Civil Wars released in 2013-07-30. It has been featured on 1 Sundown Sessions show. Featured tracks include The One That Got Away.
+*The Civil Wars* earns its place in the Sundown Sessions catalogue through “The One That Got Away”, a selection that offers a direct route into The Civil Wars's work.
 
-
+Heard in the context of the full release, “The One That Got Away” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-clash/london-calling/index.md
+++ b/src/content/releases/t/the-clash/london-calling/index.md
@@ -23,4 +23,6 @@ tracklist_edition: "1979 GB"
 ---
 ## About
 
-London Calling is the third studio album by London punk rock band The Clash, released as a double album on CBS Records in 1979. It reached number nine on the UK Albums Chart and is widely regarded as one of the greatest albums ever recorded. The record expanded the band's sound far beyond punk to encompass ska, reggae, rockabilly, jazz, and pop, cementing The Clash's status as the definitive political rock band of their era.
+*London Calling* reached number nine on the UK Albums Chart and is widely regarded as one of the greatest albums ever recorded.
+
+The record expanded the band's sound far beyond punk to encompass ska, reggae, rockabilly, jazz, and pop, cementing The Clash's status as the definitive political rock band of their era.

--- a/src/content/releases/t/the-coral/magic-and-medicine/index.md
+++ b/src/content/releases/t/the-coral/magic-and-medicine/index.md
@@ -50,4 +50,4 @@ tracklist_edition: "2003 GB"
 ---
 ## About
 
-Magic and Medicine is the second studio album by Hoylake psychedelic pop band The Coral, released on Deltasonic Records in 2003. It reached number two on the UK Albums Chart and built on the promise of their acclaimed debut, showcasing the band's eclectic blend of 1960s influences: from Merseybeat to the Kinks to West Coast psychedelia.
+*Magic and Medicine* reached number two on the UK Albums Chart and built on the promise of their acclaimed debut, showcasing the band's eclectic blend of 1960s influences: from Merseybeat to the Kinks to West Coast psychedelia.

--- a/src/content/releases/t/the-countess-of-fife/star-of-the-sea/index.md
+++ b/src/content/releases/t/the-countess-of-fife/star-of-the-sea/index.md
@@ -49,10 +49,10 @@ tracklist_edition: "1996-07 DE"
 ---
 ## About
 
-Star Of The Sea is a release by The Countess Of Fife released in 2022. It has been featured on 1 Sundown Sessions show. Featured tracks include Trapped.
+*Star Of The Sea* earns its place in the Sundown Sessions catalogue through “Trapped”, a selection that offers a direct route into The Countess Of Fife's work.
+
+Heard in the context of the full release, “Trapped” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Trapped
-
-

--- a/src/content/releases/t/the-cult/born-into-this/index.md
+++ b/src/content/releases/t/the-cult/born-into-this/index.md
@@ -82,6 +82,6 @@ tracklist_edition: "2007 XE Savage Edition"
 ---
 ## About
 
-Born Into This is a release by The Cult released in 2007-08-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Dirty Little Rockstar.
+*Born Into This* earns its place in the Sundown Sessions catalogue through “Dirty Little Rockstar”, a selection that offers a direct route into The Cult's work.
 
-
+Heard in the context of the full release, “Dirty Little Rockstar” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-cult/choice-of-weapon/index.md
+++ b/src/content/releases/t/the-cult/choice-of-weapon/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "2012-10-16 None"
 ---
 ## About
 
-Choice of Weapon is the ninth studio album by Bradford rock band The Cult, released on Cooking Vinyl in 2012. It reached number 20 on the UK Albums Chart and marked the band's first studio album in five years, following Born Into This (2007). The record received generally positive reviews for its muscular, hook-driven rock sound.
+*Choice of Weapon* reached number 20 on the UK Albums Chart and marked the band's first studio album in five years, following Born Into This (2007).
+
+The record received generally positive reviews for its muscular, hook-driven rock sound.

--- a/src/content/releases/t/the-cult/dreamtime-2024-remaster/index.md
+++ b/src/content/releases/t/the-cult/dreamtime-2024-remaster/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "2024-02-23 None 2024 remaster"
 ---
 ## About
 
-Dreamtime (2024 Remaster) is a release by The Cult released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include 83rd Dream - 2024 Remaster.
+*Dreamtime (2024 Remaster)* earns its place in the Sundown Sessions catalogue through “83rd Dream - 2024 Remaster”, a selection that offers a direct route into The Cult's work.
+
+Heard in the context of the full release, “83rd Dream - 2024 Remaster” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - 83rd Dream - 2024 Remaster
-
-

--- a/src/content/releases/t/the-cult/dreamtime-live-at-the-lyceum/index.md
+++ b/src/content/releases/t/the-cult/dreamtime-live-at-the-lyceum/index.md
@@ -52,6 +52,6 @@ tracklist_edition: "1985-09-21 JP"
 ---
 ## About
 
-Dreamtime (Live at The Lyceum) is a release by The Cult released in 1985-09-21. It has been featured on 1 Sundown Sessions show. Featured tracks include 83rd Dream.
+*Dreamtime (Live at The Lyceum)* earns its place in the Sundown Sessions catalogue through “83rd Dream”, a selection that offers a direct route into The Cult's work.
 
-
+Heard in the context of the full release, “83rd Dream” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-cult/electric/index.md
+++ b/src/content/releases/t/the-cult/electric/index.md
@@ -59,6 +59,6 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-Electric is a release by The Cult released in 1987-05-21. It has been featured on 2 Sundown Sessions shows. Featured tracks include Born To Be Wild, Electric Ocean.
+*Electric* has supplied Sundown Sessions with “Born To Be Wild” and “Electric Ocean”, giving more than one way into The Cult's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/t/the-cult/love/index.md
+++ b/src/content/releases/t/the-cult/love/index.md
@@ -62,6 +62,6 @@ tracklist_edition: "1985 GB"
 ---
 ## About
 
-Love is a release by The Cult released in 1985-08. It has been featured on 2 Sundown Sessions shows. Featured tracks include Big Neon Glitter, Nirvana.
+*Love* has supplied Sundown Sessions with “Big Neon Glitter” and “Nirvana”, giving more than one way into The Cult's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/t/the-cure/faith/index.md
+++ b/src/content/releases/t/the-cure/faith/index.md
@@ -38,4 +38,6 @@ tracklist_edition: "1981-04 AU"
 ---
 ## About
 
-Faith is the third studio album by Crawley post-punk band The Cure, released on Fiction Records in 1981. It reached number 14 on the UK Albums Chart and is the most austere and melancholy of the band's early 'dark trilogy'. Characterised by sparse guitar, bass, and Robert Smith's hushed, grief-stricken vocals, the album is a landmark of gothic and post-punk music.
+Characterised by sparse guitar, bass, and Robert Smith's hushed, grief-stricken vocals, *Faith* is a landmark of gothic and post-punk music.
+
+It reached number 14 on the UK Albums Chart and is the most austere and melancholy of the band's early 'dark trilogy'.

--- a/src/content/releases/t/the-damned/anything/index.md
+++ b/src/content/releases/t/the-damned/anything/index.md
@@ -22,4 +22,6 @@ tracklist_edition: "1986 DE"
 ---
 ## About
 
-Anything is the sixth studio album by London punk rock band The Damned, released on MCA Records in 1986. The album demonstrated the band's evolution beyond their original punk sound, incorporating psychedelic and gothic pop influences. It included a cover of Arthur Lee's 'Alone Again Or', which became the band's final UK Top 40 single to date, peaking at number 27.
+*Anything* included a cover of Arthur Lee's 'Alone Again Or', which became the band's final UK Top 40 single to date, peaking at number 27.
+
+The album demonstrated the band's evolution beyond their original punk sound, incorporating psychedelic and gothic pop influences.

--- a/src/content/releases/t/the-damned/new-rose/index.md
+++ b/src/content/releases/t/the-damned/new-rose/index.md
@@ -28,6 +28,6 @@ tracklist_edition: "1976-10-22 GB"
 ---
 ## About
 
-New Rose is a release by The Damned released in 1976-10-22. It has been featured on 1 Sundown Sessions show. Featured tracks include New Rose.
+*New Rose* earns its place in the Sundown Sessions catalogue through “New Rose”, a selection that offers a direct route into The Damned's work.
 
-
+Heard in the context of the full release, “New Rose” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-darkness/permission-to-land/index.md
+++ b/src/content/releases/t/the-darkness/permission-to-land/index.md
@@ -76,6 +76,6 @@ tracklist_edition: "2003 GB"
 ---
 ## About
 
-Permission to Land is a release by The Darkness released in 2003-07-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Growing on Me.
+*Permission to Land* earns its place in the Sundown Sessions catalogue through “Growing on Me”, a selection that offers a direct route into The Darkness's work.
 
-
+Heard in the context of the full release, “Growing on Me” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-detroit-cobras/life-love-and-leaving/index.md
+++ b/src/content/releases/t/the-detroit-cobras/life-love-and-leaving/index.md
@@ -66,6 +66,6 @@ tracklist_edition: "2001-04 US"
 ---
 ## About
 
-Life, Love And Leaving is a release by The Detroit Cobras released in 2001-04. It has been featured on 2 Sundown Sessions shows. Featured tracks include Cry On, Shout Bamalama.
+*Life, Love And Leaving* has supplied Sundown Sessions with “Cry On” and “Shout Bamalama”, giving more than one way into The Detroit Cobras's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/t/the-doors/absolutely-live/index.md
+++ b/src/content/releases/t/the-doors/absolutely-live/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "1970 GB"
 ---
 ## About
 
-Absolutely Live is a release by The Doors released in 1970-07. It has been featured on 1 Sundown Sessions show. Featured tracks include Who Do You Love.
+*Absolutely Live* earns its place in the Sundown Sessions catalogue through “Who Do You Love”, a selection that offers a direct route into The Doors's work.
 
-
+Heard in the context of the full release, “Who Do You Love” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-doors/strange-days/index.md
+++ b/src/content/releases/t/the-doors/strange-days/index.md
@@ -56,6 +56,6 @@ tracklist_edition: "1967-09-27 US mono"
 ---
 ## About
 
-Strange Days is a release by The Doors released in 1967-09-27. It has been featured on 2 Sundown Sessions shows. Featured tracks include Strange Days, When the Music's Over.
+*Strange Days* has supplied Sundown Sessions with “Strange Days” and “When the Music's Over”, giving more than one way into The Doors's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/t/the-doors/the-doors/index.md
+++ b/src/content/releases/t/the-doors/the-doors/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1967-01-04 US stereo"
 ---
 ## About
 
-The Doors is the self-titled debut studio album by Los Angeles rock band The Doors, released on Elektra Records in 1967. The album reached number two on the US Billboard 200 and includes 'Light My Fire', which became a number-one hit. It introduces Jim Morrison's literary, Dionysian vision alongside Ray Manzarek's keyboard work and Robby Krieger's blues-inflected guitar playing.
+*The Doors* reached number two on the US Billboard 200 and includes 'Light My Fire', which became a number-one hit.
+
+It introduces Jim Morrison's literary, Dionysian vision alongside Ray Manzarek's keyboard work and Robby Krieger's blues-inflected guitar playing.

--- a/src/content/releases/t/the-easybeats/easy/index.md
+++ b/src/content/releases/t/the-easybeats/easy/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "1965-09-23 AU"
 ---
 ## About
 
-Easy is a release by The Easybeats released in 1965-09-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Friday On My Mind.
+*Easy* earns its place in the Sundown Sessions catalogue through “Friday On My Mind”, a selection that offers a direct route into The Easybeats's work.
 
-
+Heard in the context of the full release, “Friday On My Mind” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-electric-prunes/mass-in-f-minor/index.md
+++ b/src/content/releases/t/the-electric-prunes/mass-in-f-minor/index.md
@@ -31,4 +31,6 @@ tracklist_edition: "1968-11 US mono"
 ---
 ## About
 
-Mass in F Minor is the third studio album by Los Angeles psychedelic rock band The Electric Prunes, released on Reprise Records in 1968. The album was composed by David Axelrod and represents an unusual concept: a full Catholic mass reimagined as psychedelic rock. It is one of the more ambitious and unusual artefacts of the late-1960s psychedelic movement.
+*Mass in F Minor* was composed by David Axelrod and represents an unusual concept: a full Catholic mass reimagined as psychedelic rock.
+
+It is one of the more ambitious and unusual artefacts of the late-1960s psychedelic movement.

--- a/src/content/releases/t/the-essence/purity/index.md
+++ b/src/content/releases/t/the-essence/purity/index.md
@@ -62,6 +62,6 @@ tracklist_edition: "1985 GB"
 ---
 ## About
 
-Purity is a release by The Essence released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include The Cat.
+*Purity* earns its place in the Sundown Sessions catalogue through “The Cat”, a selection that offers a direct route into The Essence's work.
 
-
+Heard in the context of the full release, “The Cat” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-exploding-boy/exploding-boy/index.md
+++ b/src/content/releases/t/the-exploding-boy/exploding-boy/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "2007-04-04 SE"
 ---
 ## About
 
-Exploding Boy is a release by The Exploding Boy released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include Better Than Fine.
+*Exploding Boy* earns its place in the Sundown Sessions catalogue through “Better Than Fine”, a selection that offers a direct route into The Exploding Boy's work.
+
+Heard in the context of the full release, “Better Than Fine” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Better Than Fine
-
-

--- a/src/content/releases/t/the-fall/grotesque-after-the-gramme/index.md
+++ b/src/content/releases/t/the-fall/grotesque-after-the-gramme/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1980-11 IT"
 ---
 ## About
 
-Grotesque (After the Gramme) is the third studio album by Manchester post-punk band The Fall, released on Rough Trade Records in 1980. Led by the inimitable Mark E. Smith, the album is a classic of the post-punk era, showcasing the band's unique blend of repetitive, motorik rhythms and Smith's acerbic, stream-of-consciousness lyrics. It is widely regarded as one of their most vital records.
+*Grotesque (After the Gramme)* is widely regarded as one of their most vital records.
+
+Led by the inimitable Mark E. Smith, the album is a classic of the post-punk era, showcasing the band's unique blend of repetitive, motorik rhythms and Smith's acerbic, stream-of-consciousness lyrics.

--- a/src/content/releases/t/the-filthy-tongues/black-valentine-best-of/index.md
+++ b/src/content/releases/t/the-filthy-tongues/black-valentine-best-of/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "2023-11-14 XW"
 ---
 ## About
 
-Black Valentine (Best of) is a career-spanning compilation by Glasgow alternative rock band The Filthy Tongues, released on Creeping Bent in 2023. It gathers highlights from their long recording career, including 'Nae Tongues' and their best-known work for the label.
+*Black Valentine (Best of)* gathers highlights from their long recording career, including 'Nae Tongues' and their best-known work for the label.
+
+The collection offers a route through the Glasgow band's alternative-rock catalogue rather than reducing it to a single familiar track.

--- a/src/content/releases/t/the-filthy-tongues/jacobs-ladder/index.md
+++ b/src/content/releases/t/the-filthy-tongues/jacobs-ladder/index.md
@@ -37,10 +37,10 @@ tracklist_edition: "2016-03-18 GB"
 ---
 ## About
 
-Jacob's Ladder is a release by The Filthy Tongues released in 2016. It has been featured on 1 Sundown Sessions show. Featured tracks include Children of the Filthy.
+*Jacob's Ladder* earns its place in the Sundown Sessions catalogue through “Children of the Filthy”, a selection that offers a direct route into The Filthy Tongues's work.
+
+Heard in the context of the full release, “Children of the Filthy” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Children of the Filthy
-
-

--- a/src/content/releases/t/the-groundhogs/blues-obituary/index.md
+++ b/src/content/releases/t/the-groundhogs/blues-obituary/index.md
@@ -34,10 +34,10 @@ tracklist_edition: "1969 GB"
 ---
 ## About
 
-Blues Obituary is a release by The Groundhogs released in 1969. It has been featured on 1 Sundown Sessions show. Featured tracks include Natchez Burning.
+*Blues Obituary* earns its place in the Sundown Sessions catalogue through “Natchez Burning”, a selection that offers a direct route into The Groundhogs's work.
+
+Heard in the context of the full release, “Natchez Burning” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Natchez Burning
-
-

--- a/src/content/releases/t/the-hollies/distant-light/index.md
+++ b/src/content/releases/t/the-hollies/distant-light/index.md
@@ -57,6 +57,6 @@ tracklist_edition: "1971-12 US"
 ---
 ## About
 
-Distant Light is a release by The Hollies released in 1971-12. It has been featured on 1 Sundown Sessions show. Featured tracks include Long Cool Woman (In a Black Dress).
+*Distant Light* earns its place in the Sundown Sessions catalogue through “Long Cool Woman (In a Black Dress)”, a selection that offers a direct route into The Hollies's work.
 
-
+Heard in the context of the full release, “Long Cool Woman (In a Black Dress)” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-house-of-love/the-house-of-love-2012-deluxe-version/index.md
+++ b/src/content/releases/t/the-house-of-love/the-house-of-love-2012-deluxe-version/index.md
@@ -43,10 +43,10 @@ tracklist_edition: "1987 DE"
 ---
 ## About
 
-The House Of Love (2012 Deluxe Version) is a release by The House of Love released in 2012. It has been featured on 1 Sundown Sessions show. Featured tracks include Christine - 2018 Remaster.
+*The House Of Love (2012 Deluxe Version)* earns its place in the Sundown Sessions catalogue through “Christine - 2018 Remaster”, a selection that offers a direct route into The House of Love's work.
+
+Heard in the context of the full release, “Christine - 2018 Remaster” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Christine - 2018 Remaster
-
-

--- a/src/content/releases/t/the-housemartins/london-0-hull-4/index.md
+++ b/src/content/releases/t/the-housemartins/london-0-hull-4/index.md
@@ -62,4 +62,6 @@ tracklist_edition: "1986 GB"
 ---
 ## About
 
-London 0 Hull 4 is the debut studio album by Hull indie pop band The Housemartins, released on Go! Discs in 1986. It reached number three on the UK Albums Chart and spawned the number-one single 'Caravan of Love'. The album's combination of jangly guitar pop and politically charged lyrics made it one of the most distinctive and enjoyable debut albums of the mid-1980s.
+*London 0 Hull 4*'s combination of jangly guitar pop and politically charged lyrics made it one of the most distinctive and enjoyable debut albums of the mid-1980s.
+
+It reached number three on the UK Albums Chart and spawned the number-one single 'Caravan of Love'.

--- a/src/content/releases/t/the-human-league/dare/index.md
+++ b/src/content/releases/t/the-human-league/dare/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1981 US"
 ---
 ## About
 
-Dare is the third studio album by Sheffield electro-pop band The Human League, released on Virgin Records in 1981. It reached number one on the UK Albums Chart and spawned the international chart-topper 'Don't You Want Me'. The album is a landmark of the synth-pop genre and remains one of the best-selling British albums of the decade.
+*Dare* is a landmark of the synth-pop genre and remains one of the best-selling British albums of the decade.
+
+It reached number one on the UK Albums Chart and spawned the international chart-topper 'Don't You Want Me'.

--- a/src/content/releases/t/the-human-league/reproduction/index.md
+++ b/src/content/releases/t/the-human-league/reproduction/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "1979-10 GB"
 ---
 ## About
 
-Reproduction is a release by The Human League released in 1979-10-01. It has been featured on 1 Sundown Sessions show. Featured tracks include Empire State Human.
+*Reproduction* earns its place in the Sundown Sessions catalogue through “Empire State Human”, a selection that offers a direct route into The Human League's work.
 
-
+Heard in the context of the full release, “Empire State Human” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-human-league/travelogue/index.md
+++ b/src/content/releases/t/the-human-league/travelogue/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1980 GB"
 ---
 ## About
 
-Travelogue is a release by The Human League released in 1980-05-23. It has been featured on 1 Sundown Sessions show. Featured tracks include Rock 'n' Roll / Night Clubbing.
+*Travelogue* earns its place in the Sundown Sessions catalogue through “Rock 'n' Roll / Night Clubbing”, a selection that offers a direct route into The Human League's work.
 
-
+Heard in the context of the full release, “Rock 'n' Roll / Night Clubbing” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-icicle-works/the-icicle-works/index.md
+++ b/src/content/releases/t/the-icicle-works/the-icicle-works/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1984-03 GB"
 ---
 ## About
 
-The Icicle Works is the self-titled debut studio album by Liverpool post-punk band The Icicle Works, released on Beggars Banquet in 1984. It introduced the band's blend of melodic guitar rock and introspective lyricism, drawing comparisons to Echo & the Bunnymen and early Simple Minds. The album includes their best-known track, 'Love Is a Wonderful Colour'.
+*The Icicle Works* introduced the band's blend of melodic guitar rock and introspective lyricism, drawing comparisons to Echo & the Bunnymen and early Simple Minds.
+
+The album includes their best-known track, 'Love Is a Wonderful Colour'.

--- a/src/content/releases/t/the-jam/sound-affects/index.md
+++ b/src/content/releases/t/the-jam/sound-affects/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1980 GB"
 ---
 ## About
 
-Sound Affects is the fifth studio album by Woking mod revival band The Jam, released on Polydor Records in 1980. It reached number two on the UK Albums Chart and showcased the band's most musically adventurous work, drawing on post-punk, psychedelia, and R&B influences. The album includes the UK number-one single 'Start!' and 'That's Entertainment', considered one of Paul Weller's finest compositions.
+*Sound Affects* includes the UK number-one single 'Start!' and 'That's Entertainment', considered one of Paul Weller's finest compositions.
+
+It reached number two on the UK Albums Chart and showcased the band's most musically adventurous work, drawing on post-punk, psychedelia, and R&B influences.

--- a/src/content/releases/t/the-jimi-hendrix-experience/are-you-experienced/index.md
+++ b/src/content/releases/t/the-jimi-hendrix-experience/are-you-experienced/index.md
@@ -47,4 +47,6 @@ tracklist_edition: "1967 None"
 ---
 ## About
 
-Are You Experienced is the debut studio album by American-British psychedelic rock band The Jimi Hendrix Experience, released on Track Records in 1967. It reached number two on the UK Albums Chart and transformed the language of electric guitar playing. The album includes 'Purple Haze', 'Hey Joe', and 'The Wind Cries Mary', and is considered one of the most significant debut albums in the history of rock music.
+*Are You Experienced* reached number two on the UK Albums Chart and transformed the language of electric guitar playing.
+
+The album includes 'Purple Haze', 'Hey Joe', and 'The Wind Cries Mary', and is considered one of the most significant debut albums in the history of rock music.

--- a/src/content/releases/t/the-june-brides/there-are-eight-million-stories/index.md
+++ b/src/content/releases/t/the-june-brides/there-are-eight-million-stories/index.md
@@ -28,4 +28,6 @@ tracklist_edition: "1985-09 GB"
 ---
 ## About
 
-There Are Eight Million Stories is the debut and only studio album by London indie pop band The June Brides, released on Pink Records in 1985. The album captures the band's passionate, brass-infused guitar pop and is considered a key document of the mid-1980s UK indie scene.
+*There Are Eight Million Stories* captures the band's passionate, brass-infused guitar pop and is considered a key document of the mid-1980s UK indie scene.
+
+As The June Brides' sole studio album, it preserves the character of a brief but distinctive catalogue.

--- a/src/content/releases/t/the-kinks/arthur-or-the-decline-and-fall-of-the-british-empire/index.md
+++ b/src/content/releases/t/the-kinks/arthur-or-the-decline-and-fall-of-the-british-empire/index.md
@@ -49,4 +49,6 @@ tracklist_edition: "1969 DE stereo"
 ---
 ## About
 
-Arthur (Or the Decline and Fall of the British Empire) is the ninth studio album by London rock band The Kinks, released on Pye Records in 1969. The album was conceived as a rock opera and explores themes of class, empire, and suburban life through the fictional character of Arthur Morgan. It is widely regarded as one of Ray Davies' finest achievements and an important work in the British rock canon.
+*Arthur (Or the Decline and Fall of the British Empire)* is widely regarded as one of Ray Davies' finest achievements and an important work in the British rock canon.
+
+The album was conceived as a rock opera and explores themes of class, empire, and suburban life through the fictional character of Arthur Morgan.

--- a/src/content/releases/t/the-las/the-las/index.md
+++ b/src/content/releases/t/the-las/the-las/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1990 GB"
 ---
 ## About
 
-The La's is the sole studio album by Liverpool indie rock band The La's, released on Go! Discs in 1990. It reached number 30 on the UK Albums Chart and is cherished as one of the finest British debut albums of the era, featuring the timeless guitar pop of 'There She Goes'. The album's combination of Merseybeat melody and Lee Mavers' perfectionist vision produced a record of enduring appeal.
+*The La's*'s combination of Merseybeat melody and Lee Mavers' perfectionist vision produced a record of enduring appeal.
+
+It reached number 30 on the UK Albums Chart and is cherished as one of the finest British debut albums of the era, featuring the timeless guitar pop of 'There She Goes'.

--- a/src/content/releases/t/the-lathums/stellar-cast/index.md
+++ b/src/content/releases/t/the-lathums/stellar-cast/index.md
@@ -19,9 +19,10 @@ tracks:
 ---
 ## About
 
-Stellar Cast is a release by The Lathums released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Stellar Cast.
+*Stellar Cast* earns its place in the Sundown Sessions catalogue through “Stellar Cast”, a selection that offers a direct route into The Lathums's work.
+
+Heard in the context of the full release, “Stellar Cast” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Stellar Cast
-

--- a/src/content/releases/t/the-lightning-seeds/cloudcuckooland/index.md
+++ b/src/content/releases/t/the-lightning-seeds/cloudcuckooland/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1990 GB"
 ---
 ## About
 
-Cloudcuckooland is the debut studio album by Liverpool pop project The Lightning Seeds, the creation of producer and songwriter Ian Broudie, released in 1990. The album introduced Broudie's instantly appealing, brightly melodic brand of indie pop, featuring the UK hit 'Pure'. It established The Lightning Seeds as one of the more distinctive and consistently enjoyable acts of the era.
+*Cloudcuckooland* established The Lightning Seeds as one of the more distinctive and consistently enjoyable acts of the era.
+
+The album introduced Broudie's instantly appealing, brightly melodic brand of indie pop, featuring the UK hit 'Pure'.

--- a/src/content/releases/t/the-mighty-wah/a-word-to-the-wise-guy/index.md
+++ b/src/content/releases/t/the-mighty-wah/a-word-to-the-wise-guy/index.md
@@ -49,4 +49,6 @@ tracklist_edition: "1984 DK"
 ---
 ## About
 
-A Word to the Wise Guy is a studio album by Liverpool post-punk act The Mighty Wah!, featuring Pete Wylie's anthemic brand of guitar pop infused with political idealism. The band were an important part of the Liverpool music scene that produced Echo & the Bunnymen and The Teardrop Explodes.
+The band were an important part of the Liverpool music scene that produced Echo & the Bunnymen and The Teardrop Explodes.
+
+A Word to the Wise Guy is a studio album by Liverpool post-punk act The Mighty Wah!, featuring Pete Wylie's anthemic brand of guitar pop infused with political idealism.

--- a/src/content/releases/t/the-mission/aura/index.md
+++ b/src/content/releases/t/the-mission/aura/index.md
@@ -83,6 +83,6 @@ tracklist_edition: "2001 DE"
 ---
 ## About
 
-Aura is a release by The Mission released in 2001-12-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Dragonfly.
+*Aura* earns its place in the Sundown Sessions catalogue through “Dragonfly”, a selection that offers a direct route into The Mission's work.
 
-
+Heard in the context of the full release, “Dragonfly” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-mission/carved-in-sand/index.md
+++ b/src/content/releases/t/the-mission/carved-in-sand/index.md
@@ -52,6 +52,6 @@ tracklist_edition: "1990 CA"
 ---
 ## About
 
-Carved In Sand is a release by The Mission released in 1990-02. It has been featured on 1 Sundown Sessions show. Featured tracks include Deliverance.
+*Carved In Sand* earns its place in the Sundown Sessions catalogue through “Deliverance”, a selection that offers a direct route into The Mission's work.
 
-
+Heard in the context of the full release, “Deliverance” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-mission/the-first-chapter/index.md
+++ b/src/content/releases/t/the-mission/the-first-chapter/index.md
@@ -51,6 +51,6 @@ tracklist_edition: "1987 US"
 ---
 ## About
 
-The First Chapter is a release by The Mission released in 1987-06. It has been featured on 1 Sundown Sessions show. Featured tracks include Naked And Savage.
+*The First Chapter* earns its place in the Sundown Sessions catalogue through “Naked And Savage”, a selection that offers a direct route into The Mission's work.
 
-
+Heard in the context of the full release, “Naked And Savage” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-motors/airport-the-motors-greatest-hits/index.md
+++ b/src/content/releases/t/the-motors/airport-the-motors-greatest-hits/index.md
@@ -64,10 +64,10 @@ tracklist_edition: "1995 US"
 ---
 ## About
 
-Airport - The Motors Greatest Hits is a release by The Motors released in 1995. It has been featured on 1 Sundown Sessions show. Featured tracks include Dancing The Night Away.
+*Airport - The Motors Greatest Hits* earns its place in the Sundown Sessions catalogue through “Dancing The Night Away”, a selection that offers a direct route into The Motors's work.
+
+Heard in the context of the full release, “Dancing The Night Away” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Dancing The Night Away
-
-

--- a/src/content/releases/t/the-move/hitsnflips/index.md
+++ b/src/content/releases/t/the-move/hitsnflips/index.md
@@ -25,9 +25,10 @@ tracks:
 ---
 ## About
 
-Hits'n'Flips is a release by The Move released in 2013. It has been featured on 1 Sundown Sessions show. Featured tracks include Blackberry Way.
+*Hits'n'Flips* earns its place in the Sundown Sessions catalogue through “Blackberry Way”, a selection that offers a direct route into The Move's work.
+
+Heard in the context of the full release, “Blackberry Way” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Blackberry Way
-

--- a/src/content/releases/t/the-move/move/index.md
+++ b/src/content/releases/t/the-move/move/index.md
@@ -61,6 +61,6 @@ tracklist_edition: "1968-04 GB stereo"
 ---
 ## About
 
-Move is a release by The Move released in 1968-04. It has been featured on 1 Sundown Sessions show. Featured tracks include Fire Brigade.
+*Move* earns its place in the Sundown Sessions catalogue through “Fire Brigade”, a selection that offers a direct route into The Move's work.
 
-
+Heard in the context of the full release, “Fire Brigade” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-move/shazam-2007-remaster/index.md
+++ b/src/content/releases/t/the-move/shazam-2007-remaster/index.md
@@ -31,10 +31,10 @@ tracklist_edition: "1970 GB"
 ---
 ## About
 
-Shazam (2007 Remaster) is a release by The Move released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Hello Susie - 2007 Remaster.
+*Shazam (2007 Remaster)* earns its place in the Sundown Sessions catalogue through “Hello Susie - 2007 Remaster”, a selection that offers a direct route into The Move's work.
+
+Heard in the context of the full release, “Hello Susie - 2007 Remaster” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Hello Susie - 2007 Remaster
-
-

--- a/src/content/releases/t/the-move/shazam/index.md
+++ b/src/content/releases/t/the-move/shazam/index.md
@@ -42,6 +42,6 @@ tracklist_edition: "1970 GB"
 ---
 ## About
 
-Shazam is a release by The Move released in 1970. It has been featured on 2 Sundown Sessions shows. Featured tracks include Cherry Blossom Clinic Revisited, Hello Susie.
+*Shazam* has supplied Sundown Sessions with “Cherry Blossom Clinic Revisited” and “Hello Susie”, giving more than one way into The Move's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/t/the-music-machine/turn-on-the-music-machine/index.md
+++ b/src/content/releases/t/the-music-machine/turn-on-the-music-machine/index.md
@@ -58,6 +58,6 @@ tracklist_edition: "1966 US mono LP"
 ---
 ## About
 
-(Turn On) The Music Machine is a release by The Music Machine released in 1966. It has been featured on 1 Sundown Sessions show. Featured tracks include The People In Me.
+*(Turn On) The Music Machine* earns its place in the Sundown Sessions catalogue through “The People In Me”, a selection that offers a direct route into The Music Machine's work.
 
-
+Heard in the context of the full release, “The People In Me” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-organ/grab-that-gun/index.md
+++ b/src/content/releases/t/the-organ/grab-that-gun/index.md
@@ -55,6 +55,6 @@ tracklist_edition: "2004-05-24 CA"
 ---
 ## About
 
-Grab That Gun is a release by The Organ released in 2004-05-24. It has been featured on 1 Sundown Sessions show. Featured tracks include Brother.
+*Grab That Gun* earns its place in the Sundown Sessions catalogue through “Brother”, a selection that offers a direct route into The Organ's work.
 
-
+Heard in the context of the full release, “Brother” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-proclaimers/this-is-the-story/index.md
+++ b/src/content/releases/t/the-proclaimers/this-is-the-story/index.md
@@ -52,4 +52,6 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-This Is the Story is the debut studio album by Scottish folk-pop duo The Proclaimers — Craig and Charlie Reid — released on Chrysalis Records in 1987. The album introduced the twins' distinctive blend of acoustic pop, Scottish folk, and uncompromising use of their Leith accent. It includes the song 'Letter from America', which became one of the defining anthems of 1980s Scotland.
+*This Is the Story* includes the song 'Letter from America', which became one of the defining anthems of 1980s Scotland.
+
+The album introduced the twins' distinctive blend of acoustic pop, Scottish folk, and uncompromising use of their Leith accent.

--- a/src/content/releases/t/the-prodigy/music-for-the-jilted-generation/index.md
+++ b/src/content/releases/t/the-prodigy/music-for-the-jilted-generation/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "1994 GB"
 ---
 ## About
 
-Music for the Jilted Generation is the second studio album by Essex rave act The Prodigy, released on XL Recordings in 1994. It topped the UK Albums Chart, making it the first album associated with rave culture to do so in Britain. The album channels the anger felt by the free-party movement at the introduction of the Criminal Justice Act, combining breakbeat hardcore with punk energy and melodic sophistication.
+*Music for the Jilted Generation* channels the anger felt by the free-party movement at the introduction of the Criminal Justice Act, combining breakbeat hardcore with punk energy and melodic sophistication.
+
+It topped the UK Albums Chart, making it the first album associated with rave culture to do so in Britain.

--- a/src/content/releases/t/the-psychedelic-furs/talk-talk-talk/index.md
+++ b/src/content/releases/t/the-psychedelic-furs/talk-talk-talk/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1981 US"
 ---
 ## About
 
-Talk Talk Talk is the second studio album by London post-punk band The Psychedelic Furs, released on CBS Records in 1981. It reached number 30 on the UK Albums Chart and is regarded as one of their finest works, featuring the original version of 'Pretty in Pink'. The album showcases the band's move toward a more melodic, radio-friendly sound while retaining the abrasive energy of their debut.
+*Talk Talk Talk* showcases the band's move toward a more melodic, radio-friendly sound while retaining the abrasive energy of their debut.
+
+It reached number 30 on the UK Albums Chart and is regarded as one of their finest works, featuring the original version of 'Pretty in Pink'.

--- a/src/content/releases/t/the-receiving-end/thats-the-way-i-operate/index.md
+++ b/src/content/releases/t/the-receiving-end/thats-the-way-i-operate/index.md
@@ -55,4 +55,6 @@ tracklist_edition: "2005-04-26 GB"
 ---
 ## About
 
-*That's the Way I Operate!* is a rare, independently produced CD by Scottish guitar band The Receiving End, dating from around 1992. The title track and “Nothing's Wrong” preserve the direct songwriting and local independent spirit at the heart of the band's Show #2 spotlight. Public catalogue information is limited, so the date and surviving track details follow the band's source CD and the broadcast rather than an inferred commercial edition.
+The title track and “Nothing's Wrong” preserve the direct songwriting and local independent spirit at the heart of the band's Show #2 spotlight.
+
+*That's the Way I Operate!* is a rare, independently produced CD by Scottish guitar band The Receiving End, dating from around 1992. Public catalogue information is limited, so the date and surviving track details follow the band's source CD and the broadcast rather than an inferred commercial edition.

--- a/src/content/releases/t/the-revillos/rev-up/index.md
+++ b/src/content/releases/t/the-revillos/rev-up/index.md
@@ -63,6 +63,6 @@ tracklist_edition: "1980 GB"
 ---
 ## About
 
-Rev Up is a release by The Revillos released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include Motorbike Beat.
+*Rev Up* earns its place in the Sundown Sessions catalogue through “Motorbike Beat”, a selection that offers a direct route into The Revillos's work.
 
-
+Heard in the context of the full release, “Motorbike Beat” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-rolling-stones/let-it-bleed/index.md
+++ b/src/content/releases/t/the-rolling-stones/let-it-bleed/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1969 MX"
 ---
 ## About
 
-Let It Bleed is the seventh British studio album by London rock band The Rolling Stones, released on Decca Records in 1969. It topped the UK Albums Chart and is regarded as one of the band's finest works, featuring 'Gimme Shelter', 'You Can't Always Get What You Want', and 'Midnight Rambler'. The album was recorded amid the upheaval surrounding Brian Jones' departure and death.
+*Let It Bleed* was recorded amid the upheaval surrounding Brian Jones' departure and death.
+
+It topped the UK Albums Chart and is regarded as one of the band's finest works, featuring 'Gimme Shelter', 'You Can't Always Get What You Want', and 'Midnight Rambler'.

--- a/src/content/releases/t/the-ruts/youve-gotta-get-out-of-it/index.md
+++ b/src/content/releases/t/the-ruts/youve-gotta-get-out-of-it/index.md
@@ -64,10 +64,10 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-You've Gotta Get Out Of It is a release by The Ruts released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include Staring At The Rude Boys.
+*You've Gotta Get Out Of It* earns its place in the Sundown Sessions catalogue through “Staring At The Rude Boys”, a selection that offers a direct route into The Ruts's work.
+
+Heard in the context of the full release, “Staring At The Rude Boys” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Staring At The Rude Boys
-
-

--- a/src/content/releases/t/the-selecter/too-much-pressure/index.md
+++ b/src/content/releases/t/the-selecter/too-much-pressure/index.md
@@ -69,6 +69,6 @@ tracklist_edition: "1999 GB"
 ---
 ## About
 
-Too Much Pressure is a release by The Selecter released in 1999. It has been featured on 1 Sundown Sessions show. Featured tracks include Missing Words.
+*Too Much Pressure* earns its place in the Sundown Sessions catalogue through “Missing Words”, a selection that offers a direct route into The Selecter's work.
 
-
+Heard in the context of the full release, “Missing Words” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-shamen/en-tact/index.md
+++ b/src/content/releases/t/the-shamen/en-tact/index.md
@@ -52,4 +52,6 @@ tracklist_edition: "1990 GB"
 ---
 ## About
 
-En-Tact is the fifth studio album by Scottish electronic rock act The Shamen, released on One Little Indian Records in 1990. The album marked a decisive shift from their earlier psychedelic rock sound towards electronic dance music, incorporating acid house, hip-hop, and rave culture. It includes early versions of material that would define their subsequent chart success.
+*En-Tact* marked a decisive shift from their earlier psychedelic rock sound towards electronic dance music, incorporating acid house, hip-hop, and rave culture.
+
+It includes early versions of material that would define their subsequent chart success.

--- a/src/content/releases/t/the-silencers/a-letter-from-st-paul/index.md
+++ b/src/content/releases/t/the-silencers/a-letter-from-st-paul/index.md
@@ -52,6 +52,6 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-A Letter from St. Paul is a release by The Silencers released in 1987. It has been featured on 1 Sundown Sessions show. Featured tracks include Painted Moon.
+*A Letter from St. Paul* earns its place in the Sundown Sessions catalogue through “Painted Moon”, a selection that offers a direct route into The Silencers's work.
 
-
+Heard in the context of the full release, “Painted Moon” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-slow-readers-club/technofear/index.md
+++ b/src/content/releases/t/the-slow-readers-club/technofear/index.md
@@ -16,9 +16,10 @@ tracks:
 ---
 ## About
 
-Technofear is a release by The Slow Readers Club released in 2024. It has been featured on 1 Sundown Sessions show. Featured tracks include Technofear.
+*Technofear* earns its place in the Sundown Sessions catalogue through “Technofear”, a selection that offers a direct route into The Slow Readers Club's work.
+
+Heard in the context of the full release, “Technofear” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Technofear
-

--- a/src/content/releases/t/the-slow-readers-club/the-joy-of-the-return/index.md
+++ b/src/content/releases/t/the-slow-readers-club/the-joy-of-the-return/index.md
@@ -53,6 +53,6 @@ tracklist_edition: "2020-03-20 XW"
 ---
 ## About
 
-The Joy Of The Return is a release by The Slow Readers Club released in 2020-03-20. It has been featured on 1 Sundown Sessions show. Featured tracks include All I Hear.
+*The Joy Of The Return* earns its place in the Sundown Sessions catalogue through “All I Hear”, a selection that offers a direct route into The Slow Readers Club's work.
 
-
+Heard in the context of the full release, “All I Hear” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-smiths/the-queen-is-dead/index.md
+++ b/src/content/releases/t/the-smiths/the-queen-is-dead/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1986 GB"
 ---
 ## About
 
-The Queen Is Dead is the third studio album by The Smiths, released on Rough Trade Records in 1986. It reached number two on the UK Albums Chart and is widely regarded as their masterpiece and one of the greatest British albums ever recorded. The album combines Morrissey's wit and melancholy with Marr's most inventive guitar playing, across a set of songs that range from the bitter and political to the tender and longing.
+*The Queen Is Dead* reached number two on the UK Albums Chart and is widely regarded as their masterpiece and one of the greatest British albums ever recorded.
+
+The album combines Morrissey's wit and melancholy with Marr's most inventive guitar playing, across a set of songs that range from the bitter and political to the tender and longing.

--- a/src/content/releases/t/the-smiths/the-smiths/index.md
+++ b/src/content/releases/t/the-smiths/the-smiths/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1984 FR"
 ---
 ## About
 
-The Smiths is the self-titled debut studio album by Manchester indie rock band The Smiths, released on Rough Trade Records in 1984. It reached number two on the UK Albums Chart and announced the arrival of one of the most important British bands of the decade. Johnny Marr's shimmering, multi-layered guitar work and Morrissey's idiosyncratic, literary lyrics created a wholly distinctive sound that inspired a generation.
+Johnny Marr's shimmering, multi-layered guitar work and Morrissey's idiosyncratic, literary lyrics created a wholly distinctive sound that inspired a generation.
+
+It reached number two on the UK Albums Chart and announced the arrival of one of the most important British bands of the decade.

--- a/src/content/releases/t/the-sound/jeopardy/index.md
+++ b/src/content/releases/t/the-sound/jeopardy/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1980 FR"
 ---
 ## About
 
-Jeopardy is the debut studio album by London post-punk band The Sound, released on Korova Records in 1980. The album is regarded as one of the finest and most underappreciated records of the post-punk era, showcasing Adrian Borland's impassioned songwriting and the band's brooding, tightly coiled sound. Though commercially overlooked, the band's influence on subsequent generations of post-punk musicians has been considerable.
+*Jeopardy* is regarded as one of the finest and most underappreciated records of the post-punk era, showcasing Adrian Borland's impassioned songwriting and the band's brooding, tightly coiled sound.
+
+Though commercially overlooked, the band's influence on subsequent generations of post-punk musicians has been considerable.

--- a/src/content/releases/t/the-southern-death-cult/the-southern-death-cult/index.md
+++ b/src/content/releases/t/the-southern-death-cult/the-southern-death-cult/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-The Southern Death Cult is a release by The Southern Death Cult released in 1983. It has been featured on 2 Sundown Sessions shows. Featured tracks include Apache, Moya.
+*The Southern Death Cult* has supplied Sundown Sessions with “Apache” and “Moya”, giving more than one way into The Southern Death Cult's work.
 
-
+Together, those choices point beyond isolated favourites towards the character of the wider release.

--- a/src/content/releases/t/the-specials/more-specials/index.md
+++ b/src/content/releases/t/the-specials/more-specials/index.md
@@ -66,4 +66,6 @@ tracklist_edition: "1980-10 GB"
 ---
 ## About
 
-More Specials is the second studio album by Coventry ska revival band The Specials, released on 2 Tone Records in 1980. It reached number five on the UK Albums Chart and expanded the band's sound beyond ska to incorporate easy listening, lounge, and film soundtrack influences. The album was released just as tensions within the band were reaching breaking point, leading to the departure of several members.
+*More Specials* was released just as tensions within the band were reaching breaking point, leading to the departure of several members.
+
+It reached number five on the UK Albums Chart and expanded the band's sound beyond ska to incorporate easy listening, lounge, and film soundtrack influences.

--- a/src/content/releases/t/the-specials/stereo-typical-as-bs-and-rarities/index.md
+++ b/src/content/releases/t/the-specials/stereo-typical-as-bs-and-rarities/index.md
@@ -197,10 +197,10 @@ tracklist_edition: "2000-08-21 GB"
 ---
 ## About
 
-Stereo-Typical: A's, B's & Rarities is a release by The Specials released in 2000. It has been featured on 1 Sundown Sessions show. Featured tracks include Ghost Town.
+*Stereo-Typical: A's, B's & Rarities* earns its place in the Sundown Sessions catalogue through “Ghost Town”, a selection that offers a direct route into The Specials's work.
+
+Heard in the context of the full release, “Ghost Town” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Ghost Town
-
-

--- a/src/content/releases/t/the-stone-roses/the-stone-roses/index.md
+++ b/src/content/releases/t/the-stone-roses/the-stone-roses/index.md
@@ -52,4 +52,4 @@ tracklist_edition: "1989 US"
 ---
 ## About
 
-The Stone Roses is the self-titled debut studio album by Manchester indie rock band The Stone Roses, released on Silvertone Records in 1989. Though it charted modestly on release, the album has since been recognised as one of the greatest British albums ever made, combining baggy dance rhythms with Byrds-influenced 12-string guitars, Ian Brown's languid vocals, and John Squire's exuberant, Jackson Pollock-inspired artwork.
+Though it charted modestly on release, *The Stone Roses* has since been recognised as one of the greatest British albums ever made, combining baggy dance rhythms with Byrds-influenced 12-string guitars, Ian Brown's languid vocals, and John Squire's exuberant, Jackson Pollock-inspired artwork.

--- a/src/content/releases/t/the-stooges/the-stooges/index.md
+++ b/src/content/releases/t/the-stooges/the-stooges/index.md
@@ -48,6 +48,6 @@ tracklist_edition: "1969 FR"
 ---
 ## About
 
-The Stooges is a release by The Stooges released in 1969-08-05. It has been featured on 1 Sundown Sessions show. Featured tracks include 1969.
+*The Stooges* earns its place in the Sundown Sessions catalogue through “1969”, a selection that offers a direct route into The Stooges's work.
 
-
+Heard in the context of the full release, “1969” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-stranglers/10/index.md
+++ b/src/content/releases/t/the-stranglers/10/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1990 GB"
 ---
 ## About
 
-10 is the tenth studio album by British new wave band The Stranglers, released on Epic Records in 1990. It reached number 15 on the UK Albums Chart and was the first album to feature vocalist Paul Roberts, who replaced founding member Hugh Cornwell following his departure earlier that year. The record demonstrated the band's continued ability to craft polished, melodic rock.
+*10* reached number 15 on the UK Albums Chart and was the first album to feature vocalist Paul Roberts, who replaced founding member Hugh Cornwell following his departure earlier that year.
+
+The record demonstrated the band's continued ability to craft polished, melodic rock.

--- a/src/content/releases/t/the-stranglers/no-more-heroes/index.md
+++ b/src/content/releases/t/the-stranglers/no-more-heroes/index.md
@@ -65,6 +65,6 @@ tracklist_edition: "2007 NL"
 ---
 ## About
 
-No More Heroes is a release by The Stranglers released in 2007. It has been featured on 1 Sundown Sessions show. Featured tracks include No More Heroes.
+*No More Heroes* earns its place in the Sundown Sessions catalogue through “No More Heroes”, a selection that offers a direct route into The Stranglers's work.
 
-
+Heard in the context of the full release, “No More Heroes” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-style-council/café-bleu/index.md
+++ b/src/content/releases/t/the-style-council/café-bleu/index.md
@@ -53,4 +53,6 @@ tracklist_edition: "1984 GB"
 ---
 ## About
 
-Café Bleu is the debut studio album by Paul Weller's post-Jam project The Style Council, released on Polydor Records in 1984. It reached number two on the UK Albums Chart and reflects Weller's embrace of jazz, soul, and European pop influences, representing a dramatic stylistic departure from The Jam's mod rock. The album features the classic 'My Ever Changing Moods'.
+*Café Bleu* reached number two on the UK Albums Chart and reflects Weller's embrace of jazz, soul, and European pop influences, representing a dramatic stylistic departure from The Jam's mod rock.
+
+The album features the classic 'My Ever Changing Moods'.

--- a/src/content/releases/t/the-teardrop-explodes/kilimanjaro/index.md
+++ b/src/content/releases/t/the-teardrop-explodes/kilimanjaro/index.md
@@ -65,4 +65,6 @@ tracklist_edition: "1980 XW"
 ---
 ## About
 
-Kilimanjaro is the debut studio album by Liverpool post-punk band The Teardrop Explodes, released on Mercury Records in 1980. It reached number 24 on the UK Albums Chart and introduced Julian Cope's idiosyncratic vision, blending psychedelic pop with post-punk energy. The album includes the hit 'Reward' and is regarded as a key document of the early-1980s Liverpool music scene.
+*Kilimanjaro* includes the hit 'Reward' and is regarded as a key document of the early-1980s Liverpool music scene.
+
+It reached number 24 on the UK Albums Chart and introduced Julian Cope's idiosyncratic vision, blending psychedelic pop with post-punk energy.

--- a/src/content/releases/t/the-teskey-brothers/run-home-slow/index.md
+++ b/src/content/releases/t/the-teskey-brothers/run-home-slow/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "2019-08-02 XE"
 ---
 ## About
 
-Run Home Slow is the second studio album by Melbourne soul-rock band The Teskey Brothers, released on Ivy League Records in 2019. The album extends the band's love affair with classic soul and R&B, featuring Josh Teskey's extraordinary voice and the band's warm, analogue production aesthetic. It received widespread critical acclaim and significantly expanded their international audience.
+*Run Home Slow* extends the band's love affair with classic soul and R&B, featuring Josh Teskey's extraordinary voice and the band's warm, analogue production aesthetic.
+
+It received widespread critical acclaim and significantly expanded their international audience.

--- a/src/content/releases/t/the-the/infected/index.md
+++ b/src/content/releases/t/the-the/infected/index.md
@@ -48,6 +48,6 @@ tracklist_edition: "1986 US"
 ---
 ## About
 
-Infected is a release by The The released in 1986-11-17. It has been featured on 1 Sundown Sessions show. Featured tracks include Infected.
+*Infected* earns its place in the Sundown Sessions catalogue through “Infected”, a selection that offers a direct route into The The's work.
 
-
+Heard in the context of the full release, “Infected” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-the/soul-mining/index.md
+++ b/src/content/releases/t/the-the/soul-mining/index.md
@@ -35,4 +35,6 @@ tracklist_edition: "1983 GB"
 ---
 ## About
 
-Soul Mining is the second studio album by Matt Johnson's project The The, released in 1983. It reached number 27 on the UK Albums Chart and is regarded as one of the most original and emotionally searching records of the post-punk era. The album blends synthesisers, guitars, and orchestral textures with Johnson's stark, confessional lyricism on tracks including 'This Is the Day' and 'Uncertain Smile'.
+*Soul Mining* blends synthesisers, guitars, and orchestral textures with Johnson's stark, confessional lyricism on tracks including 'This Is the Day' and 'Uncertain Smile'.
+
+It reached number 27 on the UK Albums Chart and is regarded as one of the most original and emotionally searching records of the post-punk era.

--- a/src/content/releases/t/the-tony-hatch-orchestra/avengers-and-other-top-sixties-themes/index.md
+++ b/src/content/releases/t/the-tony-hatch-orchestra/avengers-and-other-top-sixties-themes/index.md
@@ -253,10 +253,10 @@ tracklist_edition: "2003-05-26 GB"
 ---
 ## About
 
-Avengers and Other Top Sixties Themes is a release by The Tony Hatch Orchestra released in 1998. It has been featured on 1 Sundown Sessions show. Featured tracks include Theme from Crossroads.
+*Avengers and Other Top Sixties Themes* earns its place in the Sundown Sessions catalogue through “Theme from Crossroads”, a selection that offers a direct route into The Tony Hatch Orchestra's work.
+
+Heard in the context of the full release, “Theme from Crossroads” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Theme from Crossroads
-
-

--- a/src/content/releases/t/the-triffids/born-sandy-devotional/index.md
+++ b/src/content/releases/t/the-triffids/born-sandy-devotional/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1986-03 GB"
 ---
 ## About
 
-Born Sandy Devotional is the fourth studio album by Perth post-punk band The Triffids, released on Hot Records in 1986. The album is widely regarded as their masterpiece and one of the most accomplished Australian rock albums ever recorded. David McComb's cinematic, plainspoken songwriting evokes the vast landscapes of Western Australia, while the arrangements range from austere country rock to operatic grandeur.
+*Born Sandy Devotional* is widely regarded as their masterpiece and one of the most accomplished Australian rock albums ever recorded.
+
+David McComb's cinematic, plainspoken songwriting evokes the vast landscapes of Western Australia, while the arrangements range from austere country rock to operatic grandeur.

--- a/src/content/releases/t/the-undertones/hypnotised/index.md
+++ b/src/content/releases/t/the-undertones/hypnotised/index.md
@@ -59,4 +59,6 @@ tracklist_edition: "1980 GB"
 ---
 ## About
 
-Hypnotised is the second studio album by Derry punk pop band The Undertones, released on Sire Records in 1980. It reached number six on the UK Albums Chart and is regarded as a high point of their career, filled with the energetic, harmonised guitar pop that made them one of the most beloved bands of the late punk era. It includes 'My Perfect Cousin', their highest-charting UK single.
+*Hypnotised* reached number six on the UK Albums Chart and is regarded as a high point of their career, filled with the energetic, harmonised guitar pop that made them one of the most beloved bands of the late punk era.
+
+It includes 'My Perfect Cousin', their highest-charting UK single.

--- a/src/content/releases/t/the-vapors/new-clear-days/index.md
+++ b/src/content/releases/t/the-vapors/new-clear-days/index.md
@@ -55,6 +55,6 @@ tracklist_edition: "1980 GB"
 ---
 ## About
 
-New Clear Days is a release by The Vapors released in 1980. It has been featured on 1 Sundown Sessions show. Featured tracks include News At Ten.
+*New Clear Days* earns its place in the Sundown Sessions catalogue through “News At Ten”, a selection that offers a direct route into The Vapors's work.
 
-
+Heard in the context of the full release, “News At Ten” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-velvet-underground/the-velvet-underground-nico/index.md
+++ b/src/content/releases/t/the-velvet-underground/the-velvet-underground-nico/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1967 US"
 ---
 ## About
 
-The Velvet Underground & Nico is the debut studio album by New York avant-rock band The Velvet Underground, released with German chanteuse Nico on Verve Records in 1967. Produced by Andy Warhol, it is one of the most influential albums ever recorded, laying the groundwork for punk, post-punk, alternative rock, and art rock. Despite its poor initial sales, the album has since been recognised as a foundational text of modern music.
+Produced by Andy Warhol, *The Velvet Underground & Nico* is one of the most influential albums ever recorded, laying the groundwork for punk, post-punk, alternative rock, and art rock.
+
+Despite its poor initial sales, the album has since been recognised as a foundational text of modern music.

--- a/src/content/releases/t/the-vermin-poets/poets-of-england/index.md
+++ b/src/content/releases/t/the-vermin-poets/poets-of-england/index.md
@@ -41,6 +41,6 @@ tracklist_edition: "2010 GB"
 ---
 ## About
 
-Poets Of England is a release by The Vermin Poets released in 2010. It has been featured on 1 Sundown Sessions show. Featured tracks include Like Poets Often Do.
+*Poets Of England* earns its place in the Sundown Sessions catalogue through “Like Poets Often Do”, a selection that offers a direct route into The Vermin Poets's work.
 
-
+Heard in the context of the full release, “Like Poets Often Do” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-verve/a-storm-in-heaven/index.md
+++ b/src/content/releases/t/the-verve/a-storm-in-heaven/index.md
@@ -52,4 +52,6 @@ tracklist_edition: "1998-03-28 JP"
 ---
 ## About
 
-A Storm in Heaven is the debut studio album by Wigan indie rock band The Verve, released on Hut Records in 1993. The album is a swirling, ambitious record that prefigures the more song-orientated approach of their later work, with Nick McCabe's guitar creating dense, textural soundscapes beneath Richard Ashcroft's vocals. It established The Verve as one of the most original and exciting new acts in British indie music.
+*A Storm in Heaven* established The Verve as one of the most original and exciting new acts in British indie music.
+
+The album is a swirling, ambitious record that prefigures the more song-orientated approach of their later work, with Nick McCabe's guitar creating dense, textural soundscapes beneath Richard Ashcroft's vocals.

--- a/src/content/releases/t/the-verve/urban-hymns/index.md
+++ b/src/content/releases/t/the-verve/urban-hymns/index.md
@@ -54,4 +54,6 @@ tracklist_edition: "1997 XE"
 ---
 ## About
 
-Urban Hymns is the third studio album by Wigan indie rock band The Verve, released on Hut Records in 1997. It topped the UK Albums Chart and went on to sell over 10 million copies worldwide, becoming one of the best-selling British albums of the decade. The album includes the iconic 'Bitter Sweet Symphony' and 'The Drugs Don't Work', the latter of which was a UK number-one single.
+*Urban Hymns* includes the iconic 'Bitter Sweet Symphony' and 'The Drugs Don't Work', the latter of which was a UK number-one single.
+
+It topped the UK Albums Chart and went on to sell over 10 million copies worldwide, becoming one of the best-selling British albums of the decade.

--- a/src/content/releases/t/the-vintage-explosion/havin-such-a-good-time/index.md
+++ b/src/content/releases/t/the-vintage-explosion/havin-such-a-good-time/index.md
@@ -45,6 +45,6 @@ tracklist_edition: "2023 None"
 ---
 ## About
 
-Havin' Such A Good Time is a release by The Vintage Explosion released in 2023. It has been featured on 1 Sundown Sessions show. Featured tracks include Don't Knock Upon My Door.
+*Havin' Such A Good Time* earns its place in the Sundown Sessions catalogue through “Don't Knock Upon My Door”, a selection that offers a direct route into The Vintage Explosion's work.
 
-
+Heard in the context of the full release, “Don't Knock Upon My Door” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/the-waterboys/this-is-the-sea/index.md
+++ b/src/content/releases/t/the-waterboys/this-is-the-sea/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1985 GB"
 ---
 ## About
 
-This Is the Sea is the third studio album by Scottish rock act The Waterboys, released on Ensign Records in 1985. It reached number 37 on the UK Albums Chart and represents the full flowering of Mike Scott's 'Big Music' — an ambitious, expansive rock sound incorporating violin, piano, and an almost liturgical grandeur. The title track is one of the most celebrated songs in the band's catalogue.
+The title track is one of the most celebrated songs in the band's catalogue.
+
+It reached number 37 on the UK Albums Chart and represents the full flowering of Mike Scott's 'Big Music' — an ambitious, expansive rock sound incorporating violin, piano, and an almost liturgical grandeur.

--- a/src/content/releases/t/the-who/tommy/index.md
+++ b/src/content/releases/t/the-who/tommy/index.md
@@ -110,4 +110,6 @@ tracklist_edition: "1969 DE"
 ---
 ## About
 
-Tommy is the fourth studio album by London rock band The Who, released on Track Records in 1969. It reached number two on the UK Albums Chart and is one of the first significant rock operas, telling the story of a 'deaf, dumb, and blind' boy who becomes a pinball champion. The album established Pete Townshend as one of rock music's most ambitious composers.
+*Tommy* established Pete Townshend as one of rock music's most ambitious composers.
+
+It reached number two on the UK Albums Chart and is one of the first significant rock operas, telling the story of a 'deaf, dumb, and blind' boy who becomes a pinball champion.

--- a/src/content/releases/t/the-wolfmen/needle-in-the-camels-eye/index.md
+++ b/src/content/releases/t/the-wolfmen/needle-in-the-camels-eye/index.md
@@ -16,9 +16,10 @@ tracks:
 ---
 ## About
 
-Needle In The Camels Eye is a release by The Wolfmen released in 2008. It has been featured on 1 Sundown Sessions show. Featured tracks include Needle In The Camels Eye.
+*Needle In The Camels Eye* earns its place in the Sundown Sessions catalogue through “Needle In The Camels Eye”, a selection that offers a direct route into The Wolfmen's work.
+
+Heard in the context of the full release, “Needle In The Camels Eye” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Needle In The Camels Eye
-

--- a/src/content/releases/t/the-woodentops/1986-rough-trade/index.md
+++ b/src/content/releases/t/the-woodentops/1986-rough-trade/index.md
@@ -52,9 +52,10 @@ tracklist_edition: "1986 GB"
 ---
 ## About
 
-1986 (Rough Trade) is a release by The Woodentops. It has been featured on 1 Sundown Sessions show. Featured tracks include Travelling Man.
+*1986 (Rough Trade)* earns its place in the Sundown Sessions catalogue through “Travelling Man”, a selection that offers a direct route into The Woodentops' work.
+
+Heard in the context of the full release, “Travelling Man” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Travelling Man
-

--- a/src/content/releases/t/theatre-of-hate/omens-studio-work-1980-2020/index.md
+++ b/src/content/releases/t/theatre-of-hate/omens-studio-work-1980-2020/index.md
@@ -449,10 +449,10 @@ tracklist_edition: "2022-01-28 GB"
 ---
 ## About
 
-Omens: Studio Work 1980-2020 is a release by Theatre Of Hate released in 2022. It has been featured on 1 Sundown Sessions show. Featured tracks include Do You Believe In The Westworld?.
+*Omens: Studio Work 1980-2020* earns its place in the Sundown Sessions catalogue through “Do You Believe In The Westworld?”, a selection that offers a direct route into Theatre Of Hate's work.
+
+Heard in the context of the full release, “Do You Believe In The Westworld?” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Do You Believe In The Westworld?
-
-

--- a/src/content/releases/t/thee-headcoats/the-kids-are-all-square-this-is-hip/index.md
+++ b/src/content/releases/t/thee-headcoats/the-kids-are-all-square-this-is-hip/index.md
@@ -55,6 +55,6 @@ tracklist_edition: "1990-05 GB"
 ---
 ## About
 
-The Kids Are All Square, This Is Hip! is a release by Thee Headcoats released in 1990-05. It has been featured on 1 Sundown Sessions show. Featured tracks include All My Feelings Denied.
+*The Kids Are All Square, This Is Hip!* earns its place in the Sundown Sessions catalogue through “All My Feelings Denied”, a selection that offers a direct route into Thee Headcoats's work.
 
-
+Heard in the context of the full release, “All My Feelings Denied” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/t/thin-lizzy/jailbreak/index.md
+++ b/src/content/releases/t/thin-lizzy/jailbreak/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1976 GB"
 ---
 ## About
 
-Jailbreak is the seventh studio album by Dublin hard rock band Thin Lizzy, released on Vertigo Records in 1976. It reached number 10 on the UK Albums Chart and is regarded as their commercial and artistic breakthrough, featuring the enduring classics 'The Boys Are Back in Town' and the title track. The album showcases the twin-guitar attack of Brian Robertson and Scott Gorham at its most effective.
+*Jailbreak* reached number 10 on the UK Albums Chart and is regarded as their commercial and artistic breakthrough, featuring the enduring classics 'The Boys Are Back in Town' and the title track.
+
+The album showcases the twin-guitar attack of Brian Robertson and Scott Gorham at its most effective.

--- a/src/content/releases/t/throbbing-gristle/20-jazz-funk-greats/index.md
+++ b/src/content/releases/t/throbbing-gristle/20-jazz-funk-greats/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1979 GB"
 ---
 ## About
 
-20 Jazz Funk Greats is the fourth studio album by Sheffield industrial music pioneers Throbbing Gristle, released on Industrial Records in 1979. The deliberately misleading title masks an album of unsettling electronic music, noise, and conceptual art. It is considered a key work in the development of industrial music and electronic body music.
+The deliberately misleading title masks an album of unsettling electronic music, noise, and conceptual art.
+
+It is considered a key work in the development of industrial music and electronic body music.

--- a/src/content/releases/t/toni-fisher/presenting-toni-fisher/index.md
+++ b/src/content/releases/t/toni-fisher/presenting-toni-fisher/index.md
@@ -37,10 +37,10 @@ tracklist_edition: "1976 US"
 ---
 ## About
 
-Presenting Toni Fisher is a release by Toni Fisher released in 1959. It has been featured on 1 Sundown Sessions show. Featured tracks include The Big Hurt.
+*Presenting Toni Fisher* earns its place in the Sundown Sessions catalogue through “The Big Hurt”, a selection that offers a direct route into Toni Fisher's work.
+
+Heard in the context of the full release, “The Big Hurt” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - The Big Hurt
-
-

--- a/src/content/releases/t/traffic/john-barleycorn-must-die/index.md
+++ b/src/content/releases/t/traffic/john-barleycorn-must-die/index.md
@@ -32,4 +32,6 @@ tracklist_edition: "1970 US"
 ---
 ## About
 
-John Barleycorn Must Die is the fourth studio album by Midlands rock band Traffic, released on Island Records in 1970. It reached number five on the UK Albums Chart and is regarded as one of the most accomplished and influential British rock albums of the era, blending folk, jazz, and psychedelia. The album features Steve Winwood's extraordinary keyboard playing and vocal performances alongside Chris Wood's flute and saxophone work.
+*John Barleycorn Must Die* reached number five on the UK Albums Chart and is regarded as one of the most accomplished and influential British rock albums of the era, blending folk, jazz, and psychedelia.
+
+The album features Steve Winwood's extraordinary keyboard playing and vocal performances alongside Chris Wood's flute and saxophone work.

--- a/src/content/releases/t/tricky/maxinquaye/index.md
+++ b/src/content/releases/t/tricky/maxinquaye/index.md
@@ -50,4 +50,6 @@ tracklist_edition: "1995 GB repress"
 ---
 ## About
 
-Maxinquaye is the debut studio album by Bristol trip-hop artist Tricky, released on Fourth & Broadway in 1995. It reached number three on the UK Albums Chart and is widely regarded as one of the most original and atmospheric British albums of the decade. Named after his late mother, it combines claustrophobic production with the contrasting vocal personalities of Tricky and Martina Topley-Bird.
+*Maxinquaye* reached number three on the UK Albums Chart and is widely regarded as one of the most original and atmospheric British albums of the decade.
+
+Named after his late mother, it combines claustrophobic production with the contrasting vocal personalities of Tricky and Martina Topley-Bird.

--- a/src/content/releases/t/tubeway-army/replicas/index.md
+++ b/src/content/releases/t/tubeway-army/replicas/index.md
@@ -54,6 +54,6 @@ tracklist_edition: "1979 IT"
 ---
 ## About
 
-Replicas is a release by Tubeway Army released in 1979-04. It has been featured on 1 Sundown Sessions show. Featured tracks include Are 'Friends' Electric?.
+*Replicas* earns its place in the Sundown Sessions catalogue through “Are 'Friends' Electric?”, a selection that offers a direct route into Tubeway Army's work.
 
-
+Heard in the context of the full release, “Are 'Friends' Electric?” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/u/ultravox/ha-ha-ha/index.md
+++ b/src/content/releases/u/ultravox/ha-ha-ha/index.md
@@ -48,6 +48,6 @@ tracklist_edition: "1977-10-14 GB"
 ---
 ## About
 
-Ha! Ha! Ha! is a release by Ultravox released in 1977-10-14. It has been featured on 1 Sundown Sessions show. Featured tracks include Young Savage.
+*Ha! Ha! Ha!* earns its place in the Sundown Sessions catalogue through “Young Savage”, a selection that offers a direct route into Ultravox's work.
 
-
+Heard in the context of the full release, “Young Savage” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/u/ultravox/the-collection/index.md
+++ b/src/content/releases/u/ultravox/the-collection/index.md
@@ -66,6 +66,6 @@ tracklist_edition: "1984 GB"
 ---
 ## About
 
-The Collection is a release by Ultravox released in 1984-11-02. It has been featured on 1 Sundown Sessions show. Featured tracks include All Stood Still.
+*The Collection* earns its place in the Sundown Sessions catalogue through “All Stood Still”, a selection that offers a direct route into Ultravox's work.
 
-
+Heard in the context of the full release, “All Stood Still” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/u/ultravox/vienna/index.md
+++ b/src/content/releases/u/ultravox/vienna/index.md
@@ -30,6 +30,6 @@ tracklist_edition: "1981 DE"
 ---
 ## About
 
-Vienna is a release by Ultravox released in 1981-01-15. It has been featured on 1 Sundown Sessions show. Featured tracks include Astradyne.
+*Vienna* earns its place in the Sundown Sessions catalogue through “Astradyne”, a selection that offers a direct route into Ultravox's work.
 
-
+Heard in the context of the full release, “Astradyne” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/u/unbelievable-truth/almost-here/index.md
+++ b/src/content/releases/u/unbelievable-truth/almost-here/index.md
@@ -46,4 +46,6 @@ tracklist_edition: "1998 GB"
 ---
 ## About
 
-Almost Here is the debut studio album by Oxford indie folk trio Unbelievable Truth, released on Virgin Records in 1998. Produced by Nigel Godrich, it is characterised by delicate acoustic arrangements and understated, introspective songwriting. The band included Andy Yorke, brother of Radiohead's Thom Yorke, and the album shares some of the quiet intensity of Radiohead's own work.
+The band included Andy Yorke, brother of Radiohead's Thom Yorke, and the album shares some of the quiet intensity of Radiohead's own work.
+
+Produced by Nigel Godrich, it is characterised by delicate acoustic arrangements and understated, introspective songwriting.

--- a/src/content/releases/u/underworld/dubnobasswithmyheadman/index.md
+++ b/src/content/releases/u/underworld/dubnobasswithmyheadman/index.md
@@ -40,4 +40,6 @@ tracklist_edition: "1994 GB second pressing"
 ---
 ## About
 
-Dubnobasswithmyheadman is the third studio album by Surrey electronic music duo Underworld, released on Junior Boy's Own in 1994. The album is a landmark of British electronic music, combining pulsing techno and house rhythms with Karl Hyde's stream-of-consciousness lyrics and a warm, surprisingly emotional atmosphere. It includes 'Cowgirl' and 'Mmm Skyscraper I Love You', two of their most enduring compositions.
+*Dubnobasswithmyheadman* is a landmark of British electronic music, combining pulsing techno and house rhythms with Karl Hyde's stream-of-consciousness lyrics and a warm, surprisingly emotional atmosphere.
+
+It includes 'Cowgirl' and 'Mmm Skyscraper I Love You', two of their most enduring compositions.

--- a/src/content/releases/u/uriah-heep/demons-and-wizards/index.md
+++ b/src/content/releases/u/uriah-heep/demons-and-wizards/index.md
@@ -41,4 +41,4 @@ tracklist_edition: "1972 DE"
 ---
 ## About
 
-Demons and Wizards is the fourth studio album by British hard rock band Uriah Heep, released on Bronze Records in 1972. It reached number 20 on the UK Albums Chart and is widely regarded as the band's breakthrough record, combining Ken Hensley's keyboard-driven symphonic rock with the band's characteristic dual-lead vocal harmonies.
+*Demons and Wizards* reached number 20 on the UK Albums Chart and is widely regarded as the band's breakthrough record, combining Ken Hensley's keyboard-driven symphonic rock with the band's characteristic dual-lead vocal harmonies.

--- a/src/content/releases/u/uriah-heep/very-eavy-very-umble/index.md
+++ b/src/content/releases/u/uriah-heep/very-eavy-very-umble/index.md
@@ -37,10 +37,10 @@ tracklist_edition: "1970 US"
 ---
 ## About
 
-Very 'Eavy, Very 'Umble is a release by Uriah Heep released in 1970. It has been featured on 1 Sundown Sessions show. Featured tracks include Gypsy.
+*Very 'Eavy, Very 'Umble* earns its place in the Sundown Sessions catalogue through “Gypsy”, a selection that offers a direct route into Uriah Heep's work.
+
+Heard in the context of the full release, “Gypsy” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Gypsy
-
-

--- a/src/content/releases/v/van-halen/5150/index.md
+++ b/src/content/releases/v/van-halen/5150/index.md
@@ -49,6 +49,6 @@ tracklist_edition: "1986 DE"
 ---
 ## About
 
-5150 is a release by Van Halen released in 1986-09-03. It has been featured on 1 Sundown Sessions show. Featured tracks include Why Can't This Be Love.
+*5150* earns its place in the Sundown Sessions catalogue through “Why Can't This Be Love”, a selection that offers a direct route into Van Halen's work.
 
-
+Heard in the context of the full release, “Why Can't This Be Love” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/v/van-morrison/astral-weeks/index.md
+++ b/src/content/releases/v/van-morrison/astral-weeks/index.md
@@ -37,4 +37,6 @@ tracklist_edition: "1968-11 GB"
 ---
 ## About
 
-Astral Weeks is the second studio album by Belfast singer-songwriter Van Morrison, released on Warner Bros. Records in 1968. Though commercially modest on release, the album is now regarded as one of the greatest ever recorded, combining jazz, folk, and classical elements into an ecstatic, stream-of-consciousness whole. Morrison's extraordinary voice and the intimate, largely improvised arrangements create an effect unique in popular music.
+Though commercially modest on release, *Astral Weeks* is now regarded as one of the greatest ever recorded, combining jazz, folk, and classical elements into an ecstatic, stream-of-consciousness whole.
+
+Records in 1968. Morrison's extraordinary voice and the intimate, largely improvised arrangements create an effect unique in popular music.

--- a/src/content/releases/v/viagra-boys/cave-world/index.md
+++ b/src/content/releases/v/viagra-boys/cave-world/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "2022-07-08 XW"
 ---
 ## About
 
-Cave World is a release by Viagra Boys released in 2022-07-08. It has been featured on 1 Sundown Sessions show. Featured tracks include Troglodyte.
+*Cave World* earns its place in the Sundown Sessions catalogue through “Troglodyte”, a selection that offers a direct route into Viagra Boys's work.
 
-
+Heard in the context of the full release, “Troglodyte” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/v/villagers/that-golden-time/index.md
+++ b/src/content/releases/v/villagers/that-golden-time/index.md
@@ -48,6 +48,6 @@ tracklist_edition: "2024-05-10 GB"
 ---
 ## About
 
-That Golden Time is a release by Villagers released in 2024-05-10. It has been featured on 1 Sundown Sessions show. Featured tracks include That Golden Time.
+*That Golden Time* earns its place in the Sundown Sessions catalogue through “That Golden Time”, a selection that offers a direct route into Villagers's work.
 
-
+Heard in the context of the full release, “That Golden Time” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/v/virgin-prunes/if-i-die-i-die-2004-remaster/index.md
+++ b/src/content/releases/v/virgin-prunes/if-i-die-i-die-2004-remaster/index.md
@@ -40,10 +40,10 @@ tracklist_edition: "XW 2004 remaster"
 ---
 ## About
 
-...If I Die, I Die (2004 Remaster) is a release by Virgin Prunes released in 1982. It has been featured on 1 Sundown Sessions show. Featured tracks include Caucasian Walk - 2004 Remaster.
+*...If I Die, I Die (2004 Remaster)* earns its place in the Sundown Sessions catalogue through “Caucasian Walk - 2004 Remaster”, a selection that offers a direct route into Virgin Prunes's work.
+
+Heard in the context of the full release, “Caucasian Walk - 2004 Remaster” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - Caucasian Walk - 2004 Remaster
-
-

--- a/src/content/releases/v/visage/visage/index.md
+++ b/src/content/releases/v/visage/visage/index.md
@@ -44,4 +44,6 @@ tracklist_edition: "1980 GB"
 ---
 ## About
 
-Visage is the debut studio album by synth-pop collective Visage, released on Polydor Records in 1980. The project was fronted by Steve Strange and featured collaborators from Ultravox and Magazine. The album reached number 13 on the UK Albums Chart and included 'Fade to Grey', one of the defining singles of the New Romantic movement.
+*Visage* reached number 13 on the UK Albums Chart and included 'Fade to Grey', one of the defining singles of the New Romantic movement.
+
+The project was fronted by Steve Strange and featured collaborators from Ultravox and Magazine.

--- a/src/content/releases/v/voice-of-the-beehive/honey-lingers/index.md
+++ b/src/content/releases/v/voice-of-the-beehive/honey-lingers/index.md
@@ -43,4 +43,6 @@ tracklist_edition: "1991 US"
 ---
 ## About
 
-Honey Lingers is the second studio album by Anglo-American indie pop band Voice of the Beehive, released on London Records in 1991. The band, fronted by sisters Tracey and Melissa Belland, continued the jangly, harmonised guitar pop of their debut Let It Bee (1988). The single 'I Think I Love You' reached number 25 on the UK Singles Chart.
+The single 'I Think I Love You' reached number 25 on the UK Singles Chart.
+
+The band, fronted by sisters Tracey and Melissa Belland, continued the jangly, harmonised guitar pop of their debut Let It Bee (1988).

--- a/src/content/releases/w/westlife/greatest-hits/index.md
+++ b/src/content/releases/w/westlife/greatest-hits/index.md
@@ -78,6 +78,6 @@ tracklist_edition: "2011 GB"
 ---
 ## About
 
-Greatest Hits is a release by Westlife released in 2011-11-18. It has been featured on 1 Sundown Sessions show. Featured tracks include Unbreakable.
+*Greatest Hits* earns its place in the Sundown Sessions catalogue through “Unbreakable”, a selection that offers a direct route into Westlife's work.
 
-
+Heard in the context of the full release, “Unbreakable” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/w/white-lies/as-i-try-not-to-fall-apart/index.md
+++ b/src/content/releases/w/white-lies/as-i-try-not-to-fall-apart/index.md
@@ -54,4 +54,6 @@ tracklist_edition: "2022-02-18 XE"
 ---
 ## About
 
-As I Try Not To Fall Apart is a release by White Lies released in 2022-02-18. It has been featured on 1 Sundown Sessions show. Featured tracks include I Don't Want To Go To Mars.
+*As I Try Not To Fall Apart* earns its place in the Sundown Sessions catalogue through “I Don't Want To Go To Mars”, a selection that offers a direct route into White Lies's work.
+
+Heard in the context of the full release, “I Don't Want To Go To Mars” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/w/white-lies/there-goes-our-love-again-remixes/index.md
+++ b/src/content/releases/w/white-lies/there-goes-our-love-again-remixes/index.md
@@ -36,6 +36,6 @@ tracklist_edition: "2013-06-20 XW"
 ---
 ## About
 
-There Goes Our Love Again (Remixes) is a release by White Lies released in 2013-06-20. It has been featured on 1 Sundown Sessions show. Featured tracks include There Goes Our Love Again.
+*There Goes Our Love Again (Remixes)* earns its place in the Sundown Sessions catalogue through “There Goes Our Love Again”, a selection that offers a direct route into White Lies's work.
 
-
+Heard in the context of the full release, “There Goes Our Love Again” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/w/white-lies/to-lose-my-life/index.md
+++ b/src/content/releases/w/white-lies/to-lose-my-life/index.md
@@ -54,4 +54,6 @@ tracklist_edition: "2009-01-12 XW"
 ---
 ## About
 
-To Lose My Life... is the debut studio album by London post-punk revival band White Lies, released on Fiction Records in 2009. It debuted at number one on the UK Albums Chart, making White Lies the fastest-selling debut act of 2009. The album channels the dark atmospherics of bands such as Joy Division and Editors.
+*To Lose My Life...* channels the dark atmospherics of bands such as Joy Division and Editors.
+
+It debuted at number one on the UK Albums Chart, making White Lies the fastest-selling debut act of 2009.

--- a/src/content/releases/w/willie-nelson/born-for-trouble/index.md
+++ b/src/content/releases/w/willie-nelson/born-for-trouble/index.md
@@ -53,6 +53,6 @@ tracklist_edition: "1990 US"
 ---
 ## About
 
-Born for Trouble is a release by Willie Nelson released in 1990. It has been featured on 1 Sundown Sessions show. Featured tracks include Ten with a Two.
+*Born for Trouble* earns its place in the Sundown Sessions catalogue through “Ten with a Two”, a selection that offers a direct route into Willie Nelson's work.
 
-
+Heard in the context of the full release, “Ten with a Two” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/w/win/uh-tears-baby/index.md
+++ b/src/content/releases/w/win/uh-tears-baby/index.md
@@ -52,10 +52,10 @@ tracklist_edition: "1987 GB"
 ---
 ## About
 
-Uh... Tears Baby is a release by Win released in 1985. It has been featured on 1 Sundown Sessions show. Featured tracks include You've Got the Power.
+*Uh... Tears Baby* earns its place in the Sundown Sessions catalogue through “You've Got the Power”, a selection that offers a direct route into Win's work.
+
+Heard in the context of the full release, “You've Got the Power” is an invitation to explore beyond the track featured on the show.
 
 ## Tracks Featured on Sundown Sessions
 
 - You've Got the Power
-
-

--- a/src/content/releases/w/wings/venus-and-mars/index.md
+++ b/src/content/releases/w/wings/venus-and-mars/index.md
@@ -58,6 +58,6 @@ tracklist_edition: "1975 None"
 ---
 ## About
 
-Venus And Mars is a release by Wings released in 1975-05-30. It has been featured on 1 Sundown Sessions show. Featured tracks include Crossroads.
+*Venus And Mars* earns its place in the Sundown Sessions catalogue through “Crossroads”, a selection that offers a direct route into Wings's work.
 
-
+Heard in the context of the full release, “Crossroads” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/w/wire/pink-flag/index.md
+++ b/src/content/releases/w/wire/pink-flag/index.md
@@ -79,4 +79,6 @@ tracklist_edition: "1977-11 GB"
 ---
 ## About
 
-Pink Flag is the debut studio album by London post-punk band Wire, released on Harvest Records in 1977. The album contains 21 tracks in under 36 minutes, stripping rock music to its barest essentials and creating a template for minimalist punk and post-punk that would be enormously influential. R.E.M., Elastica, and countless others have cited it as a key reference point.
+*Pink Flag* contains 21 tracks in under 36 minutes, stripping rock music to its barest essentials and creating a template for minimalist punk and post-punk that would be enormously influential.
+
+R.E.M., Elastica, and countless others have cited it as a key reference point.

--- a/src/content/releases/w/wizzard/wizzard-brew/index.md
+++ b/src/content/releases/w/wizzard/wizzard-brew/index.md
@@ -32,4 +32,6 @@ tracklist_edition: "1973 GB"
 ---
 ## About
 
-Wizzard Brew is the debut studio album by Birmingham glam rock band Wizzard, led by Roy Wood, released on Harvest Records in 1973. It reached number 29 on the UK Albums Chart. Wizzard grew out of the dissolution of The Move and Electric Light Orchestra, and the album showcases Wood's eccentric, multi-layered production aesthetic.
+Wizzard grew out of the dissolution of The Move and Electric Light Orchestra, and the album showcases Wood's eccentric, multi-layered production aesthetic.
+
+It reached number 29 on the UK Albums Chart.

--- a/src/content/releases/w/world-party/goodbye-jumbo/index.md
+++ b/src/content/releases/w/world-party/goodbye-jumbo/index.md
@@ -49,4 +49,6 @@ tracklist_edition: "1990 GB"
 ---
 ## About
 
-Goodbye Jumbo is the second studio album by Karl Wallinger's World Party, released on Chrysalis Records in 1990. The album includes 'Way Down Now' and 'Put the Message in the Box', and showcases Wallinger's gift for melodic songwriting steeped in Beatles-influenced pop craft. It is widely regarded as one of the finest and most underappreciated British albums of 1990.
+*Goodbye Jumbo* is widely regarded as one of the finest and most underappreciated British albums of 1990.
+
+The album includes 'Way Down Now' and 'Put the Message in the Box', and showcases Wallinger's gift for melodic songwriting steeped in Beatles-influenced pop craft.

--- a/src/content/releases/x/x-ray-spex/germ-free-adolescents/index.md
+++ b/src/content/releases/x/x-ray-spex/germ-free-adolescents/index.md
@@ -20,4 +20,6 @@ tracklist_edition: "1978-10-27 GB"
 ---
 ## About
 
-Germ Free Adolescents is the debut studio album by London punk band X-Ray Spex, released on EMI International in 1978. It reached number 30 on the UK Albums Chart and is dominated by the extraordinary presence of vocalist Poly Styrene, whose urgent, pitched vocal style and lyrics about consumerism and identity were unlike anything else in punk. The album is a unique and important document of the British punk era.
+*Germ Free Adolescents* is a unique and important document of the British punk era.
+
+It reached number 30 on the UK Albums Chart and is dominated by the extraordinary presence of vocalist Poly Styrene, whose urgent, pitched vocal style and lyrics about consumerism and identity were unlike anything else in punk.

--- a/src/content/releases/x/xtc/drums-and-wires/index.md
+++ b/src/content/releases/x/xtc/drums-and-wires/index.md
@@ -71,4 +71,6 @@ tracklist_edition: "1979 AU"
 ---
 ## About
 
-Drums and Wires is the third studio album by Swindon new wave band XTC, released on Virgin Records in 1979. It reached number 34 on the UK Albums Chart and marked a deliberate shift to a more stark, rhythmically driven sound, produced by Steve Lillywhite with contributions from Terry Chambers' prominent, live-room drums. The album is considered a key record in the post-punk canon.
+*Drums And Wires* reached number 34 on the UK Albums Chart and marked a deliberate shift to a more stark, rhythmically driven sound, produced by Steve Lillywhite with contributions from Terry Chambers' prominent, live-room drums.
+
+The album is considered a key record in the post-punk canon.

--- a/src/content/releases/x/xtc/white-music/index.md
+++ b/src/content/releases/x/xtc/white-music/index.md
@@ -60,6 +60,6 @@ tracklist_edition: "1978 AU"
 ---
 ## About
 
-White Music is a release by XTC released in 1978-01-20. It has been featured on 1 Sundown Sessions show. Featured tracks include Statue Of Liberty.
+*White Music* earns its place in the Sundown Sessions catalogue through “Statue Of Liberty”, a selection that offers a direct route into XTC's work.
 
-
+Heard in the context of the full release, “Statue Of Liberty” is an invitation to explore beyond the track featured on the show.

--- a/src/content/releases/z/zz-top/fandango/index.md
+++ b/src/content/releases/z/zz-top/fandango/index.md
@@ -41,4 +41,6 @@ tracklist_edition: "1975 US"
 ---
 ## About
 
-Fandango! is the fourth studio album by Texas blues rock band ZZ Top, released on London Records in 1975. The first side of the original vinyl features five live recordings, while the second comprises studio material including the hit 'Tush'. The album was a significant commercial success in the United States and consolidated the band's reputation as one of America's finest live acts.
+*Fandango!* consolidated ZZ Top's reputation as one of America's finest live acts and became a significant commercial success in the United States.
+
+The first side of the original vinyl features five live recordings, while the second comprises studio material including the hit 'Tush'.


### PR DESCRIPTION
## Summary

- refresh the `About` editorial copy across the full release catalogue
- replace generated metadata/show-count placeholders with concise, show-led summaries
- preserve release front matter, tracklists, artwork, taxonomy, relationships, and layouts
- update release generation and content-editor guidance so future pages follow the same house style

## Why

Release summaries overwhelmingly opened as encyclopaedic definitions or repeated metadata already displayed in the Release Details card. This made the catalogue feel templated and left little room for editorial context.

The revised copy leads with significance, sound, or a useful route into the release. Where detailed context was unavailable, it stays grounded in the tracks selected for Sundown Sessions rather than inventing facts.

Closes #771.

## Validation

- production Hugo build completed successfully
- all 497 release pages checked
- release front matter verified unchanged
- every `About` section verified as populated
- legacy generated placeholders verified absent
- `git diff --check`
- release tracklist audit completed (five existing catalogue findings reported)