### PR TITLE
Fix Franz Ferdinand standard CD tracklist

### DIFF
--- a/src/content/releases/f/franz-ferdinand/franz-ferdinand/index.md
+++ b/src/content/releases/f/franz-ferdinand/franz-ferdinand/index.md
@@ -17,7 +17,7 @@ tracks:
   - discNumber: 1
     trackNumber: 2
     title: "Tell Her Tonight"
-    duration: "2:18"
+    duration: "2:17"
   - discNumber: 1
     trackNumber: 3
     title: "Take Me Out"
@@ -25,59 +25,39 @@ tracks:
     url: "/tracks/f/franz-ferdinand/take-me-out/"
   - discNumber: 1
     trackNumber: 4
-    title: "The Dark of the Matinée"
+    title: "The Dark Of The Matinée"
     duration: "4:03"
   - discNumber: 1
     trackNumber: 5
     title: "Auf Achse"
-    duration: "4:20"
+    duration: "4:19"
   - discNumber: 1
     trackNumber: 6
-    title: "Cheating on You"
-    duration: "2:37"
+    title: "Cheating On You"
+    duration: "2:36"
   - discNumber: 1
     trackNumber: 7
     title: "This Fire"
-    duration: "4:15"
+    duration: "4:14"
   - discNumber: 1
     trackNumber: 8
-    title: "Darts of Pleasure"
-    duration: "3:00"
+    title: "Darts Of Pleasure"
+    duration: "2:59"
   - discNumber: 1
     trackNumber: 9
     title: "Michael"
     duration: "3:21"
   - discNumber: 1
     trackNumber: 10
-    title: "Come on Home"
+    title: "Come On Home"
     duration: "3:46"
   - discNumber: 1
     trackNumber: 11
-    title: "40′"
+    title: "40'"
     duration: "3:24"
-  - discNumber: 2
-    trackNumber: 1
-    title: "This Fffire"
-    duration: "3:35"
-  - discNumber: 2
-    trackNumber: 2
-    title: "Van Tango"
-    duration: "3:26"
-  - discNumber: 2
-    trackNumber: 3
-    title: "Shopping for Blood"
-    duration: "3:35"
-  - discNumber: 2
-    trackNumber: 4
-    title: "All for You, Sophia"
-    duration: "2:59"
-  - discNumber: 2
-    trackNumber: 5
-    title: "Words So Leisured"
-    duration: "2:20"
-duration: "54:45"
-tracklist_source: "https://musicbrainz.org/release/002b9cc5-d66f-4d78-bf44-6550401ebff5"
-tracklist_edition: "2004 XE"
+duration: "38:45"
+tracklist_source: "https://www.discogs.com/master/4334-Franz-Ferdinand-Franz-Ferdinand"
+tracklist_edition: "2004 Europe standard single-CD edition (WIGCD136)"
 ---
 ## About
 
@@ -85,4 +65,4 @@ tracklist_edition: "2004 XE"
 
 ## External Links
 
-- {{< new-tab-link "[Discogs](https://www.discogs.com/master/15753-Franz-Ferdinand-Franz-Ferdinand)" >}}
+- {{< new-tab-link "[Discogs](https://www.discogs.com/master/4334-Franz-Ferdinand-Franz-Ferdinand)" >}}


### PR DESCRIPTION
## Summary

- replace the deluxe two-disc Franz Ferdinand tracklist with the standard 11-track CD edition
- correct Discogs track titles, timings, total duration, and edition provenance
- preserve the existing internal link for “Take Me Out”

## Why

The release page represented a deluxe two-disc edition while its title, artwork, and metadata were intended to describe the regular single-CD release. This produced an incorrect track count and duration.

## Impact

The release page now consistently displays the standard 2004 European CD edition (WIGCD136): 11 tracks with a total duration of 38:45, sourced from Discogs master 4334.

## Validation

- `python3 -m unittest tests.test_audit_release_tracklists`
- `python3 scripts/audit-release-tracklists.py --root . --report /tmp/sundown-release-audit.md`
- assertions for single-disc structure, 11 tracks, 38:45 total duration, and internal track-link existence
- `git diff --check`

Closes #781