### PR TITLE
fix(content): correct Villains release details

### DIFF
--- a/src/content/releases/q/queens-of-the-stone-age/villains/index.md
+++ b/src/content/releases/q/queens-of-the-stone-age/villains/index.md
@@ -18,8 +18,8 @@ years:
 tags:
   - alternative rock
   - queens of the stone age
-uk_chart_position: 2
-catalogue_number: "MAT 0983"
+uk_chart_position: 1
+catalogue_number: "OLE-1125-2"
 duration: "48:03"
 for_sale: true
 release_page: true
@@ -55,11 +55,14 @@ tracks:
     title: "Villains of Circumstance"
     duration: "6:09"
 tracklist_source: "https://musicbrainz.org/release/fde9a6de-1610-44d5-8f11-bfc139656a2b"
-tracklist_edition: "2017-08-25 US"
+tracklist_edition: "2017-08-25 US Matador CD"
+metadata_source: "https://musicbrainz.org/release/fde9a6de-1610-44d5-8f11-bfc139656a2b"
 ---
 ## About
 
-Produced by Mark Ronson, *Villains* was the band's first album in four years following ...Like Clockwork (2013).
+Arriving four years after the shadowy sprawl of *...Like Clockwork*, *Villains* finds Queens of the Stone Age tightening their riffs around a sharper rhythmic pulse. Glam-rock swagger, clipped guitars and restless grooves give the record a danceable momentum without sanding away the band's menace.
+
+Mark Ronson's production brings that tension to the foreground: drums hit with unusual snap, keyboards flash through the arrangements and Josh Homme's melodies are given room to strut. The collaboration makes *Villains* a bright, wiry turn in the band's catalogue and a bridge between the weight of its predecessor and the looser experiments that followed.
 
 ## External Links
 

--- a/src/content/tracks/q/queens-of-the-stone-age/feet-dont-fail-me/index.md
+++ b/src/content/tracks/q/queens-of-the-stone-age/feet-dont-fail-me/index.md
@@ -7,7 +7,7 @@ track_page: true
 ---
 ## About
 
-"Feet Don't Fail Me" is a track by Queens of the Stone Age, featuring Mark Lanegan on backing vocals. It is the opening track on their seventh studio album, [Villains](/releases/q/queens-of-the-stone-age/villains/) (2017).
+"Feet Don't Fail Me" opens Queens of the Stone Age's seventh studio album, [Villains](/releases/q/queens-of-the-stone-age/villains/) (2017). Its long, suspenseful introduction gives way to a strutting guitar riff and dance-rock pulse, establishing the album's rhythmic direction from the outset.
 
 ## External Links
 


### PR DESCRIPTION
## What changed

- align the *Villains* catalogue number and provenance with the cited 2017 US Matador CD
- correct the UK Albums Chart peak from number 2 to number 1
- replace the unsupported Mark Lanegan credit on “Feet Don’t Fail Me” with track-focused editorial
- expand the album editorial to describe its rhythmic, glam-inflected direction and Mark Ronson’s production

## Why

The release page mixed metadata from different editions, contained an incorrect chart position and performance credit, and did not meet the catalogue’s current editorial standard.

## Impact

The existing release, track, artist and Show #1 relationships remain unchanged. Visitors now see internally consistent edition metadata and accurate, fuller editorial copy.

## Validation

- `python3 scripts/audit-release-metadata.py --check-report`
- `python3 scripts/audit-release-tracklists.py --check`
- `hugo --source src --environment production --destination /tmp/sundown-sessions-791-public`
- `git diff --check`

The production build completed successfully with existing Hugo/theme deprecation warnings. The pytest suite was not run because pytest is not installed in the checkout.

Closes #791